### PR TITLE
tests: reduce background task timing flakiness

### DIFF
--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -465,7 +465,7 @@ rl.on("line", (line) => {
 	              }
 	            }
 	            send({ method: "turn/completed", params: { threadId: thread.id, turn: buildTurn(turnId, "completed") } });
-	          }, 400);
+	          }, 5000);
 	          interruptibleTurns.set(turnId, { threadId: thread.id, timer });
 	        } else if (BEHAVIOR === "slow-task") {
 	          emitTurnCompletedLater(thread.id, turnId, items, 400);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -553,7 +553,7 @@ test("task --background enqueues a detached worker and exposes per-job status", 
 
   const waitedStatus = run(
     "node",
-    [SCRIPT, "status", launchPayload.jobId, "--wait", "--timeout-ms", "5000", "--json"],
+    [SCRIPT, "status", launchPayload.jobId, "--wait", "--timeout-ms", "15000", "--json"],
     {
       cwd: repo,
       env: buildEnv(binDir)
@@ -1275,7 +1275,7 @@ test("cancel sends turn interrupt to the shared app-server before killing a brok
       return job;
     }
     return null;
-  });
+  }, { timeoutMs: 15000 });
 
   const cancelResult = run("node", [SCRIPT, "cancel", jobId, "--json"], {
     cwd: repo,


### PR DESCRIPTION
## Summary
- relax the background-task status wait window in `runtime.test.mjs`
- allow a longer window for the brokered cancellation test to observe an in-flight task
- widen the fake interruptible task window so cancel assertions race against a real running task, not normal completion

## Why
Closes #33.

The background-task runtime tests are too timing-sensitive on slower machines. Normal startup variance can leave a job in `running` long enough to fail assertions even when the implementation is correct.

## Validation
- manually reproduced the background task completion flow and verified the job reaches `completed`
- manually reproduced the brokered cancellation flow and verified `turnInterrupted: true` plus the recorded interrupt in the fake Codex state
