### PR TITLE
fix: add shell option for Windows spawn in app-server

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -188,7 +188,8 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
     this.proc = spawn("codex", ["app-server"], {
       cwd: this.cwd,
       env: this.options.env,
-      stdio: ["pipe", "pipe", "pipe"]
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === "win32"
     });
 
     this.proc.stdout.setEncoding("utf8");


### PR DESCRIPTION
## Summary

- On Windows, npm global binaries (like `codex`) are installed as `.cmd` wrappers
- `spawn("codex", [...])` in `app-server.mjs` without `shell: true` causes `ENOENT` because Node.js cannot resolve `.cmd` files directly
- Added `shell: process.platform === "win32"` to match the existing pattern in `process.mjs` line 11

## Reproduction

1. Install Codex plugin on Windows via `claude plugins install codex@openai-codex`
2. Run `/codex:rescue` or any task that triggers `app-server` startup
3. Observe `spawn codex ENOENT` error

## Fix

One-line change: add `shell: process.platform === "win32"` to the `spawn()` options in `SpawnedCodexAppServerClient.initialize()`.

This is consistent with how `process.mjs` already handles Windows compatibility for all other `codex` binary invocations via `runCommand()`.

## Test plan

- [x] Verified `codex setup --json` still reports `ready: true`
- [x] Verified `codex-companion.mjs task` completes successfully on Windows
- [x] No impact on non-Windows platforms (condition is platform-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)