### PR TITLE
fix: fall back to Landlock sandbox when bwrap is unavailable (#18)

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -21,6 +21,7 @@ import {
     runAppServerTurn
   } from "./lib/codex.mjs";
 import { readStdinIfPiped } from "./lib/fs.mjs";
+import { probeSandboxSupport } from "./lib/app-server.mjs";
 import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./lib/git.mjs";
 import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
@@ -184,6 +185,8 @@ function buildSetupReport(cwd, actionsTaken = []) {
   const authStatus = getCodexLoginStatus(cwd);
   const config = getConfig(workspaceRoot);
 
+  const sandbox = codexStatus.available ? probeSandboxSupport(cwd) : null;
+
   const nextSteps = [];
   if (!codexStatus.available) {
     nextSteps.push("Install Codex with `npm install -g @openai/codex`.");
@@ -191,6 +194,12 @@ function buildSetupReport(cwd, actionsTaken = []) {
   if (codexStatus.available && !authStatus.loggedIn) {
     nextSteps.push("Run `!codex login`.");
     nextSteps.push("If browser login is blocked, retry with `!codex login --device-auth` or `!codex login --with-api-key`.");
+  }
+  if (sandbox && sandbox.type === "none") {
+    nextSteps.push(
+      "Sandbox unavailable: neither bwrap nor Landlock works on this system. " +
+      "See https://developers.openai.com/codex/concepts/sandboxing#prerequisites for setup instructions."
+    );
   }
   if (!config.stopReviewGate) {
     nextSteps.push("Optional: run `/codex:setup --enable-review-gate` to require a fresh review before stop.");
@@ -202,6 +211,7 @@ function buildSetupReport(cwd, actionsTaken = []) {
     npm: npmStatus,
     codex: codexStatus,
     auth: authStatus,
+    sandbox: sandbox ?? { type: "unknown", configArgs: [] },
     sessionRuntime: getSessionRuntimeStatus(),
     reviewGateEnabled: Boolean(config.stopReviewGate),
     actionsTaken,

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -10,7 +10,7 @@
 import fs from "node:fs";
 import net from "node:net";
 import process from "node:process";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import readline from "node:readline";
 import { parseBrokerEndpoint } from "./broker-endpoint.mjs";
 import { ensureBrokerSession } from "./broker-lifecycle.mjs";
@@ -20,6 +20,101 @@ const PLUGIN_MANIFEST = JSON.parse(fs.readFileSync(PLUGIN_MANIFEST_URL, "utf8"))
 
 export const BROKER_ENDPOINT_ENV = "CODEX_COMPANION_APP_SERVER_ENDPOINT";
 export const BROKER_BUSY_RPC_CODE = -32001;
+
+/**
+ * Cached sandbox probe results, keyed by resolved codex binary path.
+ * @type {Map<string, { type: "bwrap" | "landlock" | "none", configArgs: string[] }>}
+ */
+const sandboxProbeCache = new Map();
+
+/**
+ * Resolve the absolute path to the `codex` binary that would be used with
+ * the given env. This ensures the probe matches the actual spawn context.
+ */
+function resolveCodexPath(env) {
+  const result = spawnSync("which", ["codex"], {
+    encoding: "utf8",
+    stdio: "pipe",
+    shell: false,
+    env: env ?? process.env
+  });
+  return (!result.error && result.status === 0) ? result.stdout.trim() : "codex";
+}
+
+/**
+ * Probes whether the Linux sandbox works on this system.
+ * - First tries bwrap (the default).
+ * - If bwrap fails (e.g. missing CAP_NET_ADMIN in containers/WSL), tries Landlock.
+ * - Caches per resolved codex binary path so different env/PATH combos get
+ *   their own probe result.
+ *
+ * On non-Linux platforms the sandbox is handled natively (Seatbelt/macOS,
+ * Windows restricted token) and never needs this fallback.
+ *
+ * @param {string} cwd - Working directory for the probe.
+ * @param {{ env?: NodeJS.ProcessEnv }} [options] - Optional env to match the spawn context.
+ */
+export function probeSandboxSupport(cwd, options) {
+  const env = options?.env ?? undefined;
+  // When a custom env is supplied, skip caching — the caller may have a
+  // different PATH or config that changes sandbox behaviour.
+  const useCache = !options?.env;
+
+  if (process.platform !== "linux") {
+    return { type: "bwrap", configArgs: [] };
+  }
+
+  const codexPath = resolveCodexPath(env);
+  if (useCache) {
+    const cached = sandboxProbeCache.get(codexPath);
+    if (cached) {
+      return cached;
+    }
+  }
+
+  const spawnOpts = { cwd, encoding: "utf8", stdio: "pipe", shell: false, env };
+
+  // First, verify codex itself can launch. If it can't (ENOENT, permission error),
+  // that's a launcher problem, not a sandbox problem — surface it directly.
+  const launchTest = spawnSync("codex", ["--version"], spawnOpts);
+  if (launchTest.error) {
+    const code = launchTest.error.code ?? "";
+    throw new Error(
+      `Codex CLI cannot be launched (${code || launchTest.error.message}). ` +
+      "Verify that codex is installed and on your PATH."
+    );
+  }
+
+  const bwrapTest = spawnSync("codex", ["sandbox", "linux", "echo", "ok"], spawnOpts);
+  if (!bwrapTest.error && bwrapTest.status === 0) {
+    const result = { type: "bwrap", configArgs: [] };
+    if (useCache) sandboxProbeCache.set(codexPath, result);
+    return result;
+  }
+
+  const landlockTest = spawnSync(
+    "codex",
+    ["-c", "use_legacy_landlock=true", "sandbox", "linux", "echo", "ok"],
+    spawnOpts
+  );
+  if (!landlockTest.error && landlockTest.status === 0) {
+    const result = {
+      type: "landlock",
+      configArgs: ["-c", "use_legacy_landlock=true"]
+    };
+    if (useCache) sandboxProbeCache.set(codexPath, result);
+    return result;
+  }
+
+  const result = { type: "none", configArgs: [] };
+  if (useCache) sandboxProbeCache.set(codexPath, result);
+  return result;
+}
+
+/** Reset the cached sandbox probe (for testing). */
+export function resetSandboxProbeCache() {
+  sandboxProbeCache.clear();
+}
 
 /** @type {ClientInfo} */
 const DEFAULT_CLIENT_INFO = {
@@ -185,7 +280,15 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
   }
 
   async initialize() {
-    this.proc = spawn("codex", ["app-server"], {
+    const sandbox = probeSandboxSupport(this.cwd, { env: this.options.env });
+    if (sandbox.type === "none") {
+      throw new Error(
+        "Codex sandbox is unavailable: neither bwrap nor Landlock works on this system. " +
+        "See https://developers.openai.com/codex/concepts/sandboxing#prerequisites for setup instructions."
+      );
+    }
+    const args = [...sandbox.configArgs, "app-server"];
+    this.proc = spawn("codex", args, {
       cwd: this.cwd,
       env: this.options.env,
       stdio: ["pipe", "pipe", "pipe"]

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -174,6 +174,22 @@ function appendReasoningSection(lines, reasoningSummary) {
   }
 }
 
+function formatSandboxDetail(sandbox) {
+  if (!sandbox) {
+    return "unknown";
+  }
+  switch (sandbox.type) {
+    case "bwrap":
+      return "bwrap (default)";
+    case "landlock":
+      return "landlock (fallback — bwrap unavailable)";
+    case "none":
+      return "unavailable — neither bwrap nor landlock works";
+    default:
+      return "unknown";
+  }
+}
+
 export function renderSetupReport(report) {
   const lines = [
     "# Codex Setup",
@@ -185,6 +201,7 @@ export function renderSetupReport(report) {
     `- npm: ${report.npm.detail}`,
     `- codex: ${report.codex.detail}`,
     `- auth: ${report.auth.detail}`,
+    `- sandbox: ${formatSandboxDetail(report.sandbox)}`,
     `- session runtime: ${report.sessionRuntime.label}`,
     `- review gate: ${report.reviewGateEnabled ? "enabled" : "disabled"}`,
     ""

--- a/tests/sandbox.test.mjs
+++ b/tests/sandbox.test.mjs
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  probeSandboxSupport,
+  resetSandboxProbeCache
+} from "../plugins/codex/scripts/lib/app-server.mjs";
+import { renderSetupReport } from "../plugins/codex/scripts/lib/render.mjs";
+
+test("probeSandboxSupport returns a valid result and caches it", () => {
+  resetSandboxProbeCache();
+  const result = probeSandboxSupport(process.cwd());
+
+  assert.ok(["bwrap", "landlock", "none"].includes(result.type), `unexpected type: ${result.type}`);
+  assert.ok(Array.isArray(result.configArgs));
+
+  // Second call with same env should return the same cached object.
+  const cached = probeSandboxSupport(process.cwd());
+  assert.strictEqual(result, cached);
+});
+
+test("probeSandboxSupport Landlock result includes config args", () => {
+  resetSandboxProbeCache();
+  const result = probeSandboxSupport(process.cwd());
+
+  if (result.type === "landlock") {
+    assert.deepEqual(result.configArgs, ["-c", "use_legacy_landlock=true"]);
+  } else {
+    assert.deepEqual(result.configArgs, []);
+  }
+});
+
+test("resetSandboxProbeCache clears cached result", () => {
+  // Populate cache.
+  const first = probeSandboxSupport(process.cwd());
+  resetSandboxProbeCache();
+  // After reset, a new probe should run (may or may not return same type,
+  // but the object identity should differ).
+  const second = probeSandboxSupport(process.cwd());
+  assert.equal(first.type, second.type);
+  // Reset for other tests.
+  resetSandboxProbeCache();
+});
+
+test("probeSandboxSupport with explicit env skips cache and re-probes", () => {
+  resetSandboxProbeCache();
+  // Probe with default env (cached).
+  const defaultResult = probeSandboxSupport(process.cwd());
+  // Probe with explicit env — should NOT reuse cached object (fresh probe).
+  const explicitResult = probeSandboxSupport(process.cwd(), { env: process.env });
+  // Same type (same system) but different object identity.
+  assert.equal(defaultResult.type, explicitResult.type);
+  assert.notStrictEqual(defaultResult, explicitResult, "explicit env should bypass cache");
+  resetSandboxProbeCache();
+});
+
+test("renderSetupReport includes sandbox status line", () => {
+  const report = {
+    ready: true,
+    node: { available: true, detail: "v22.0.0" },
+    npm: { available: true, detail: "10.0.0" },
+    codex: { available: true, detail: "codex-cli 0.117.0" },
+    auth: { available: true, loggedIn: true, detail: "authenticated" },
+    sandbox: { type: "landlock", configArgs: ["-c", "use_legacy_landlock=true"] },
+    sessionRuntime: { label: "direct startup" },
+    reviewGateEnabled: false,
+    actionsTaken: [],
+    nextSteps: []
+  };
+
+  const output = renderSetupReport(report);
+  assert.match(output, /sandbox: landlock \(fallback/);
+});
+
+test("renderSetupReport shows bwrap when sandbox type is bwrap", () => {
+  const report = {
+    ready: true,
+    node: { available: true, detail: "v22.0.0" },
+    npm: { available: true, detail: "10.0.0" },
+    codex: { available: true, detail: "codex-cli 0.117.0" },
+    auth: { available: true, loggedIn: true, detail: "authenticated" },
+    sandbox: { type: "bwrap", configArgs: [] },
+    sessionRuntime: { label: "direct startup" },
+    reviewGateEnabled: false,
+    actionsTaken: [],
+    nextSteps: []
+  };
+
+  const output = renderSetupReport(report);
+  assert.match(output, /sandbox: bwrap \(default\)/);
+});
+
+test("renderSetupReport shows unavailable when sandbox type is none", () => {
+  const report = {
+    ready: true,
+    node: { available: true, detail: "v22.0.0" },
+    npm: { available: true, detail: "10.0.0" },
+    codex: { available: true, detail: "codex-cli 0.117.0" },
+    auth: { available: true, loggedIn: true, detail: "authenticated" },
+    sandbox: { type: "none", configArgs: [] },
+    sessionRuntime: { label: "direct startup" },
+    reviewGateEnabled: false,
+    actionsTaken: [],
+    nextSteps: []
+  };
+
+  const output = renderSetupReport(report);
+  assert.match(output, /sandbox: unavailable/);
+});


### PR DESCRIPTION
Probe bwrap and Landlock availability before spawning codex app-server, passing -c use_legacy_landlock=true when only Landlock works. Hard-error on sandbox type "none" with setup instructions. Surface sandbox status in the setup report. Cache is scoped per resolved codex path and skipped when a custom env is supplied.