### PR TITLE
fix: add shell: true on Windows for codex app-server spawn

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -188,7 +188,8 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
     this.proc = spawn("codex", ["app-server"], {
       cwd: this.cwd,
       env: this.options.env,
-      stdio: ["pipe", "pipe", "pipe"]
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === "win32"
     });
 
     this.proc.stdout.setEncoding("utf8");


### PR DESCRIPTION
## Summary

On Windows, `spawn("codex", ["app-server"], ...)` in `app-server.mjs` fails with `ENOENT` because Node.js `spawn` without `shell: true` cannot resolve the `.cmd` wrappers that `npm install -g` creates.

This one-line fix adds `shell: process.platform === "win32"`, matching the existing pattern in `process.mjs` line 12.

Fixes #32

## Test plan

- Verified locally on Windows 11 with Node v25.4.0 and @openai/codex 0.117.0
- `/codex:setup` reports ready before and after the change
- `/codex:review --base <branch>` fails with `spawn codex ENOENT` before the fix, completes successfully after