### PR TITLE
Add pull request CI workflow for tests and builds

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -1,0 +1,35 @@
+name: Pull Request CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+
+      - name: Run test suite
+        run: npm test
+
+      - name: Run build
+        run: npm run build


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on `pull_request`
- install dependencies with `npm ci` and install the Codex CLI required by `prebuild`
- run `npm test` and `npm run build` in a single CI job
- pin `actions/checkout` to `v6.0.2` and `actions/setup-node` to `v6.3.0` by SHA
- use Node.js 22 and set a 10-minute job timeout

## Testing
- Not run (not requested)