### PR TITLE
fix: skip broken symlinks during review context collection

### DIFF
--- a/plugins/codex/scripts/lib/git.mjs
+++ b/plugins/codex/scripts/lib/git.mjs
@@ -135,12 +135,33 @@ function formatSection(title, body) {
 
 function formatUntrackedFile(cwd, relativePath) {
   const absolutePath = path.join(cwd, relativePath);
-  const stat = fs.statSync(absolutePath);
+
+  let stat;
+  try {
+    stat = fs.lstatSync(absolutePath);
+  } catch {
+    return `### ${relativePath}\n(skipped: unable to read file)`;
+  }
+
+  if (stat.isSymbolicLink()) {
+    try {
+      stat = fs.statSync(absolutePath);
+    } catch {
+      return `### ${relativePath}\n(skipped: broken symlink)`;
+    }
+  }
+
   if (stat.size > MAX_UNTRACKED_BYTES) {
     return `### ${relativePath}\n(skipped: ${stat.size} bytes exceeds ${MAX_UNTRACKED_BYTES} byte limit)`;
   }
 
-  const buffer = fs.readFileSync(absolutePath);
+  let buffer;
+  try {
+    buffer = fs.readFileSync(absolutePath);
+  } catch {
+    return `### ${relativePath}\n(skipped: unable to read file)`;
+  }
+
   if (!isProbablyText(buffer)) {
     return `### ${relativePath}\n(skipped: binary file)`;
   }

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -55,6 +55,23 @@ test("resolveReviewTarget honors explicit base overrides", () => {
   assert.equal(target.baseRef, "main");
 });
 
+test("collectReviewContext skips broken symlinks in untracked files", () => {
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v1');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+
+  // Create a broken symlink pointing to a nonexistent target.
+  fs.symlinkSync(path.join(cwd, "nonexistent-target"), path.join(cwd, "broken-link"));
+
+  const target = resolveReviewTarget(cwd, { scope: "working-tree" });
+  const context = collectReviewContext(cwd, target);
+
+  assert.equal(target.mode, "working-tree");
+  assert.match(context.content, /broken symlink/);
+});
+
 test("resolveReviewTarget requires an explicit base when no default branch can be inferred", () => {
   const cwd = makeTempDir();
   initGitRepo(cwd);


### PR DESCRIPTION
## Summary

- `formatUntrackedFile` in `git.mjs` now uses `lstatSync` instead of `statSync` to avoid `ENOENT` on broken symlinks
- Broken symlinks are gracefully skipped with a `(skipped: broken symlink)` message instead of crashing the entire review
- Other unreadable paths (permission errors, etc.) are also handled with a fallback skip message

## Test plan

- [x] Added test: broken symlink in untracked files doesn't crash `collectReviewContext`
- [x] All existing tests pass (`node --test tests/git.test.mjs` — 5/5)
- [ ] Manual: create a broken symlink in a dirty repo, run `/codex:review` — should complete without error

Closes #65