### PR TITLE
Fix /codex:rescue AskUserQuestion contract

### DIFF
--- a/plugins/codex/commands/rescue.md
+++ b/plugins/codex/commands/rescue.md
@@ -2,7 +2,7 @@
 description: Delegate investigation, an explicit fix request, or follow-up rescue work to the Codex rescue subagent
 argument-hint: "[--background|--wait] [--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [what Codex should investigate, solve, or continue]"
 context: fork
-allowed-tools: Bash(node:*)
+allowed-tools: Bash(node:*), AskUserQuestion
 ---
 
 Route this request to the `codex:codex-rescue` subagent.

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -89,6 +89,7 @@ test("rescue command absorbs continue semantics", () => {
   const runtimeSkill = read("skills/codex-cli-runtime/SKILL.md");
 
   assert.match(rescue, /The final user-visible response must be Codex's output verbatim/i);
+  assert.match(rescue, /allowed-tools:\s*Bash\(node:\*\),\s*AskUserQuestion/);
   assert.match(rescue, /--background\|--wait/);
   assert.match(rescue, /--resume\|--fresh/);
   assert.match(rescue, /--model <model\|spark>/);


### PR DESCRIPTION
## Summary
- allow `/codex:rescue` to use `AskUserQuestion` in frontmatter
- add a regression assertion for the allowed-tools contract

## Testing
- verified the updated rescue contract directly
- full `npm test` is still blocked by the unrelated hard-coded test path issue tracked in #27

Fixes #42
