### PR TITLE
tests: derive repo roots from test file locations

### DIFF
--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -2,8 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
 
-const ROOT = "/Users/dkundel/code/codex-plugin";
+const ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const PLUGIN_ROOT = path.join(ROOT, "plugins", "codex");
 
 function read(relativePath) {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -3,13 +3,14 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 import { buildEnv, installFakeCodex } from "./fake-codex-fixture.mjs";
 import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
 import { loadBrokerSession } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
 import { resolveStateDir } from "../plugins/codex/scripts/lib/state.mjs";
 
-const ROOT = "/Users/dkundel/code/codex-plugin";
+const ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const PLUGIN_ROOT = path.join(ROOT, "plugins", "codex");
 const SCRIPT = path.join(PLUGIN_ROOT, "scripts", "codex-companion.mjs");
 const STOP_HOOK = path.join(PLUGIN_ROOT, "scripts", "stop-review-gate-hook.mjs");


### PR DESCRIPTION
## Summary
- derive the repo root in test files from `import.meta.url`
- remove the hardcoded `/Users/dkundel/code/codex-plugin` dependency

## Why
Closes #27.

The current test suite assumes one developer-specific checkout path, which makes `npm test` fail on fresh clones and masks real regressions behind path errors.

## Validation
- `node --test tests/commands.test.mjs`
- `node --test --test-name-pattern "setup reports ready when fake codex is installed and authenticated" tests/runtime.test.mjs`
