### PR TITLE
fix: resolve ENOENT for .cmd shims on Windows

### DIFF
--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -7,7 +7,8 @@ export function runCommand(command, args = [], options = {}) {
     env: options.env,
     encoding: "utf8",
     input: options.input,
-    stdio: options.stdio ?? "pipe"
+    stdio: options.stdio ?? "pipe",
+    shell: process.platform === "win32"
   });
 
   return {


### PR DESCRIPTION
## Summary

- Adds `shell: process.platform === "win32"` to `spawnSync` in `runCommand()`, fixing binary detection (`codex`, `npm`, etc.) on Windows

## Problem

On Windows, npm installs global CLI tools as `.cmd` shims (e.g., `codex.cmd`). Node.js `spawnSync()` without `shell: true` calls `CreateProcess`, which only resolves `.exe` files — it cannot find `.cmd` or `.bat` files, even when they are on `PATH`.

This causes `binaryAvailable("codex", ...)` to return `{ available: false, detail: "not found" }` on Windows, even with a correctly installed and PATH-accessible Codex CLI. The same applies to `npm` detection.

### Before (on Windows)
```
codex: { available: false, detail: "not found" }
npm:   { available: false, detail: "not found" }
```

### After
```
codex: { available: true, detail: "codex-cli 0.117.0; advanced runtime available" }
npm:   { available: true, detail: "11.6.3" }
```

## Root cause

`spawnSync("codex", ["--version"])` → Windows `CreateProcess` → searches for `codex.exe` only → ENOENT.

Adding `shell: true` routes through `cmd.exe`, which resolves commands using `PATHEXT` (`.CMD`, `.BAT`, etc.), matching how the Windows shell resolves commands.

## Why this is safe

- The condition `process.platform === "win32"` evaluates to `false` on macOS/Linux — **zero behavior change** on non-Windows platforms
- `shell: true` is the standard Node.js pattern for cross-platform command resolution (used by `cross-spawn`, `execa`, and npm itself)
- `terminateProcessTree` already works on Windows because `taskkill` is a native `.exe`, not a `.cmd` shim — so it is unaffected by this change

## Test plan

- [x] Verified on Windows 11 + Node.js v22.21.0 + Codex CLI 0.117.0
- [x] `/codex:setup` reports all components as available after the fix
- [ ] Verify no regression on macOS/Linux (condition is `false`, no code path change)