### PR TITLE
Update README with plugin reload and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Install the plugin:
 /plugin install codex@openai-codex
 ```
 
+Reload plugins:
+
+```bash
+/reload-plugins
+```
+
 Then run:
 
 ```bash


### PR DESCRIPTION
Added instructions for reloading plugins. Otherwise it just says `Unknown skill: codex:setup` when you try to run `/codex:setup`

<img width="856" height="293" alt="image" src="https://github.com/user-attachments/assets/a4a61e86-4385-4bf5-adb7-ba1a6129111a" />
