### PR TITLE
feat: add Cursor marketplace and plugin support

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,33 @@
+{
+  "name": "openai-codex",
+  "owner": {
+    "name": "OpenAI"
+  },
+  "metadata": {
+    "description": "Codex plugins to use in Cursor for delegation and code review.",
+    "version": "1.0.1",
+    "pluginRoot": "./plugins"
+  },
+  "plugins": [
+    {
+      "name": "codex",
+      "source": "codex",
+      "description": "Use Codex from Cursor to review code or delegate tasks.",
+      "version": "1.0.1",
+      "category": "developer-tools",
+      "tags": [
+        "review",
+        "ai",
+        "codex",
+        "code-quality"
+      ],
+      "keywords": [
+        "codex",
+        "openai",
+        "code-review",
+        "delegation",
+        "ai-assistant"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Codex plugin for Claude Code
+# Codex plugin for Claude Code & Cursor
 
-Use Codex from inside Claude Code for code reviews or to delegate tasks to Codex.
+Use Codex from inside Claude Code or Cursor for code reviews or to delegate tasks to Codex.
 
-This plugin is for Claude Code users who want an easy way to start using Codex from the workflow
+This plugin is for Claude Code and Cursor users who want an easy way to start using Codex from the workflow
 they already have.
 
 <video src="./docs/plugin-demo.webm" controls muted playsinline autoplay></video>
@@ -20,6 +20,8 @@ they already have.
 - **Node.js 18.18 or later**
 
 ## Install
+
+### Claude Code
 
 Add the marketplace in Claude Code:
 
@@ -39,7 +41,19 @@ Reload plugins:
 /reload-plugins
 ```
 
-Then run:
+### Cursor
+
+Add the plugin in Cursor using the `/add-plugin` command:
+
+```
+/add-plugin openai/codex-plugin-cc
+```
+
+Alternatively, browse the [Cursor Marketplace](https://cursor.com/marketplace) and install the Codex plugin from there.
+
+### Setup
+
+After installing (in either Claude Code or Cursor), run:
 
 ```bash
 /codex:setup

--- a/plugins/codex/.cursor-plugin/plugin.json
+++ b/plugins/codex/.cursor-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "codex",
+  "version": "1.0.1",
+  "description": "Use Codex from Cursor to review code or delegate tasks.",
+  "author": {
+    "name": "OpenAI"
+  },
+  "homepage": "https://github.com/openai/codex-plugin-cc",
+  "repository": "https://github.com/openai/codex-plugin-cc",
+  "license": "Apache-2.0",
+  "keywords": [
+    "codex",
+    "openai",
+    "code-review",
+    "delegation",
+    "ai-assistant"
+  ],
+  "skills": "./skills/",
+  "commands": "./commands/",
+  "agents": "./agents/",
+  "hooks": "./hooks/cursor-hooks.json"
+}

--- a/plugins/codex/hooks/cursor-hooks.json
+++ b/plugins/codex/hooks/cursor-hooks.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": "CLAUDE_PLUGIN_ROOT=\"${CURSOR_PLUGIN_ROOT}\" node \"${CURSOR_PLUGIN_ROOT}/scripts/cursor-session-lifecycle-hook.mjs\" sessionStart",
+        "timeout": 5
+      }
+    ],
+    "sessionEnd": [
+      {
+        "command": "CLAUDE_PLUGIN_ROOT=\"${CURSOR_PLUGIN_ROOT}\" node \"${CURSOR_PLUGIN_ROOT}/scripts/session-lifecycle-hook.mjs\" SessionEnd",
+        "timeout": 5
+      }
+    ],
+    "stop": [
+      {
+        "command": "CLAUDE_PLUGIN_ROOT=\"${CURSOR_PLUGIN_ROOT}\" node \"${CURSOR_PLUGIN_ROOT}/scripts/stop-review-gate-hook.mjs\"",
+        "timeout": 900
+      }
+    ]
+  }
+}

--- a/plugins/codex/scripts/cursor-session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/cursor-session-lifecycle-hook.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+/**
+ * Cursor-specific sessionStart hook adapter.
+ *
+ * Cursor propagates env vars via the hook's JSON stdout `{ "env": { ... } }`
+ * rather than Claude Code's CLAUDE_ENV_FILE mechanism.  This thin wrapper reads
+ * the Cursor hook input and emits the env vars the companion runtime needs for
+ * the rest of the session.
+ *
+ * sessionEnd and stop hooks reuse the original scripts directly (see
+ * cursor-hooks.json).
+ */
+
+import fs from "node:fs";
+import process from "node:process";
+
+const SESSION_ID_ENV = "CODEX_COMPANION_SESSION_ID";
+
+function readHookInput() {
+  const raw = fs.readFileSync(0, "utf8").trim();
+  if (!raw) {
+    return {};
+  }
+  return JSON.parse(raw);
+}
+
+function main() {
+  const input = readHookInput();
+
+  // Emit env vars that subsequent hooks (sessionEnd, stop) will need.
+  const env = {};
+
+  if (input.session_id) {
+    env[SESSION_ID_ENV] = String(input.session_id);
+  }
+
+  // Cursor does not provide CLAUDE_PLUGIN_DATA; the companion runtime falls
+  // back to $TMPDIR/codex-companion automatically (see lib/state.mjs).
+
+  process.stdout.write(JSON.stringify({ env }));
+}
+
+main();


### PR DESCRIPTION
## Summary

Add `.cursor-plugin/` manifests alongside the existing `.claude-plugin/` ones so the Codex plugin is discoverable from both the Claude Code and Cursor marketplaces.

### What's included

- **`.cursor-plugin/marketplace.json`** — root marketplace manifest for Cursor (uses `pluginRoot` convention, plugin-level metadata with `category`/`tags`/`keywords`)
- **`plugins/codex/.cursor-plugin/plugin.json`** — plugin manifest validated against [cursor.com/docs/reference/plugins](https://cursor.com/docs/reference/plugins) (only spec-valid fields; `category`/`tags` live in marketplace entry, not here)
- **`plugins/codex/hooks/cursor-hooks.json`** — Cursor-format hooks (`version: 1`, camelCase event names, `timeout` values, `${CURSOR_PLUGIN_ROOT}` interpolation)
- **`plugins/codex/scripts/cursor-session-lifecycle-hook.mjs`** — Cursor `sessionStart` adapter that outputs `{ "env": { ... } }` JSON (Cursor's mechanism) instead of writing to `CLAUDE_ENV_FILE` (Claude Code's mechanism)
- **`README.md`** — updated title, description, and install section with Cursor instructions

### Design decisions

| Concern | Approach |
|---|---|
| Hooks format differs (PascalCase/nested vs camelCase/flat) | Separate `cursor-hooks.json` referenced via explicit `"hooks"` field in plugin.json; existing `hooks.json` (Claude Code format) untouched |
| `CURSOR_PLUGIN_ROOT` vs `CLAUDE_PLUGIN_ROOT` | Hook commands bridge with `CLAUDE_PLUGIN_ROOT="${CURSOR_PLUGIN_ROOT}"` so existing scripts resolve paths correctly |
| `CLAUDE_ENV_FILE` not available in Cursor | Dedicated `cursor-session-lifecycle-hook.mjs` outputs `{ "env": { ... } }` on stdout per Cursor hook output spec |
| `CLAUDE_PLUGIN_DATA` not available in Cursor | `lib/state.mjs` already falls back to `$TMPDIR/codex-companion` — no change needed |
| Shared components (skills, commands, agents) | Markdown-based — portable as-is; both manifests point to the same directories |

### Limitations

- The `sessionEnd` and `stop` hooks reuse the original scripts. They work but lack `CLAUDE_ENV_FILE` and `CLAUDE_PLUGIN_DATA`, so session-scoped env var propagation relies on Cursor's `sessionStart` → `env` output mechanism and the tmpdir state fallback.
- Command markdown files contain Claude Code-specific frontmatter (`allowed-tools`, `disable-model-invocation`). Cursor tolerates unknown frontmatter fields, but these features won't activate in Cursor.
- Cursor CLI does not support plugins yet (desktop only).

### Cursor Marketplace/Plugins References

- https://cursor.com/docs/plugins   
- https://cursor.com/docs/reference/plugins   
- Examples:
  - https://cursor.com/marketplace/cursor/create-plugin
  - https://github.com/cursor/plugins

## Test plan

- [ ] Install plugin via Cursor marketplace (`/add-plugin openai/codex-plugin-cc`) and verify it appears in installed plugins
- [ ] Verify `/codex:setup`, `/codex:review`, and other slash commands are discoverable in Cursor
- [ ] Verify `sessionStart` hook fires and propagates `CODEX_COMPANION_SESSION_ID` to subsequent hooks
- [ ] Verify existing Claude Code plugin functionality is unaffected (no changes to `.claude-plugin/` or `hooks/hooks.json`)

## Note

We might be able to interpret the **cc* portion of the repo name as either "Claude Code" or "Claude Code and Cursor". 
