### PR TITLE
fix: prevent ENOBUFS crash and oversized input on large diffs (#11)

### DIFF
--- a/plugins/codex/scripts/lib/git.mjs
+++ b/plugins/codex/scripts/lib/git.mjs
@@ -4,7 +4,35 @@ import path from "node:path";
 import { isProbablyText } from "./fs.mjs";
 import { runCommand, runCommandChecked } from "./process.mjs";
 
+/**
+ * Try to run a git command; on buffer-limit failure return null instead of
+ * throwing. Other errors (permissions, bad rev, corruption) are re-thrown
+ * so they don't get silently downgraded to stat-only review context.
+ */
+function gitTry(cwd, args) {
+  const result = runCommand("git", args, { cwd });
+  if (result.error) {
+    const code = result.error.code ?? "";
+    // ENOBUFS / ERR_CHILD_PROCESS_STDIO_MAXBUFFER are buffer-limit failures.
+    if (code === "ENOBUFS" || code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
+      return null;
+    }
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed (exit ${result.status}): ${result.stderr.trim() || result.stdout.trim()}`);
+  }
+  return result.stdout;
+}
+
 const MAX_UNTRACKED_BYTES = 24 * 1024;
+
+/**
+ * Maximum character length for assembled review content.
+ * The Codex API input limit is 1,048,576 characters. We reserve headroom for
+ * the prompt template and other metadata that wrap the review content.
+ */
+export const MAX_REVIEW_CONTENT_CHARS = 800_000;
 
 function git(cwd, args, options = {}) {
   return runCommand("git", args, { cwd, ...options });
@@ -148,23 +176,177 @@ function formatUntrackedFile(cwd, relativePath) {
   return [`### ${relativePath}`, "```", buffer.toString("utf8").trimEnd(), "```"].join("\n");
 }
 
+/**
+ * Estimate the byte size of the text portion of a diff from `--numstat` output.
+ *
+ * Each line is: `<insertions>\t<deletions>\t<path>`
+ * Binary files show: `-\t-\t<path>` — these are skipped because `git diff`
+ * with `--binary` encodes them separately, and the text estimate should only
+ * reflect reviewable text hunks. The caller can check `hasBinaryFiles` to
+ * decide whether to filter binary entries from the full diff later.
+ *
+ * We assume ~80 bytes per changed line (context + hunk headers + content).
+ */
+export function estimateDiffBytes(numstatOutput) {
+  if (!numstatOutput.trim()) {
+    return { bytes: 0, hasBinaryFiles: false };
+  }
+  let totalBytes = 0;
+  let hasBinaryFiles = false;
+  for (const line of numstatOutput.trim().split("\n")) {
+    const parts = line.split("\t");
+    if (parts.length < 3) {
+      continue;
+    }
+    const [ins, del] = parts;
+    if (ins === "-" && del === "-") {
+      hasBinaryFiles = true;
+      continue;
+    }
+    const insertions = parseInt(ins, 10) || 0;
+    const deletions = parseInt(del, 10) || 0;
+    totalBytes += (insertions + deletions) * 80;
+  }
+  return { bytes: totalBytes, hasBinaryFiles };
+}
+
+/**
+ * Collect untracked file bodies up to a byte budget.
+ * Once the budget is exhausted, a single summary line is appended
+ * (not per-file placeholders) to keep the output strictly bounded.
+ */
+function collectUntrackedBodies(cwd, files, budget) {
+  const parts = [];
+  let used = 0;
+  let skippedCount = 0;
+  for (const file of files) {
+    if (used >= budget) {
+      skippedCount++;
+      continue;
+    }
+    const body = formatUntrackedFile(cwd, file);
+    if (used + body.length > budget) {
+      // Skip this file but keep scanning — smaller files may still fit.
+      skippedCount++;
+      continue;
+    }
+    parts.push(body);
+    used += body.length;
+  }
+  if (skippedCount > 0) {
+    parts.push(`(${skippedCount} untracked file(s) omitted — content budget exhausted)`);
+  }
+  return parts.join("\n\n");
+}
+
+/**
+ * Hard-cap content to MAX_REVIEW_CONTENT_CHARS.
+ * If truncated, appends a note so the reviewer knows the output is incomplete.
+ */
+function enforceContentLimit(content) {
+  if (content.length <= MAX_REVIEW_CONTENT_CHARS) {
+    return content;
+  }
+  const truncNote = "\n\n> **Note:** Review content was truncated to stay within the input size limit.";
+  return content.slice(0, MAX_REVIEW_CONTENT_CHARS - truncNote.length) + truncNote;
+}
+
 function collectWorkingTreeContext(cwd, state) {
   const status = gitChecked(cwd, ["status", "--short"]).stdout.trim();
-  const stagedDiff = gitChecked(cwd, ["diff", "--cached", "--binary", "--no-ext-diff", "--submodule=diff"]).stdout;
-  const unstagedDiff = gitChecked(cwd, ["diff", "--binary", "--no-ext-diff", "--submodule=diff"]).stdout;
-  const untrackedBody = state.untracked.map((file) => formatUntrackedFile(cwd, file)).join("\n\n");
 
-  const parts = [
+  // Check diff sizes BEFORE reading full diffs to avoid ENOBUFS on large changes.
+  // Use --numstat to detect binary files (reported as "-\t-") and estimate text size.
+  const stagedNumstat = gitChecked(cwd, ["diff", "--cached", "--numstat"]).stdout.trim();
+  const unstagedNumstat = gitChecked(cwd, ["diff", "--numstat"]).stdout.trim();
+  const stagedEstimate = estimateDiffBytes(stagedNumstat);
+  const unstagedEstimate = estimateDiffBytes(unstagedNumstat);
+  const estimatedBytes = stagedEstimate.bytes + unstagedEstimate.bytes;
+  const diffLikelyOversized = estimatedBytes > MAX_REVIEW_CONTENT_CHARS;
+
+  if (diffLikelyOversized) {
+    const stagedStat = gitChecked(cwd, ["diff", "--cached", "--stat"]).stdout.trim();
+    const unstagedStat = gitChecked(cwd, ["diff", "--stat"]).stdout.trim();
+    const headerParts = [
+      formatSection("Git Status", status),
+      formatSection("Staged Diff (stat only — full diff too large)", stagedStat || "(none)"),
+      formatSection("Unstaged Diff (stat only — full diff too large)", unstagedStat || "(none)")
+    ].join("\n");
+    // Budget remaining for untracked files after header + note.
+    const untrackedBudget = Math.max(0, MAX_REVIEW_CONTENT_CHARS - headerParts.length - 200);
+    const untrackedBody = collectUntrackedBodies(cwd, state.untracked, untrackedBudget);
+    const content = [headerParts, formatSection("Untracked Files", untrackedBody)].join("\n") +
+      "\n\n> **Note:** The full diff exceeded the input size limit and was replaced with `--stat` summaries. " +
+      "Use shell commands (`git diff`, `git diff --cached`) to inspect the complete changes.";
+
+    return {
+      mode: "working-tree",
+      summary: `Reviewing ${state.staged.length} staged, ${state.unstaged.length} unstaged, and ${state.untracked.length} untracked file(s).`,
+      content: enforceContentLimit(content)
+    };
+  }
+
+  // When binary files are present, use text-only diff to avoid buffering
+  // large binary patches. Binary entries get a "(binary file)" note in the diff.
+  const hasBinary = stagedEstimate.hasBinaryFiles || unstagedEstimate.hasBinaryFiles;
+  const diffFlags = hasBinary
+    ? ["--no-ext-diff", "--submodule=diff"]
+    : ["--binary", "--no-ext-diff", "--submodule=diff"];
+
+  // Use gitTry so oversized single-line diffs (ENOBUFS) degrade to --stat
+  // instead of crashing the entire review collection.
+  const stagedDiff = gitTry(cwd, ["diff", "--cached", ...diffFlags]);
+  const unstagedDiff = gitTry(cwd, ["diff", ...diffFlags]);
+
+  if (stagedDiff === null || unstagedDiff === null) {
+    // Diff read failed (likely ENOBUFS) — fall back to stat-only.
+    const stagedStat = gitChecked(cwd, ["diff", "--cached", "--stat"]).stdout.trim();
+    const unstagedStat = gitChecked(cwd, ["diff", "--stat"]).stdout.trim();
+    const headerParts = [
+      formatSection("Git Status", status),
+      formatSection("Staged Diff (stat only — diff read failed)", stagedStat || "(none)"),
+      formatSection("Unstaged Diff (stat only — diff read failed)", unstagedStat || "(none)")
+    ].join("\n");
+    const untrackedBudget = Math.max(0, MAX_REVIEW_CONTENT_CHARS - headerParts.length - 200);
+    const untrackedBody = collectUntrackedBodies(cwd, state.untracked, untrackedBudget);
+    const content = [headerParts, formatSection("Untracked Files", untrackedBody)].join("\n") +
+      "\n\n> **Note:** The full diff could not be read (possibly too large) and was replaced with `--stat` summaries. " +
+      "Use shell commands (`git diff`, `git diff --cached`) to inspect the complete changes.";
+
+    return {
+      mode: "working-tree",
+      summary: `Reviewing ${state.staged.length} staged, ${state.unstaged.length} unstaged, and ${state.untracked.length} untracked file(s).`,
+      content: enforceContentLimit(content)
+    };
+  }
+  const untrackedBody = collectUntrackedBodies(cwd, state.untracked, MAX_REVIEW_CONTENT_CHARS);
+
+  let content = [
     formatSection("Git Status", status),
     formatSection("Staged Diff", stagedDiff),
     formatSection("Unstaged Diff", unstagedDiff),
     formatSection("Untracked Files", untrackedBody)
-  ];
+  ].join("\n");
+
+  // Safety net: if the estimate was wrong and assembled content is still too large.
+  if (content.length > MAX_REVIEW_CONTENT_CHARS) {
+    const stagedStat = gitChecked(cwd, ["diff", "--cached", "--stat"]).stdout.trim();
+    const unstagedStat = gitChecked(cwd, ["diff", "--stat"]).stdout.trim();
+    const headerParts = [
+      formatSection("Git Status", status),
+      formatSection("Staged Diff (stat only — full diff too large)", stagedStat || "(none)"),
+      formatSection("Unstaged Diff (stat only — full diff too large)", unstagedStat || "(none)")
+    ].join("\n");
+    const remainingBudget = Math.max(0, MAX_REVIEW_CONTENT_CHARS - headerParts.length - 200);
+    const trimmedUntracked = collectUntrackedBodies(cwd, state.untracked, remainingBudget);
+    content = [headerParts, formatSection("Untracked Files", trimmedUntracked)].join("\n") +
+      "\n\n> **Note:** The full diff exceeded the input size limit and was replaced with `--stat` summaries. " +
+      "Use shell commands (`git diff`, `git diff --cached`) to inspect the complete changes.";
+  }
 
   return {
     mode: "working-tree",
     summary: `Reviewing ${state.staged.length} staged, ${state.unstaged.length} unstaged, and ${state.untracked.length} untracked file(s).`,
-    content: parts.join("\n")
+    content: enforceContentLimit(content)
   };
 }
 
@@ -174,16 +356,73 @@ function collectBranchContext(cwd, baseRef) {
   const currentBranch = getCurrentBranch(cwd);
   const logOutput = gitChecked(cwd, ["log", "--oneline", "--decorate", commitRange]).stdout.trim();
   const diffStat = gitChecked(cwd, ["diff", "--stat", commitRange]).stdout.trim();
-  const diff = gitChecked(cwd, ["diff", "--binary", "--no-ext-diff", "--submodule=diff", commitRange]).stdout;
+
+  // Check diff size BEFORE reading full diff to avoid ENOBUFS on large branches.
+  // Use --numstat to detect binary files that shortstat would miss.
+  const numstat = gitChecked(cwd, ["diff", "--numstat", commitRange]).stdout.trim();
+  const estimate = estimateDiffBytes(numstat);
+
+  if (estimate.bytes > MAX_REVIEW_CONTENT_CHARS) {
+    const content = [
+      formatSection("Commit Log", logOutput),
+      formatSection("Diff Stat", diffStat),
+      formatSection("Branch Diff (stat only — full diff too large)", diffStat)
+    ].join("\n") +
+      "\n\n> **Note:** The full branch diff exceeded the input size limit and was replaced with `--stat` summaries. " +
+      "Use shell commands (`git diff " + commitRange + "`) to inspect the complete changes.";
+
+    return {
+      mode: "branch",
+      summary: `Reviewing branch ${currentBranch} against ${baseRef} from merge-base ${mergeBase}.`,
+      content: enforceContentLimit(content)
+    };
+  }
+
+  // When binary files are present, skip --binary to avoid buffering large patches.
+  const diffFlags = estimate.hasBinaryFiles
+    ? ["--no-ext-diff", "--submodule=diff", commitRange]
+    : ["--binary", "--no-ext-diff", "--submodule=diff", commitRange];
+
+  // Use gitTry so oversized single-line diffs (ENOBUFS) degrade to --stat.
+  const diff = gitTry(cwd, ["diff", ...diffFlags]);
+
+  if (diff === null) {
+    const content = [
+      formatSection("Commit Log", logOutput),
+      formatSection("Diff Stat", diffStat),
+      formatSection("Branch Diff (stat only — diff read failed)", diffStat)
+    ].join("\n") +
+      "\n\n> **Note:** The full branch diff could not be read (possibly too large) and was replaced with `--stat` summaries. " +
+      "Use shell commands (`git diff " + commitRange + "`) to inspect the complete changes.";
+
+    return {
+      mode: "branch",
+      summary: `Reviewing branch ${currentBranch} against ${baseRef} from merge-base ${mergeBase}.`,
+      content: enforceContentLimit(content)
+    };
+  }
+
+  let content = [
+    formatSection("Commit Log", logOutput),
+    formatSection("Diff Stat", diffStat),
+    formatSection("Branch Diff", diff)
+  ].join("\n");
+
+  // Safety net: if the estimate was wrong and assembled content is still too large.
+  if (content.length > MAX_REVIEW_CONTENT_CHARS) {
+    content = [
+      formatSection("Commit Log", logOutput),
+      formatSection("Diff Stat", diffStat),
+      formatSection("Branch Diff (stat only — full diff too large)", diffStat)
+    ].join("\n") +
+      "\n\n> **Note:** The full branch diff exceeded the input size limit and was replaced with `--stat` summaries. " +
+      "Use shell commands (`git diff " + commitRange + "`) to inspect the complete changes.";
+  }
 
   return {
     mode: "branch",
     summary: `Reviewing branch ${currentBranch} against ${baseRef} from merge-base ${mergeBase}.`,
-    content: [
-      formatSection("Commit Log", logOutput),
-      formatSection("Diff Stat", diffStat),
-      formatSection("Branch Diff", diff)
-    ].join("\n")
+    content: enforceContentLimit(content)
   };
 }
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -1,6 +1,8 @@
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
+const DEFAULT_MAX_BUFFER = 50 * 1024 * 1024; // 50 MB
+
 export function runCommand(command, args = [], options = {}) {
   const result = spawnSync(command, args, {
     cwd: options.cwd,
@@ -8,7 +10,8 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     stdio: options.stdio ?? "pipe",
-    shell: process.platform === "win32"
+    shell: process.platform === "win32",
+    maxBuffer: options.maxBuffer ?? DEFAULT_MAX_BUFFER
   });
 
   return {

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { collectReviewContext, resolveReviewTarget } from "../plugins/codex/scripts/lib/git.mjs";
+import { collectReviewContext, estimateDiffBytes, MAX_REVIEW_CONTENT_CHARS, resolveReviewTarget } from "../plugins/codex/scripts/lib/git.mjs";
 import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
 
 test("resolveReviewTarget prefers working tree when repo is dirty", () => {
@@ -67,4 +67,88 @@ test("resolveReviewTarget requires an explicit base when no default branch can b
     () => resolveReviewTarget(cwd, {}),
     /Unable to detect the repository default branch\. Pass --base <ref> or use --scope working-tree\./
   );
+});
+
+test("collectReviewContext truncates oversized working-tree diffs to stat summaries", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+
+  // Create an initial commit so the repo has a HEAD.
+  fs.writeFileSync(path.join(cwd, "seed.txt"), "seed\n");
+  run("git", ["add", "seed.txt"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+
+  // Generate a large unstaged change that exceeds MAX_REVIEW_CONTENT_CHARS.
+  const bigContent = "x".repeat(MAX_REVIEW_CONTENT_CHARS + 1000);
+  fs.writeFileSync(path.join(cwd, "big.txt"), bigContent);
+  run("git", ["add", "big.txt"], { cwd });
+  run("git", ["commit", "-m", "add big file"], { cwd });
+  // Now modify it so it shows up as an unstaged diff.
+  fs.writeFileSync(path.join(cwd, "big.txt"), "y".repeat(MAX_REVIEW_CONTENT_CHARS + 1000));
+
+  const target = resolveReviewTarget(cwd, { scope: "working-tree" });
+  const context = collectReviewContext(cwd, target);
+
+  assert.ok(
+    context.content.length <= MAX_REVIEW_CONTENT_CHARS,
+    `content length (${context.content.length}) should be at most ${MAX_REVIEW_CONTENT_CHARS}`
+  );
+  assert.match(context.content, /stat only/);
+  assert.match(context.content, /full diff too large/);
+});
+
+test("collectReviewContext truncates oversized branch diffs to stat summaries", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+
+  fs.writeFileSync(path.join(cwd, "seed.txt"), "seed\n");
+  run("git", ["add", "seed.txt"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+
+  run("git", ["checkout", "-b", "feature/big"], { cwd });
+  const bigContent = "x".repeat(MAX_REVIEW_CONTENT_CHARS + 1000);
+  fs.writeFileSync(path.join(cwd, "big.txt"), bigContent);
+  run("git", ["add", "big.txt"], { cwd });
+  run("git", ["commit", "-m", "add big file"], { cwd });
+
+  const target = resolveReviewTarget(cwd, { scope: "branch" });
+  const context = collectReviewContext(cwd, target);
+
+  assert.ok(
+    context.content.length <= MAX_REVIEW_CONTENT_CHARS,
+    `content length (${context.content.length}) should be at most ${MAX_REVIEW_CONTENT_CHARS}`
+  );
+  assert.match(context.content, /stat only/);
+  assert.match(context.content, /full diff too large/);
+});
+
+test("estimateDiffBytes parses typical numstat output", () => {
+  const numstat = "150\t10\tsrc/app.js\n20\t5\tsrc/lib.js";
+  const result = estimateDiffBytes(numstat);
+  assert.equal(result.bytes, (150 + 10 + 20 + 5) * 80);
+  assert.equal(result.hasBinaryFiles, false);
+});
+
+test("estimateDiffBytes handles single file", () => {
+  const result = estimateDiffBytes("42\t0\tfile.txt");
+  assert.equal(result.bytes, 42 * 80);
+  assert.equal(result.hasBinaryFiles, false);
+});
+
+test("estimateDiffBytes skips binary files in byte estimate and flags them", () => {
+  const numstat = "10\t5\tsrc/app.js\n-\t-\tbinary.png";
+  const result = estimateDiffBytes(numstat);
+  // Only text file contributes to bytes; binary is skipped.
+  assert.equal(result.bytes, (10 + 5) * 80);
+  assert.equal(result.hasBinaryFiles, true);
+});
+
+test("estimateDiffBytes returns zero bytes and no binary flag for empty input", () => {
+  const empty = estimateDiffBytes("");
+  assert.equal(empty.bytes, 0);
+  assert.equal(empty.hasBinaryFiles, false);
+
+  const whitespace = estimateDiffBytes("   ");
+  assert.equal(whitespace.bytes, 0);
+  assert.equal(whitespace.hasBinaryFiles, false);
 });

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -1,7 +1,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+import { runCommand, terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+
+test("runCommand does not crash with ENOBUFS on large stdout", () => {
+  // Generate output larger than Node's default 1 MB maxBuffer.
+  // Uses Node itself for cross-platform compatibility (no `seq` on Windows).
+  const result = runCommand(process.execPath, [
+    "-e",
+    "for(let i=0;i<200000;i++) process.stdout.write(i+'\\n')"
+  ]);
+  assert.equal(result.error, null, "should not error with ENOBUFS");
+  assert.equal(result.status, 0);
+  assert.ok(result.stdout.length > 1_000_000, "stdout should exceed 1 MB");
+});
 
 test("terminateProcessTree uses taskkill on Windows", () => {
   let captured = null;


### PR DESCRIPTION
Add maxBuffer (50MB) to spawnSync, estimate diff size via --numstat before reading full patches, gracefully fall back to --stat summaries when diffs exceed the review content budget or fail to read, and hard-cap all review output to stay within the Codex API input limit.