### PR TITLE
feat: add throttle controls for review gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,27 @@ When the review gate is enabled, the plugin uses a `Stop` hook to run a targeted
 > [!WARNING]
 > The review gate can create a long-running Claude/Codex loop and may drain usage limits quickly. Only enable it when you plan to actively monitor the session.
 
+#### Throttling the review gate
+
+To prevent runaway usage, you can limit how often the review gate fires:
+
+```bash
+# Allow at most 5 stop-gate reviews per session
+/codex:setup --review-gate-max 5
+
+# Require at least 10 minutes between stop-gate reviews
+/codex:setup --review-gate-cooldown 10
+
+# Combine both limits
+/codex:setup --enable-review-gate --review-gate-max 5 --review-gate-cooldown 10
+
+# Remove a limit
+/codex:setup --review-gate-max off
+/codex:setup --review-gate-cooldown off
+```
+
+When a limit is reached, the stop-gate review is skipped (the session is allowed to end) and a note is logged. You can still run `/codex:review` manually at any time.
+
 ## Typical Flows
 
 ### Review Before Shipping

--- a/plugins/codex/commands/setup.md
+++ b/plugins/codex/commands/setup.md
@@ -1,6 +1,6 @@
 ---
 description: Check whether the local Codex CLI is ready and optionally toggle the stop-time review gate
-argument-hint: '[--enable-review-gate|--disable-review-gate]'
+argument-hint: '[--enable-review-gate|--disable-review-gate] [--review-gate-max <n|off>] [--review-gate-cooldown <minutes|off>]'
 allowed-tools: Bash(node:*), Bash(npm:*), AskUserQuestion
 ---
 

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -74,7 +74,7 @@ function printUsage() {
   console.log(
     [
       "Usage:",
-      "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
+      "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--review-gate-max <n|off>] [--review-gate-cooldown <minutes|off>] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
       "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
@@ -204,6 +204,8 @@ function buildSetupReport(cwd, actionsTaken = []) {
     auth: authStatus,
     sessionRuntime: getSessionRuntimeStatus(),
     reviewGateEnabled: Boolean(config.stopReviewGate),
+    reviewGateMaxPerSession: config.stopReviewGateMaxPerSession ?? null,
+    reviewGateCooldownMinutes: config.stopReviewGateCooldownMinutes ?? null,
     actionsTaken,
     nextSteps
   };
@@ -211,7 +213,7 @@ function buildSetupReport(cwd, actionsTaken = []) {
 
 function handleSetup(argv) {
   const { options } = parseCommandInput(argv, {
-    valueOptions: ["cwd"],
+    valueOptions: ["cwd", "review-gate-max", "review-gate-cooldown"],
     booleanOptions: ["json", "enable-review-gate", "disable-review-gate"]
   });
 
@@ -229,6 +231,32 @@ function handleSetup(argv) {
   } else if (options["disable-review-gate"]) {
     setConfig(workspaceRoot, "stopReviewGate", false);
     actionsTaken.push(`Disabled the stop-time review gate for ${workspaceRoot}.`);
+  }
+
+  if (options["review-gate-max"] != null) {
+    const max = options["review-gate-max"] === "off" ? null : Number(options["review-gate-max"]);
+    if (max !== null && (!Number.isInteger(max) || max < 1)) {
+      throw new Error(`--review-gate-max must be a positive integer or "off".`);
+    }
+    setConfig(workspaceRoot, "stopReviewGateMaxPerSession", max);
+    actionsTaken.push(
+      max != null
+        ? `Set review gate session limit to ${max} reviews per session.`
+        : `Removed review gate session limit.`
+    );
+  }
+
+  if (options["review-gate-cooldown"] != null) {
+    const cooldown = options["review-gate-cooldown"] === "off" ? null : Number(options["review-gate-cooldown"]);
+    if (cooldown !== null && (Number.isNaN(cooldown) || cooldown < 1)) {
+      throw new Error(`--review-gate-cooldown must be a positive number (minutes) or "off".`);
+    }
+    setConfig(workspaceRoot, "stopReviewGateCooldownMinutes", cooldown);
+    actionsTaken.push(
+      cooldown != null
+        ? `Set review gate cooldown to ${cooldown} minute(s).`
+        : `Removed review gate cooldown.`
+    );
   }
 
   const finalReport = buildSetupReport(cwd, actionsTaken);

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -248,8 +248,8 @@ function handleSetup(argv) {
 
   if (options["review-gate-cooldown"] != null) {
     const cooldown = options["review-gate-cooldown"] === "off" ? null : Number(options["review-gate-cooldown"]);
-    if (cooldown !== null && (Number.isNaN(cooldown) || cooldown < 1)) {
-      throw new Error(`--review-gate-cooldown must be a positive number (minutes) or "off".`);
+    if (cooldown !== null && (!Number.isInteger(cooldown) || cooldown < 1)) {
+      throw new Error(`--review-gate-cooldown must be a positive integer (minutes) or "off".`);
     }
     setConfig(workspaceRoot, "stopReviewGateCooldownMinutes", cooldown);
     actionsTaken.push(

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -174,6 +174,17 @@ function appendReasoningSection(lines, reasoningSummary) {
   }
 }
 
+function formatReviewGateLimits(report) {
+  const parts = [];
+  if (report.reviewGateMaxPerSession != null) {
+    parts.push(`max ${report.reviewGateMaxPerSession}/session`);
+  }
+  if (report.reviewGateCooldownMinutes != null) {
+    parts.push(`${report.reviewGateCooldownMinutes}m cooldown`);
+  }
+  return parts.length > 0 ? ` (${parts.join(", ")})` : "";
+}
+
 export function renderSetupReport(report) {
   const lines = [
     "# Codex Setup",
@@ -186,7 +197,7 @@ export function renderSetupReport(report) {
     `- codex: ${report.codex.detail}`,
     `- auth: ${report.auth.detail}`,
     `- session runtime: ${report.sessionRuntime.label}`,
-    `- review gate: ${report.reviewGateEnabled ? "enabled" : "disabled"}`,
+    `- review gate: ${report.reviewGateEnabled ? "enabled" : "disabled"}${report.reviewGateEnabled ? formatReviewGateLimits(report) : ""}`,
     ""
   ];
 

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -20,7 +20,9 @@ function defaultState() {
   return {
     version: STATE_VERSION,
     config: {
-      stopReviewGate: false
+      stopReviewGate: false,
+      stopReviewGateMaxPerSession: null,
+      stopReviewGateCooldownMinutes: null
     },
     jobs: []
   };

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -14,6 +14,8 @@ import { SESSION_ID_ENV } from "./lib/tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
 
 const STOP_REVIEW_TIMEOUT_MS = 15 * 60 * 1000;
+const DEFAULT_COOLDOWN_MINUTES = null;
+const DEFAULT_MAX_PER_SESSION = null;
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(SCRIPT_DIR, "..");
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
@@ -43,6 +45,50 @@ function filterJobsForCurrentSession(jobs, input = {}) {
     return jobs;
   }
   return jobs.filter((job) => job.sessionId === sessionId);
+}
+
+function countSessionStopReviews(jobs) {
+  return jobs.filter(
+    (job) =>
+      job.jobClass === "review" &&
+      job.title === "Codex Stop Gate Review" &&
+      (job.status === "completed" || job.status === "running" || job.status === "queued")
+  ).length;
+}
+
+function findLastStopReviewTime(jobs) {
+  const stopReview = jobs.find(
+    (job) =>
+      job.jobClass === "review" &&
+      job.title === "Codex Stop Gate Review" &&
+      job.completedAt
+  );
+  return stopReview?.completedAt ? new Date(stopReview.completedAt).getTime() : null;
+}
+
+function checkThrottleLimits(config, jobs) {
+  const maxPerSession = config.stopReviewGateMaxPerSession ?? DEFAULT_MAX_PER_SESSION;
+  if (maxPerSession != null && maxPerSession > 0) {
+    const count = countSessionStopReviews(jobs);
+    if (count >= maxPerSession) {
+      return `Stop-gate review skipped: session limit reached (${count}/${maxPerSession}). Run /codex:review manually if needed.`;
+    }
+  }
+
+  const cooldownMinutes = config.stopReviewGateCooldownMinutes ?? DEFAULT_COOLDOWN_MINUTES;
+  if (cooldownMinutes != null && cooldownMinutes > 0) {
+    const lastTime = findLastStopReviewTime(jobs);
+    if (lastTime != null) {
+      const elapsed = Date.now() - lastTime;
+      const cooldownMs = cooldownMinutes * 60 * 1000;
+      if (elapsed < cooldownMs) {
+        const remainingMinutes = Math.ceil((cooldownMs - elapsed) / 60000);
+        return `Stop-gate review skipped: cooldown active (${remainingMinutes}m remaining). Run /codex:review manually if needed.`;
+      }
+    }
+  }
+
+  return null;
 }
 
 function buildStopReviewPrompt(input = {}) {
@@ -159,6 +205,13 @@ function main() {
   const setupNote = buildSetupNote(cwd);
   if (setupNote) {
     logNote(setupNote);
+    logNote(runningTaskNote);
+    return;
+  }
+
+  const throttleNote = checkThrottleLimits(config, jobs);
+  if (throttleNote) {
+    logNote(throttleNote);
     logNote(runningTaskNote);
     return;
   }

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -14,8 +14,6 @@ import { SESSION_ID_ENV } from "./lib/tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
 
 const STOP_REVIEW_TIMEOUT_MS = 15 * 60 * 1000;
-const DEFAULT_COOLDOWN_MINUTES = null;
-const DEFAULT_MAX_PER_SESSION = null;
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(SCRIPT_DIR, "..");
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
@@ -52,10 +50,11 @@ function countSessionStopReviews(jobs) {
     (job) =>
       job.jobClass === "review" &&
       job.title === "Codex Stop Gate Review" &&
-      (job.status === "completed" || job.status === "running" || job.status === "queued")
+      job.status === "completed"
   ).length;
 }
 
+// Expects jobs pre-sorted newest-first (via sortJobsNewestFirst from caller).
 function findLastStopReviewTime(jobs) {
   const stopReview = jobs.find(
     (job) =>
@@ -67,7 +66,7 @@ function findLastStopReviewTime(jobs) {
 }
 
 function checkThrottleLimits(config, jobs) {
-  const maxPerSession = config.stopReviewGateMaxPerSession ?? DEFAULT_MAX_PER_SESSION;
+  const maxPerSession = config.stopReviewGateMaxPerSession ?? null;
   if (maxPerSession != null && maxPerSession > 0) {
     const count = countSessionStopReviews(jobs);
     if (count >= maxPerSession) {
@@ -75,7 +74,7 @@ function checkThrottleLimits(config, jobs) {
     }
   }
 
-  const cooldownMinutes = config.stopReviewGateCooldownMinutes ?? DEFAULT_COOLDOWN_MINUTES;
+  const cooldownMinutes = config.stopReviewGateCooldownMinutes ?? null;
   if (cooldownMinutes != null && cooldownMinutes > 0) {
     const lastTime = findLastStopReviewTime(jobs);
     if (lastTime != null) {

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -197,7 +197,7 @@ test("setup command can offer Codex install and still points users to codex logi
   const setup = read("commands/setup.md");
   const readme = fs.readFileSync(path.join(ROOT, "README.md"), "utf8");
 
-  assert.match(setup, /argument-hint:\s*'\[--enable-review-gate\|--disable-review-gate\]'/);
+  assert.match(setup, /argument-hint:.*--enable-review-gate\|--disable-review-gate/);
   assert.match(setup, /AskUserQuestion/);
   assert.match(setup, /npm install -g @openai\/codex/);
   assert.match(setup, /codex-companion\.mjs" setup --json \$ARGUMENTS/);
@@ -205,4 +205,8 @@ test("setup command can offer Codex install and still points users to codex logi
   assert.match(readme, /offer to install Codex for you/i);
   assert.match(readme, /\/codex:setup --enable-review-gate/);
   assert.match(readme, /\/codex:setup --disable-review-gate/);
+  assert.match(setup, /--review-gate-max/);
+  assert.match(setup, /--review-gate-cooldown/);
+  assert.match(readme, /--review-gate-max/);
+  assert.match(readme, /--review-gate-cooldown/);
 });

--- a/tests/review-gate-throttle.test.mjs
+++ b/tests/review-gate-throttle.test.mjs
@@ -1,0 +1,102 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { makeTempDir } from "./helpers.mjs";
+import {
+  getConfig,
+  loadState,
+  resolveStateFile,
+  setConfig,
+  upsertJob
+} from "../plugins/codex/scripts/lib/state.mjs";
+
+function setupWorkspace() {
+  const workspace = makeTempDir();
+  const previousPluginData = process.env.CLAUDE_PLUGIN_DATA;
+  const pluginData = makeTempDir();
+  process.env.CLAUDE_PLUGIN_DATA = pluginData;
+
+  return {
+    workspace,
+    cleanup() {
+      if (previousPluginData == null) {
+        delete process.env.CLAUDE_PLUGIN_DATA;
+      } else {
+        process.env.CLAUDE_PLUGIN_DATA = previousPluginData;
+      }
+    }
+  };
+}
+
+test("setConfig stores stopReviewGateMaxPerSession", () => {
+  const { workspace, cleanup } = setupWorkspace();
+  try {
+    setConfig(workspace, "stopReviewGateMaxPerSession", 5);
+    const config = getConfig(workspace);
+    assert.equal(config.stopReviewGateMaxPerSession, 5);
+  } finally {
+    cleanup();
+  }
+});
+
+test("setConfig stores stopReviewGateCooldownMinutes", () => {
+  const { workspace, cleanup } = setupWorkspace();
+  try {
+    setConfig(workspace, "stopReviewGateCooldownMinutes", 10);
+    const config = getConfig(workspace);
+    assert.equal(config.stopReviewGateCooldownMinutes, 10);
+  } finally {
+    cleanup();
+  }
+});
+
+test("setConfig clears throttle config with null", () => {
+  const { workspace, cleanup } = setupWorkspace();
+  try {
+    setConfig(workspace, "stopReviewGateMaxPerSession", 5);
+    setConfig(workspace, "stopReviewGateMaxPerSession", null);
+    const config = getConfig(workspace);
+    assert.equal(config.stopReviewGateMaxPerSession, null);
+  } finally {
+    cleanup();
+  }
+});
+
+test("default config has null throttle values", () => {
+  const { workspace, cleanup } = setupWorkspace();
+  try {
+    const config = getConfig(workspace);
+    assert.equal(config.stopReviewGateMaxPerSession, null);
+    assert.equal(config.stopReviewGateCooldownMinutes, null);
+    assert.equal(config.stopReviewGate, false);
+  } finally {
+    cleanup();
+  }
+});
+
+test("loadState merges throttle defaults into existing state without throttle keys", () => {
+  const { workspace, cleanup } = setupWorkspace();
+  try {
+    // Write a state file that only has the old config shape
+    const stateFile = resolveStateFile(workspace);
+    fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+    fs.writeFileSync(
+      stateFile,
+      JSON.stringify({
+        version: 1,
+        config: { stopReviewGate: true },
+        jobs: []
+      }),
+      "utf8"
+    );
+
+    const state = loadState(workspace);
+    assert.equal(state.config.stopReviewGate, true);
+    assert.equal(state.config.stopReviewGateMaxPerSession, null);
+    assert.equal(state.config.stopReviewGateCooldownMinutes, null);
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/review-gate-throttle.test.mjs
+++ b/tests/review-gate-throttle.test.mjs
@@ -30,6 +30,54 @@ function setupWorkspace() {
   };
 }
 
+// Mirror of the throttle logic from stop-review-gate-hook.mjs for unit testing.
+// The hook script calls main() at import time so it cannot be imported directly.
+function countSessionStopReviews(jobs) {
+  return jobs.filter(
+    (job) =>
+      job.jobClass === "review" &&
+      job.title === "Codex Stop Gate Review" &&
+      job.status === "completed"
+  ).length;
+}
+
+function findLastStopReviewTime(jobs) {
+  const stopReview = jobs.find(
+    (job) =>
+      job.jobClass === "review" &&
+      job.title === "Codex Stop Gate Review" &&
+      job.completedAt
+  );
+  return stopReview?.completedAt ? new Date(stopReview.completedAt).getTime() : null;
+}
+
+function checkThrottleLimits(config, jobs) {
+  const maxPerSession = config.stopReviewGateMaxPerSession ?? null;
+  if (maxPerSession != null && maxPerSession > 0) {
+    const count = countSessionStopReviews(jobs);
+    if (count >= maxPerSession) {
+      return `Stop-gate review skipped: session limit reached (${count}/${maxPerSession}). Run /codex:review manually if needed.`;
+    }
+  }
+
+  const cooldownMinutes = config.stopReviewGateCooldownMinutes ?? null;
+  if (cooldownMinutes != null && cooldownMinutes > 0) {
+    const lastTime = findLastStopReviewTime(jobs);
+    if (lastTime != null) {
+      const elapsed = Date.now() - lastTime;
+      const cooldownMs = cooldownMinutes * 60 * 1000;
+      if (elapsed < cooldownMs) {
+        const remainingMinutes = Math.ceil((cooldownMs - elapsed) / 60000);
+        return `Stop-gate review skipped: cooldown active (${remainingMinutes}m remaining). Run /codex:review manually if needed.`;
+      }
+    }
+  }
+
+  return null;
+}
+
+// --- Config storage tests ---
+
 test("setConfig stores stopReviewGateMaxPerSession", () => {
   const { workspace, cleanup } = setupWorkspace();
   try {
@@ -79,7 +127,6 @@ test("default config has null throttle values", () => {
 test("loadState merges throttle defaults into existing state without throttle keys", () => {
   const { workspace, cleanup } = setupWorkspace();
   try {
-    // Write a state file that only has the old config shape
     const stateFile = resolveStateFile(workspace);
     fs.mkdirSync(path.dirname(stateFile), { recursive: true });
     fs.writeFileSync(
@@ -99,4 +146,79 @@ test("loadState merges throttle defaults into existing state without throttle ke
   } finally {
     cleanup();
   }
+});
+
+// --- Throttle logic tests ---
+
+test("checkThrottleLimits returns null when no limits are configured", () => {
+  const config = { stopReviewGateMaxPerSession: null, stopReviewGateCooldownMinutes: null };
+  const result = checkThrottleLimits(config, []);
+  assert.equal(result, null);
+});
+
+test("checkThrottleLimits returns null when under session limit", () => {
+  const config = { stopReviewGateMaxPerSession: 3, stopReviewGateCooldownMinutes: null };
+  const jobs = [
+    { jobClass: "review", title: "Codex Stop Gate Review", status: "completed" },
+    { jobClass: "review", title: "Codex Stop Gate Review", status: "completed" }
+  ];
+  const result = checkThrottleLimits(config, jobs);
+  assert.equal(result, null);
+});
+
+test("checkThrottleLimits blocks when session limit reached", () => {
+  const config = { stopReviewGateMaxPerSession: 2, stopReviewGateCooldownMinutes: null };
+  const jobs = [
+    { jobClass: "review", title: "Codex Stop Gate Review", status: "completed" },
+    { jobClass: "review", title: "Codex Stop Gate Review", status: "completed" }
+  ];
+  const result = checkThrottleLimits(config, jobs);
+  assert.match(result, /session limit reached \(2\/2\)/);
+});
+
+test("checkThrottleLimits does not count running or queued jobs toward limit", () => {
+  const config = { stopReviewGateMaxPerSession: 2, stopReviewGateCooldownMinutes: null };
+  const jobs = [
+    { jobClass: "review", title: "Codex Stop Gate Review", status: "completed" },
+    { jobClass: "review", title: "Codex Stop Gate Review", status: "running" },
+    { jobClass: "review", title: "Codex Stop Gate Review", status: "queued" }
+  ];
+  const result = checkThrottleLimits(config, jobs);
+  assert.equal(result, null);
+});
+
+test("checkThrottleLimits ignores non-stop-gate review jobs", () => {
+  const config = { stopReviewGateMaxPerSession: 1, stopReviewGateCooldownMinutes: null };
+  const jobs = [
+    { jobClass: "review", title: "Codex Review", status: "completed" },
+    { jobClass: "review", title: "Codex Adversarial Review", status: "completed" }
+  ];
+  const result = checkThrottleLimits(config, jobs);
+  assert.equal(result, null);
+});
+
+test("checkThrottleLimits blocks when cooldown is active", () => {
+  const config = { stopReviewGateMaxPerSession: null, stopReviewGateCooldownMinutes: 10 };
+  const recentTime = new Date(Date.now() - 3 * 60 * 1000).toISOString(); // 3 minutes ago
+  const jobs = [
+    { jobClass: "review", title: "Codex Stop Gate Review", status: "completed", completedAt: recentTime }
+  ];
+  const result = checkThrottleLimits(config, jobs);
+  assert.match(result, /cooldown active/);
+});
+
+test("checkThrottleLimits allows when cooldown has elapsed", () => {
+  const config = { stopReviewGateMaxPerSession: null, stopReviewGateCooldownMinutes: 5 };
+  const oldTime = new Date(Date.now() - 10 * 60 * 1000).toISOString(); // 10 minutes ago
+  const jobs = [
+    { jobClass: "review", title: "Codex Stop Gate Review", status: "completed", completedAt: oldTime }
+  ];
+  const result = checkThrottleLimits(config, jobs);
+  assert.equal(result, null);
+});
+
+test("checkThrottleLimits allows when no previous stop-gate review exists for cooldown", () => {
+  const config = { stopReviewGateMaxPerSession: null, stopReviewGateCooldownMinutes: 10 };
+  const result = checkThrottleLimits(config, []);
+  assert.equal(result, null);
 });


### PR DESCRIPTION
Changes: 8 files, +227 lines across 2 commits:
  1. feat: add throttle controls for review gate to prevent runaway usage
  2. fix: review gate throttle improvements from self-review

  New flags:
  - --review-gate-max <n|off> — cap stop-gate reviews per session
  - --review-gate-cooldown <minutes|off> — minimum interval between reviews

  Tests: 13 new tests all passing (5 config + 8 throttle logic)