### PR TITLE
Add opencode plugin: delegate tasks to OpenCode from Claude Code

### DIFF
--- a/plugins/opencode/.claude-plugin/plugin.json
+++ b/plugins/opencode/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "opencode",
+  "version": "0.1.0",
+  "description": "Use OpenCode from Claude Code to delegate tasks.",
+  "author": {
+    "name": "Community"
+  }
+}

--- a/plugins/opencode/agents/opencode-rescue.md
+++ b/plugins/opencode/agents/opencode-rescue.md
@@ -1,0 +1,35 @@
+---
+name: opencode-rescue
+description: Proactively use when Claude Code is stuck, wants a second implementation or diagnosis pass, needs a deeper root-cause investigation, or should hand a substantial coding task to OpenCode
+tools: Bash
+---
+
+You are a thin forwarding wrapper around the OpenCode companion task runtime.
+
+Your only job is to forward the user's rescue request to the OpenCode companion script. Do not do anything else.
+
+Selection guidance:
+
+- Do not wait for the user to explicitly ask for OpenCode. Use this subagent proactively when the main Claude thread should hand a substantial debugging or implementation task to OpenCode.
+- Do not grab simple asks that the main Claude thread can finish quickly on its own.
+
+Forwarding rules:
+
+- Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/opencode-companion.mjs" task ...`.
+- If the user did not explicitly choose `--background` or `--wait`, prefer foreground for a small, clearly bounded rescue request.
+- If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep OpenCode running for a long time, prefer background execution.
+- Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
+- Do not call `status`, `result`, or `cancel`. This subagent only forwards to `task`.
+- Treat `--resume` and `--fresh` as routing controls and do not include them in the task text you pass through.
+- `--resume` means add `--continue`.
+- `--fresh` means do not add `--continue`.
+- If the user is clearly asking to continue prior OpenCode work in this repository, such as "continue", "keep going", "resume", "apply the top fix", or "dig deeper", add `--continue` unless `--fresh` is present.
+- Otherwise forward the task as a fresh `task` run.
+- Default to `--write` unless the user explicitly asks for read-only behavior.
+- Preserve the user's task text as-is apart from stripping routing flags.
+- Return the stdout of the `opencode-companion` command exactly as-is.
+- If the Bash call fails or OpenCode cannot be invoked, return nothing.
+
+Response style:
+
+- Do not add commentary before or after the forwarded `opencode-companion` output.

--- a/plugins/opencode/commands/cancel.md
+++ b/plugins/opencode/commands/cancel.md
@@ -1,0 +1,13 @@
+---
+description: Cancel a running OpenCode job
+argument-hint: "[job-id] [--json]"
+allowed-tools: Bash(node:*)
+---
+
+Run the following command and return its output verbatim:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/opencode-companion.mjs" cancel $ARGUMENTS
+```
+
+Do not paraphrase or summarize the output.

--- a/plugins/opencode/commands/rescue.md
+++ b/plugins/opencode/commands/rescue.md
@@ -1,0 +1,46 @@
+---
+description: Delegate investigation, fix request, or follow-up work to OpenCode
+argument-hint: "[--background|--wait] [--resume|--fresh] [--session <id>] [what OpenCode should investigate, solve, or continue]"
+context: fork
+allowed-tools: Bash(node:*)
+---
+
+Route this request to the `opencode:opencode-rescue` subagent.
+The final user-visible response must be OpenCode's output verbatim.
+
+Raw user request:
+$ARGUMENTS
+
+Execution mode:
+
+- If the request includes `--background`, run the `opencode:opencode-rescue` subagent in the background.
+- If the request includes `--wait`, run the `opencode:opencode-rescue` subagent in the foreground.
+- If neither flag is present, default to foreground.
+- `--background` and `--wait` are execution flags for Claude Code. Do not forward them to `task`, and do not treat them as part of the natural-language task text.
+- If the request includes `--resume`, do not ask whether to continue. The user already chose.
+- If the request includes `--fresh`, do not ask whether to continue. The user already chose.
+- Otherwise, before starting OpenCode, check for a resumable session by running:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/opencode-companion.mjs" task-resume-candidate --json
+```
+
+- If that helper reports `available: true`, use `AskUserQuestion` exactly once to ask whether to continue the current OpenCode session or start a new one.
+- The two choices must be:
+  - `Continue current OpenCode session`
+  - `Start a new OpenCode session`
+- If the user is clearly giving a follow-up instruction such as "continue", "keep going", "resume", "apply the top fix", or "dig deeper", put `Continue current OpenCode session (Recommended)` first.
+- Otherwise put `Start a new OpenCode session (Recommended)` first.
+- If the user chooses continue, add `--resume` before routing to the subagent.
+- If the user chooses a new session, add `--fresh` before routing to the subagent.
+- If the helper reports `available: false`, do not ask. Route normally.
+
+Operating rules:
+
+- The subagent is a thin forwarder only. It should use one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/opencode-companion.mjs" task ...` and return that command's stdout as-is.
+- Return the OpenCode companion stdout verbatim to the user.
+- Do not paraphrase, summarize, rewrite, or add commentary before or after it.
+- Do not ask the subagent to inspect files, monitor progress, poll `/opencode:status`, fetch `/opencode:result`, call `/opencode:cancel`, summarize output, or do follow-up work of its own.
+- Leave `--resume` and `--fresh` in the forwarded request. The subagent handles that routing when it builds the `task` command.
+- If the helper reports that OpenCode is missing or unauthenticated, stop and tell the user to run `/opencode:setup`.
+- If the user did not supply a request, ask what OpenCode should investigate or fix.

--- a/plugins/opencode/commands/result.md
+++ b/plugins/opencode/commands/result.md
@@ -1,0 +1,13 @@
+---
+description: Retrieve the result of a finished OpenCode job
+argument-hint: "[job-id] [--json]"
+allowed-tools: Bash(node:*)
+---
+
+Run the following command and return its output verbatim:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/opencode-companion.mjs" result $ARGUMENTS
+```
+
+Do not paraphrase or summarize the output.

--- a/plugins/opencode/commands/setup.md
+++ b/plugins/opencode/commands/setup.md
@@ -1,0 +1,13 @@
+---
+description: Check OpenCode installation and readiness
+argument-hint: "[--json]"
+allowed-tools: Bash(node:*)
+---
+
+Run the following command and return its output verbatim:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/opencode-companion.mjs" setup $ARGUMENTS
+```
+
+Do not paraphrase or summarize the output.

--- a/plugins/opencode/commands/status.md
+++ b/plugins/opencode/commands/status.md
@@ -1,0 +1,13 @@
+---
+description: Show status of OpenCode background jobs
+argument-hint: "[job-id] [--json]"
+allowed-tools: Bash(node:*)
+---
+
+Run the following command and return its output verbatim:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/opencode-companion.mjs" status $ARGUMENTS
+```
+
+Do not paraphrase or summarize the output.

--- a/plugins/opencode/scripts/lib/opencode.mjs
+++ b/plugins/opencode/scripts/lib/opencode.mjs
@@ -1,0 +1,153 @@
+/**
+ * OpenCode CLI integration.
+ *
+ * Unlike Codex (JSON-RPC app-server), OpenCode uses a simple CLI:
+ *   opencode run [--continue] [--session <id>] [--format json] [--quiet] "prompt"
+ */
+
+import { spawn } from "node:child_process";
+import { binaryAvailable, runCommand } from "./process.mjs";
+
+/**
+ * Check whether `opencode` is installed and reachable.
+ * @param {string} cwd
+ * @returns {{ available: boolean, detail: string }}
+ */
+export function getOpenCodeAvailability(cwd) {
+  return binaryAvailable("opencode", ["version"], { cwd });
+}
+
+/**
+ * Check whether the user is authenticated with OpenCode.
+ * OpenCode doesn't have a dedicated `login status` command, so we just
+ * check availability — authentication is handled via provider API keys
+ * in the environment or opencode config.
+ * @param {string} cwd
+ * @returns {{ available: boolean, loggedIn: boolean, detail: string }}
+ */
+export function getOpenCodeAuthStatus(cwd) {
+  const availability = getOpenCodeAvailability(cwd);
+  if (!availability.available) {
+    return { available: false, loggedIn: false, detail: availability.detail };
+  }
+  // OpenCode relies on provider API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)
+  // We can't easily check that without trying a real call, so treat as ready if binary exists.
+  return { available: true, loggedIn: true, detail: availability.detail };
+}
+
+/**
+ * Run `opencode run` and capture its output.
+ *
+ * @param {string} cwd  Working directory (git root)
+ * @param {object} options
+ * @param {string}  options.prompt        The task prompt
+ * @param {boolean} [options.continueSession]  Resume previous session (--continue)
+ * @param {string}  [options.sessionId]   Specific session to resume (--session <id>)
+ * @param {boolean} [options.write]       Allow file writes (default true)
+ * @param {((msg: string) => void)|null} [options.onProgress]
+ * @returns {Promise<{status: number, stdout: string, stderr: string, sessionId: string|null}>}
+ */
+export function runOpenCodeTask(cwd, options = {}) {
+  return new Promise((resolve, reject) => {
+    const args = ["run"];
+
+    // Session continuation
+    if (options.sessionId) {
+      args.push("--session", options.sessionId);
+    } else if (options.continueSession) {
+      args.push("--continue");
+    }
+
+    // Output format
+    args.push("--format", "default");
+    args.push("--quiet");
+
+    // Prompt
+    if (options.prompt) {
+      args.push(options.prompt);
+    }
+
+    const onProgress = options.onProgress ?? null;
+    if (onProgress) {
+      onProgress("Starting OpenCode task.");
+    }
+
+    const child = spawn("opencode", args, {
+      cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"]
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      const text = chunk.toString();
+      stdout += text;
+      if (onProgress) {
+        const lastLine = text.trim().split(/\r?\n/).pop();
+        if (lastLine) {
+          onProgress(lastLine);
+        }
+      }
+    });
+
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", (err) => {
+      reject(err);
+    });
+
+    child.on("close", (code) => {
+      // Try to extract session ID from output.
+      // OpenCode may print session info; we parse it if available.
+      const sessionId = extractSessionId(stdout) ?? extractSessionId(stderr) ?? null;
+
+      resolve({
+        status: code ?? 1,
+        stdout: stdout.trimEnd(),
+        stderr: stderr.trimEnd(),
+        sessionId
+      });
+    });
+  });
+}
+
+/**
+ * Try to extract an OpenCode session ID from output text.
+ * Looks for patterns like "Session: <id>" or "session_id: <id>".
+ * @param {string} text
+ * @returns {string|null}
+ */
+function extractSessionId(text) {
+  // opencode prints session info in various formats
+  const patterns = [
+    /session[_\s-]*(?:id)?[:\s]+([a-zA-Z0-9_-]{8,})/i,
+    /Resuming session[:\s]+([a-zA-Z0-9_-]{8,})/i
+  ];
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (match) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+/**
+ * Kill an opencode process by PID.
+ * @param {number} pid
+ */
+export function killOpenCodeProcess(pid) {
+  if (!Number.isFinite(pid)) {
+    return false;
+  }
+  try {
+    process.kill(pid, "SIGTERM");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/plugins/opencode/scripts/lib/process.mjs
+++ b/plugins/opencode/scripts/lib/process.mjs
@@ -1,0 +1,55 @@
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+export function runCommand(command, args = [], options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    encoding: "utf8",
+    input: options.input,
+    stdio: options.stdio ?? "pipe",
+    shell: process.platform === "win32"
+  });
+
+  return {
+    command,
+    args,
+    status: result.status ?? 0,
+    signal: result.signal ?? null,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    error: result.error ?? null
+  };
+}
+
+export function binaryAvailable(command, versionArgs = ["--version"], options = {}) {
+  const result = runCommand(command, versionArgs, options);
+  if (result.error && /** @type {NodeJS.ErrnoException} */ (result.error).code === "ENOENT") {
+    return { available: false, detail: "not found" };
+  }
+  if (result.error) {
+    return { available: false, detail: result.error.message };
+  }
+  if (result.status !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`;
+    return { available: false, detail };
+  }
+  return { available: true, detail: result.stdout.trim() || result.stderr.trim() || "ok" };
+}
+
+export function terminateProcessTree(pid) {
+  if (!Number.isFinite(pid)) {
+    return { attempted: false, delivered: false };
+  }
+  try {
+    process.kill(-pid, "SIGTERM");
+    return { attempted: true, delivered: true };
+  } catch {
+    try {
+      process.kill(pid, "SIGTERM");
+      return { attempted: true, delivered: true };
+    } catch {
+      return { attempted: true, delivered: false };
+    }
+  }
+}

--- a/plugins/opencode/scripts/lib/render.mjs
+++ b/plugins/opencode/scripts/lib/render.mjs
@@ -1,0 +1,96 @@
+export function renderSetupReport(report) {
+  const lines = [
+    "# OpenCode Setup",
+    "",
+    `Status: ${report.ready ? "ready" : "needs attention"}`,
+    "",
+    "Checks:",
+    `- node: ${report.node.detail}`,
+    `- opencode: ${report.opencode.detail}`,
+    ""
+  ];
+
+  if (report.nextSteps.length > 0) {
+    lines.push("Next steps:");
+    for (const step of report.nextSteps) {
+      lines.push(`- ${step}`);
+    }
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function renderTaskResult(result) {
+  if (result.stdout) {
+    return result.stdout.endsWith("\n") ? result.stdout : `${result.stdout}\n`;
+  }
+  if (result.stderr) {
+    return `OpenCode error:\n${result.stderr}\n`;
+  }
+  return "OpenCode did not return any output.\n";
+}
+
+export function renderStatusReport(report) {
+  const lines = ["# OpenCode Status", ""];
+
+  if (report.running.length > 0) {
+    lines.push("Active jobs:");
+    for (const job of report.running) {
+      lines.push(`- ${job.id} | ${job.status} | ${job.title ?? "task"} | ${job.summary ?? ""}`);
+    }
+    lines.push("");
+  }
+
+  if (report.recent.length > 0) {
+    lines.push("Recent jobs:");
+    for (const job of report.recent) {
+      lines.push(`- ${job.id} | ${job.status} | ${job.title ?? "task"} | ${job.summary ?? ""}`);
+    }
+    lines.push("");
+  }
+
+  if (report.running.length === 0 && report.recent.length === 0) {
+    lines.push("No jobs recorded yet.", "");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function renderJobResult(job, storedJob) {
+  if (storedJob?.rendered) {
+    return storedJob.rendered.endsWith("\n") ? storedJob.rendered : `${storedJob.rendered}\n`;
+  }
+  if (storedJob?.result?.stdout) {
+    return storedJob.result.stdout.endsWith("\n") ? storedJob.result.stdout : `${storedJob.result.stdout}\n`;
+  }
+
+  const lines = [
+    `# ${job.title ?? "OpenCode Result"}`,
+    "",
+    `Job: ${job.id}`,
+    `Status: ${job.status}`
+  ];
+
+  if (job.sessionId) {
+    lines.push(`Session: ${job.sessionId}`);
+  }
+  if (job.summary) {
+    lines.push(`Summary: ${job.summary}`);
+  }
+  if (job.errorMessage) {
+    lines.push("", job.errorMessage);
+  } else {
+    lines.push("", "No captured result for this job.");
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function renderCancelReport(job) {
+  return [
+    "# OpenCode Cancel",
+    "",
+    `Cancelled ${job.id}.`,
+    ""
+  ].join("\n");
+}

--- a/plugins/opencode/scripts/lib/state.mjs
+++ b/plugins/opencode/scripts/lib/state.mjs
@@ -1,0 +1,149 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { resolveWorkspaceRoot } from "./workspace.mjs";
+
+const STATE_VERSION = 1;
+const PLUGIN_DATA_ENV = "CLAUDE_PLUGIN_DATA";
+const FALLBACK_STATE_ROOT_DIR = path.join(os.tmpdir(), "opencode-companion");
+const STATE_FILE_NAME = "state.json";
+const JOBS_DIR_NAME = "jobs";
+const MAX_JOBS = 50;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function defaultState() {
+  return {
+    version: STATE_VERSION,
+    config: {},
+    jobs: []
+  };
+}
+
+export function resolveStateDir(cwd) {
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  let canonicalWorkspaceRoot = workspaceRoot;
+  try {
+    canonicalWorkspaceRoot = fs.realpathSync.native(workspaceRoot);
+  } catch {
+    canonicalWorkspaceRoot = workspaceRoot;
+  }
+
+  const slugSource = path.basename(workspaceRoot) || "workspace";
+  const slug = slugSource.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "workspace";
+  const hash = createHash("sha256").update(canonicalWorkspaceRoot).digest("hex").slice(0, 16);
+  const pluginDataDir = process.env[PLUGIN_DATA_ENV];
+  const stateRoot = pluginDataDir ? path.join(pluginDataDir, "state") : FALLBACK_STATE_ROOT_DIR;
+  return path.join(stateRoot, `${slug}-${hash}`);
+}
+
+export function resolveJobsDir(cwd) {
+  return path.join(resolveStateDir(cwd), JOBS_DIR_NAME);
+}
+
+export function ensureStateDir(cwd) {
+  fs.mkdirSync(resolveJobsDir(cwd), { recursive: true });
+}
+
+export function loadState(cwd) {
+  const stateFile = path.join(resolveStateDir(cwd), STATE_FILE_NAME);
+  if (!fs.existsSync(stateFile)) {
+    return defaultState();
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+    return {
+      ...defaultState(),
+      ...parsed,
+      config: { ...defaultState().config, ...(parsed.config ?? {}) },
+      jobs: Array.isArray(parsed.jobs) ? parsed.jobs : []
+    };
+  } catch {
+    return defaultState();
+  }
+}
+
+function pruneJobs(jobs) {
+  return [...jobs]
+    .sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")))
+    .slice(0, MAX_JOBS);
+}
+
+export function saveState(cwd, state) {
+  ensureStateDir(cwd);
+  const stateFile = path.join(resolveStateDir(cwd), STATE_FILE_NAME);
+  const nextJobs = pruneJobs(state.jobs ?? []);
+  const nextState = {
+    version: STATE_VERSION,
+    config: { ...defaultState().config, ...(state.config ?? {}) },
+    jobs: nextJobs
+  };
+  fs.writeFileSync(stateFile, `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
+  return nextState;
+}
+
+export function updateState(cwd, mutate) {
+  const state = loadState(cwd);
+  mutate(state);
+  return saveState(cwd, state);
+}
+
+export function generateJobId(prefix = "job") {
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${prefix}-${Date.now().toString(36)}-${random}`;
+}
+
+export function upsertJob(cwd, jobPatch) {
+  return updateState(cwd, (state) => {
+    const timestamp = nowIso();
+    const existingIndex = state.jobs.findIndex((job) => job.id === jobPatch.id);
+    if (existingIndex === -1) {
+      state.jobs.unshift({ createdAt: timestamp, updatedAt: timestamp, ...jobPatch });
+      return;
+    }
+    state.jobs[existingIndex] = {
+      ...state.jobs[existingIndex],
+      ...jobPatch,
+      updatedAt: timestamp
+    };
+  });
+}
+
+export function listJobs(cwd) {
+  return loadState(cwd).jobs;
+}
+
+export function getConfig(cwd) {
+  return loadState(cwd).config;
+}
+
+export function setConfig(cwd, key, value) {
+  return updateState(cwd, (state) => {
+    state.config = { ...state.config, [key]: value };
+  });
+}
+
+export function writeJobFile(cwd, jobId, payload) {
+  ensureStateDir(cwd);
+  const jobFile = resolveJobFile(cwd, jobId);
+  fs.writeFileSync(jobFile, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  return jobFile;
+}
+
+export function readJobFile(jobFile) {
+  return JSON.parse(fs.readFileSync(jobFile, "utf8"));
+}
+
+export function resolveJobFile(cwd, jobId) {
+  ensureStateDir(cwd);
+  return path.join(resolveJobsDir(cwd), `${jobId}.json`);
+}
+
+export function resolveJobLogFile(cwd, jobId) {
+  ensureStateDir(cwd);
+  return path.join(resolveJobsDir(cwd), `${jobId}.log`);
+}

--- a/plugins/opencode/scripts/lib/workspace.mjs
+++ b/plugins/opencode/scripts/lib/workspace.mjs
@@ -1,0 +1,17 @@
+import { spawnSync } from "node:child_process";
+
+export function resolveWorkspaceRoot(cwd) {
+  try {
+    const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd,
+      encoding: "utf8",
+      stdio: "pipe"
+    });
+    if (result.status === 0 && result.stdout.trim()) {
+      return result.stdout.trim();
+    }
+  } catch {
+    // not a git repo
+  }
+  return cwd;
+}

--- a/plugins/opencode/scripts/opencode-companion.mjs
+++ b/plugins/opencode/scripts/opencode-companion.mjs
@@ -1,0 +1,549 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { getOpenCodeAvailability, getOpenCodeAuthStatus, runOpenCodeTask } from "./lib/opencode.mjs";
+import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
+import {
+  generateJobId,
+  listJobs,
+  loadState,
+  resolveJobFile,
+  resolveJobLogFile,
+  upsertJob,
+  writeJobFile
+} from "./lib/state.mjs";
+import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
+import {
+  renderCancelReport,
+  renderJobResult,
+  renderSetupReport,
+  renderStatusReport,
+  renderTaskResult
+} from "./lib/render.mjs";
+
+const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const SESSION_ID_ENV = "OPENCODE_COMPANION_SESSION_ID";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function shorten(text, limit = 96) {
+  const normalized = String(text ?? "").trim().replace(/\s+/g, " ");
+  if (!normalized) return "";
+  return normalized.length <= limit ? normalized : `${normalized.slice(0, limit - 3)}...`;
+}
+
+function splitRawArgs(raw) {
+  const tokens = [];
+  let current = "";
+  let quote = null;
+  let escaping = false;
+  for (const ch of raw) {
+    if (escaping) { current += ch; escaping = false; continue; }
+    if (ch === "\\") { escaping = true; continue; }
+    if (quote) { if (ch === quote) quote = null; else current += ch; continue; }
+    if (ch === "'" || ch === '"') { quote = ch; continue; }
+    if (/\s/.test(ch)) { if (current) { tokens.push(current); current = ""; } continue; }
+    current += ch;
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function parseArgs(argv) {
+  const options = {};
+  const positionals = [];
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (token === "--") { positionals.push(...argv.slice(i + 1)); break; }
+    if (token.startsWith("--")) {
+      const [key, val] = token.slice(2).split("=", 2);
+      if (val !== undefined) { options[key] = val; }
+      else if (argv[i + 1] && !argv[i + 1].startsWith("--")) { options[key] = argv[++i]; }
+      else { options[key] = true; }
+    } else {
+      positionals.push(token);
+    }
+  }
+  return { options, positionals };
+}
+
+function normalizeArgv(argv) {
+  if (argv.length === 1 && argv[0]?.trim()) {
+    return splitRawArgs(argv[0]);
+  }
+  return argv;
+}
+
+function outputResult(value, asJson) {
+  if (asJson) {
+    console.log(JSON.stringify(value, null, 2));
+  } else {
+    process.stdout.write(typeof value === "string" ? value : JSON.stringify(value, null, 2));
+  }
+}
+
+function appendLogLine(logFile, message) {
+  if (!logFile || !message) return;
+  fs.appendFileSync(logFile, `[${nowIso()}] ${String(message).trim()}\n`, "utf8");
+}
+
+function sortJobsNewestFirst(jobs) {
+  return [...jobs].sort((a, b) => String(b.updatedAt ?? "").localeCompare(String(a.updatedAt ?? "")));
+}
+
+// ---------------------------------------------------------------------------
+// setup
+// ---------------------------------------------------------------------------
+
+function handleSetup(argv) {
+  const { options } = parseArgs(normalizeArgv(argv));
+  const cwd = options.cwd ? path.resolve(process.cwd(), options.cwd) : process.cwd();
+  const nodeStatus = binaryAvailable("node", ["--version"], { cwd });
+  const openCodeStatus = getOpenCodeAvailability(cwd);
+
+  const nextSteps = [];
+  if (!openCodeStatus.available) {
+    nextSteps.push("Install OpenCode: `curl -fsSL https://opencode.ai/install | bash` or `npm i -g opencode-ai@latest`.");
+  }
+
+  const report = {
+    ready: nodeStatus.available && openCodeStatus.available,
+    node: nodeStatus,
+    opencode: openCodeStatus,
+    nextSteps
+  };
+
+  outputResult(options.json === true || options.json === "true" ? report : renderSetupReport(report), options.json === true || options.json === "true");
+}
+
+// ---------------------------------------------------------------------------
+// task (the core — equivalent to codex rescue)
+// ---------------------------------------------------------------------------
+
+async function handleTask(argv) {
+  const { options, positionals } = parseArgs(normalizeArgv(argv));
+  const cwd = options.cwd ? path.resolve(process.cwd(), options.cwd) : process.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const prompt = positionals.join(" ").trim();
+  const continueSession = options.continue === true || options.continue === "true";
+  const sessionId = typeof options.session === "string" ? options.session : null;
+  const write = options.write === true || options.write === "true";
+  const background = options.background === true || options.background === "true";
+  const asJson = options.json === true || options.json === "true";
+
+  // Validate
+  const authStatus = getOpenCodeAuthStatus(cwd);
+  if (!authStatus.available) {
+    throw new Error("OpenCode is not installed. Run `/opencode:setup` for instructions.");
+  }
+
+  if (!prompt && !continueSession && !sessionId) {
+    throw new Error("Provide a prompt or use --continue to resume the previous session.");
+  }
+
+  const jobId = generateJobId("task");
+  const title = continueSession ? "OpenCode Resume" : "OpenCode Task";
+  const summary = shorten(prompt || "Continue previous session");
+
+  // Create job record
+  const job = {
+    id: jobId,
+    kind: "task",
+    jobClass: "task",
+    title,
+    summary,
+    write,
+    status: "running",
+    phase: "starting",
+    workspaceRoot,
+    createdAt: nowIso(),
+    startedAt: nowIso(),
+    pid: process.pid,
+    ...(process.env[SESSION_ID_ENV] ? { sessionId: process.env[SESSION_ID_ENV] } : {})
+  };
+
+  const logFile = resolveJobLogFile(workspaceRoot, jobId);
+  fs.writeFileSync(logFile, "", "utf8");
+  appendLogLine(logFile, `Starting ${title}.`);
+
+  if (background) {
+    // Spawn detached worker
+    const scriptPath = path.join(ROOT_DIR, "scripts", "opencode-companion.mjs");
+    const workerArgs = ["task-worker", "--cwd", cwd, "--job-id", jobId];
+    const child = spawn(process.execPath, [scriptPath, ...workerArgs], {
+      cwd,
+      env: process.env,
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true
+    });
+    child.unref();
+
+    const queuedJob = { ...job, status: "queued", phase: "queued", pid: child.pid ?? null, logFile, request: { cwd, prompt, continueSession, sessionId, write } };
+    writeJobFile(workspaceRoot, jobId, queuedJob);
+    upsertJob(workspaceRoot, queuedJob);
+
+    const payload = { jobId, status: "queued", title, summary, logFile };
+    outputResult(
+      asJson ? payload : `${title} started in the background as ${jobId}. Check /opencode:status ${jobId} for progress.\n`,
+      asJson
+    );
+    return;
+  }
+
+  // Foreground execution
+  writeJobFile(workspaceRoot, jobId, { ...job, logFile });
+  upsertJob(workspaceRoot, job);
+
+  const onProgress = (msg) => {
+    const text = typeof msg === "string" ? msg : msg?.message ?? "";
+    if (text) {
+      process.stderr.write(`[opencode] ${text}\n`);
+      appendLogLine(logFile, text);
+    }
+  };
+
+  try {
+    const result = await runOpenCodeTask(cwd, {
+      prompt,
+      continueSession,
+      sessionId,
+      write,
+      onProgress
+    });
+
+    const completionStatus = result.status === 0 ? "completed" : "failed";
+    const completedAt = nowIso();
+    const rendered = renderTaskResult(result);
+
+    writeJobFile(workspaceRoot, jobId, {
+      ...job,
+      status: completionStatus,
+      phase: completionStatus === "completed" ? "done" : "failed",
+      completedAt,
+      pid: null,
+      logFile,
+      sessionId: result.sessionId ?? null,
+      result: { status: result.status, stdout: result.stdout, stderr: result.stderr },
+      rendered
+    });
+    upsertJob(workspaceRoot, {
+      id: jobId,
+      status: completionStatus,
+      phase: completionStatus === "completed" ? "done" : "failed",
+      completedAt,
+      pid: null,
+      sessionId: result.sessionId ?? null,
+      summary: shorten(result.stdout || summary)
+    });
+
+    appendLogLine(logFile, `Task ${completionStatus}.`);
+    outputResult(asJson ? { jobId, status: completionStatus, ...result } : rendered, asJson);
+
+    if (result.status !== 0) {
+      process.exitCode = result.status;
+    }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const completedAt = nowIso();
+    writeJobFile(workspaceRoot, jobId, {
+      ...job,
+      status: "failed",
+      phase: "failed",
+      completedAt,
+      pid: null,
+      logFile,
+      errorMessage
+    });
+    upsertJob(workspaceRoot, {
+      id: jobId,
+      status: "failed",
+      phase: "failed",
+      completedAt,
+      pid: null,
+      errorMessage
+    });
+    throw error;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// task-worker (detached background execution)
+// ---------------------------------------------------------------------------
+
+async function handleTaskWorker(argv) {
+  const { options } = parseArgs(normalizeArgv(argv));
+  const jobId = options["job-id"];
+  if (!jobId) throw new Error("Missing required --job-id for task-worker.");
+
+  const cwd = options.cwd ? path.resolve(process.cwd(), options.cwd) : process.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const jobFile = resolveJobFile(workspaceRoot, jobId);
+  if (!fs.existsSync(jobFile)) throw new Error(`No stored job found for ${jobId}.`);
+
+  const storedJob = JSON.parse(fs.readFileSync(jobFile, "utf8"));
+  const request = storedJob.request;
+  if (!request) throw new Error(`Stored job ${jobId} is missing its request payload.`);
+
+  const logFile = storedJob.logFile ?? resolveJobLogFile(workspaceRoot, jobId);
+
+  // Mark running
+  const runningJob = { ...storedJob, status: "running", phase: "running", startedAt: nowIso(), pid: process.pid };
+  writeJobFile(workspaceRoot, jobId, runningJob);
+  upsertJob(workspaceRoot, { id: jobId, status: "running", phase: "running", pid: process.pid });
+
+  const onProgress = (msg) => {
+    const text = typeof msg === "string" ? msg : msg?.message ?? "";
+    appendLogLine(logFile, text);
+  };
+
+  try {
+    const result = await runOpenCodeTask(request.cwd ?? cwd, {
+      prompt: request.prompt,
+      continueSession: request.continueSession,
+      sessionId: request.sessionId,
+      write: request.write,
+      onProgress
+    });
+
+    const completionStatus = result.status === 0 ? "completed" : "failed";
+    const completedAt = nowIso();
+    const rendered = renderTaskResult(result);
+
+    writeJobFile(workspaceRoot, jobId, {
+      ...runningJob,
+      status: completionStatus,
+      phase: completionStatus === "completed" ? "done" : "failed",
+      completedAt,
+      pid: null,
+      sessionId: result.sessionId ?? null,
+      result: { status: result.status, stdout: result.stdout, stderr: result.stderr },
+      rendered
+    });
+    upsertJob(workspaceRoot, {
+      id: jobId,
+      status: completionStatus,
+      completedAt,
+      pid: null,
+      sessionId: result.sessionId ?? null
+    });
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    writeJobFile(workspaceRoot, jobId, {
+      ...runningJob,
+      status: "failed",
+      phase: "failed",
+      completedAt: nowIso(),
+      pid: null,
+      errorMessage
+    });
+    upsertJob(workspaceRoot, { id: jobId, status: "failed", completedAt: nowIso(), pid: null, errorMessage });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// task-resume-candidate
+// ---------------------------------------------------------------------------
+
+function handleTaskResumeCandidate(argv) {
+  const { options } = parseArgs(normalizeArgv(argv));
+  const cwd = options.cwd ? path.resolve(process.cwd(), options.cwd) : process.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const sessionId = process.env[SESSION_ID_ENV] ?? null;
+  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot));
+
+  const candidate = jobs.find(
+    (job) =>
+      job.jobClass === "task" &&
+      job.status !== "queued" &&
+      job.status !== "running" &&
+      (!sessionId || job.sessionId === sessionId)
+  ) ?? null;
+
+  const payload = {
+    available: Boolean(candidate),
+    sessionId,
+    candidate: candidate ? {
+      id: candidate.id,
+      status: candidate.status,
+      title: candidate.title ?? null,
+      summary: candidate.summary ?? null,
+      sessionId: candidate.sessionId ?? null,
+      completedAt: candidate.completedAt ?? null
+    } : null
+  };
+
+  const asJson = options.json === true || options.json === "true";
+  const rendered = candidate
+    ? `Resumable task found: ${candidate.id} (${candidate.status}).\n`
+    : "No resumable task found for this session.\n";
+  outputResult(asJson ? payload : rendered, asJson);
+}
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+function handleStatus(argv) {
+  const { options, positionals } = parseArgs(normalizeArgv(argv));
+  const cwd = options.cwd ? path.resolve(process.cwd(), options.cwd) : process.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const asJson = options.json === true || options.json === "true";
+
+  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot));
+  const reference = positionals[0] ?? "";
+
+  if (reference) {
+    const job = jobs.find((j) => j.id === reference || j.id.startsWith(reference));
+    if (!job) throw new Error(`No job found for "${reference}".`);
+    outputResult(asJson ? job : `${job.id} | ${job.status} | ${job.title ?? "task"} | ${job.summary ?? ""}\n`, asJson);
+    return;
+  }
+
+  const running = jobs.filter((j) => j.status === "queued" || j.status === "running");
+  const recent = jobs.filter((j) => j.status !== "queued" && j.status !== "running").slice(0, 8);
+  const report = { running, recent };
+  outputResult(asJson ? report : renderStatusReport(report), asJson);
+}
+
+// ---------------------------------------------------------------------------
+// result
+// ---------------------------------------------------------------------------
+
+function handleResult(argv) {
+  const { options, positionals } = parseArgs(normalizeArgv(argv));
+  const cwd = options.cwd ? path.resolve(process.cwd(), options.cwd) : process.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const asJson = options.json === true || options.json === "true";
+
+  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot));
+  const reference = positionals[0] ?? "";
+
+  const finished = jobs.filter((j) => j.status === "completed" || j.status === "failed" || j.status === "cancelled");
+  const job = reference
+    ? finished.find((j) => j.id === reference || j.id.startsWith(reference))
+    : finished[0];
+
+  if (!job) throw new Error(reference ? `No finished job found for "${reference}".` : "No finished jobs yet.");
+
+  const jobFile = resolveJobFile(workspaceRoot, job.id);
+  const storedJob = fs.existsSync(jobFile) ? JSON.parse(fs.readFileSync(jobFile, "utf8")) : null;
+
+  outputResult(asJson ? { job, storedJob } : renderJobResult(job, storedJob), asJson);
+}
+
+// ---------------------------------------------------------------------------
+// cancel
+// ---------------------------------------------------------------------------
+
+function handleCancel(argv) {
+  const { options, positionals } = parseArgs(normalizeArgv(argv));
+  const cwd = options.cwd ? path.resolve(process.cwd(), options.cwd) : process.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const asJson = options.json === true || options.json === "true";
+
+  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot));
+  const reference = positionals[0] ?? "";
+  const activeJobs = jobs.filter((j) => j.status === "queued" || j.status === "running");
+
+  let job;
+  if (reference) {
+    job = activeJobs.find((j) => j.id === reference || j.id.startsWith(reference));
+    if (!job) throw new Error(`No active job found for "${reference}".`);
+  } else if (activeJobs.length === 1) {
+    job = activeJobs[0];
+  } else if (activeJobs.length > 1) {
+    throw new Error("Multiple jobs are active. Pass a job id to cancel.");
+  } else {
+    throw new Error("No active jobs to cancel.");
+  }
+
+  terminateProcessTree(job.pid ?? Number.NaN);
+
+  const logFile = job.logFile ?? resolveJobLogFile(workspaceRoot, job.id);
+  appendLogLine(logFile, "Cancelled by user.");
+
+  const completedAt = nowIso();
+  const cancelledJob = {
+    ...job,
+    status: "cancelled",
+    phase: "cancelled",
+    pid: null,
+    completedAt,
+    errorMessage: "Cancelled by user."
+  };
+
+  const jobFile = resolveJobFile(workspaceRoot, job.id);
+  const existing = fs.existsSync(jobFile) ? JSON.parse(fs.readFileSync(jobFile, "utf8")) : {};
+  writeJobFile(workspaceRoot, job.id, { ...existing, ...cancelledJob });
+  upsertJob(workspaceRoot, { id: job.id, status: "cancelled", phase: "cancelled", pid: null, errorMessage: "Cancelled by user.", completedAt });
+
+  outputResult(asJson ? { jobId: job.id, status: "cancelled" } : renderCancelReport(cancelledJob), asJson);
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+function printUsage() {
+  console.log([
+    "Usage:",
+    "  node opencode-companion.mjs setup [--json]",
+    "  node opencode-companion.mjs task [--background] [--write] [--continue] [--session <id>] [prompt]",
+    "  node opencode-companion.mjs status [job-id] [--json]",
+    "  node opencode-companion.mjs result [job-id] [--json]",
+    "  node opencode-companion.mjs cancel [job-id] [--json]",
+    "  node opencode-companion.mjs task-resume-candidate [--json]"
+  ].join("\n"));
+}
+
+async function main() {
+  const [subcommand, ...argv] = process.argv.slice(2);
+  if (!subcommand || subcommand === "help" || subcommand === "--help") {
+    printUsage();
+    return;
+  }
+
+  switch (subcommand) {
+    case "setup":
+      handleSetup(argv);
+      break;
+    case "task":
+      await handleTask(argv);
+      break;
+    case "task-worker":
+      await handleTaskWorker(argv);
+      break;
+    case "task-resume-candidate":
+      handleTaskResumeCandidate(argv);
+      break;
+    case "status":
+      handleStatus(argv);
+      break;
+    case "result":
+      handleResult(argv);
+      break;
+    case "cancel":
+      handleCancel(argv);
+      break;
+    default:
+      throw new Error(`Unknown subcommand: ${subcommand}`);
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Implements /opencode:rescue command with the same delegation pattern as the existing /codex:rescue, but targeting OpenCode's simpler CLI interface (opencode run) instead of Codex's JSON-RPC app-server protocol.

Includes: setup, status, result, cancel commands, background job support, and session resume capability.

https://claude.ai/code/session_01SFd3C5d54MZn33sKnNKq1N