### PR TITLE
fix: add shell:true for binaryAvailable on Windows

### DIFF
--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -7,7 +7,8 @@ export function runCommand(command, args = [], options = {}) {
     env: options.env,
     encoding: "utf8",
     input: options.input,
-    stdio: options.stdio ?? "pipe"
+    stdio: options.stdio ?? "pipe",
+    shell: options.shell ?? false
   });
 
   return {
@@ -33,7 +34,8 @@ export function runCommandChecked(command, args = [], options = {}) {
 }
 
 export function binaryAvailable(command, versionArgs = ["--version"], options = {}) {
-  const result = runCommand(command, versionArgs, options);
+  const platformOptions = process.platform === "win32" ? { ...options, shell: true } : options;
+  const result = runCommand(command, versionArgs, platformOptions);
   if (result.error && /** @type {NodeJS.ErrnoException} */ (result.error).code === "ENOENT") {
     return { available: false, detail: "not found" };
   }


### PR DESCRIPTION
## Summary
On Windows, `npm` and `codex` are installed as `.cmd` batch wrappers.
`spawnSync` without `shell: true` cannot resolve `.cmd` extensions,
causing `binaryAvailable()` to return ENOENT for both.

This makes `/codex:setup` (and all commands depending on
`getCodexAvailability()`) report npm as "Missing" and Codex as
"Not installed", even though both are correctly in PATH.

## Changes
- Pass `shell` option through `runCommand` to `spawnSync`
- Set `shell: true` on `win32` in `binaryAvailable` only

## Testing
Tested on Windows 11 + Claude Code CLI (Git Bash / mingw64):
- Before: `/codex:setup` → npm Missing, Codex Not installed
- After: `/codex:setup` → npm Available, Codex Available

Fixes #17