### PR TITLE
fix: add shell: true to spawn() in app-server for Windows

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -188,7 +188,8 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
     this.proc = spawn("codex", ["app-server"], {
       cwd: this.cwd,
       env: this.options.env,
-      stdio: ["pipe", "pipe", "pipe"]
+      stdio: ["pipe", "pipe", "pipe"],
+      shell: process.platform === "win32"
     });
 
     this.proc.stdout.setEncoding("utf8");


### PR DESCRIPTION
## Summary

Fixes #53

- Add `shell: process.platform === "win32"` to the `spawn()` call in `SpawnedCodexAppServerClient.initialize()` so that Node can resolve the `codex` `.cmd` shim on Windows.

This is the same fix as #13 applied to `spawnSync` in `process.mjs`, but the async `spawn()` in `app-server.mjs` was missed.

## Test plan

- [x] Verified on Windows 11 with Node.js v22.17.0 and codex-cli 0.117.0
- [x] `/codex:review` successfully starts the app-server and completes review after the fix
- [ ] No impact on macOS/Linux (condition is gated on `process.platform === "win32"`)