### PR TITLE
fix: add shell option for Windows .cmd wrapper resolution

### DIFF
--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -7,7 +7,8 @@ export function runCommand(command, args = [], options = {}) {
     env: options.env,
     encoding: "utf8",
     input: options.input,
-    stdio: options.stdio ?? "pipe"
+    stdio: options.stdio ?? "pipe",
+    shell: process.platform === "win32"
   });
 
   return {


### PR DESCRIPTION
## Bug

On Windows, `/codex:setup` reports Codex CLI and npm as "not found" even when both are properly installed globally via npm.

## Root Cause

`spawnSync("codex", ...)` in `process.mjs` cannot resolve `.cmd` wrappers on Windows without `shell: true`. Node.js on Windows requires either the explicit `.cmd` extension or `shell: true` to find globally installed npm binaries. This is a well-documented Node.js behavior: https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows

## Fix

Conditionally set `shell: process.platform === "win32"` in the `runCommand` spawnSync options. This only enables shell resolution on Windows, avoiding any behavioral changes on macOS/Linux.

## Tested On

- Windows 11
- Node.js v24.14.0
- Codex CLI v0.117.0
- Claude Code v2.1.87