### PR TITLE
fix: strip ANSI escape sequences from JSONL before parsing

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -53,7 +53,7 @@ function createProtocolError(message, data) {
   return error;
 }
 
-class AppServerClientBase {
+export class AppServerClientBase {
   constructor(cwd, options = {}) {
     this.cwd = cwd;
     this.options = options;
@@ -119,11 +119,18 @@ class AppServerClientBase {
       return;
     }
 
+    // Strip ANSI escape sequences that terminals may inject into stdout
+    // (e.g. bracketed paste mode \x1b[?2004h from shell initialization).
+    const cleaned = line.replace(/\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*\x07|\x1b[()][A-B012]/g, "").trim();
+    if (!cleaned) {
+      return;
+    }
+
     let message;
     try {
-      message = JSON.parse(line);
+      message = JSON.parse(cleaned);
     } catch (error) {
-      this.handleExit(createProtocolError(`Failed to parse codex app-server JSONL: ${error.message}`, { line }));
+      this.handleExit(createProtocolError(`Failed to parse codex app-server JSONL: ${error.message}`, { line: cleaned }));
       return;
     }
 

--- a/tests/app-server.test.mjs
+++ b/tests/app-server.test.mjs
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { AppServerClientBase } from "../plugins/codex/scripts/lib/app-server.mjs";
+
+function createTestClient() {
+  const client = new AppServerClientBase("/tmp");
+  client.sendMessage = () => {};
+  return client;
+}
+
+test("handleLine ignores pure ANSI escape sequences", () => {
+  const client = createTestClient();
+  let exited = false;
+  client.handleExit = () => { exited = true; };
+
+  // Bracketed paste mode enable/disable sequences.
+  client.handleLine("\x1b[?2004h");
+  client.handleLine("\x1b[?2004l");
+  // Cursor movement.
+  client.handleLine("\x1b[1;1H");
+
+  assert.equal(exited, false, "handleExit should not be called for ANSI-only lines");
+});
+
+test("handleLine parses JSON after stripping inline ANSI escapes", () => {
+  const client = createTestClient();
+  let exited = false;
+  let resolved = false;
+
+  client.handleExit = () => { exited = true; };
+  client.pending.set(1, {
+    resolve() { resolved = true; },
+    reject() {},
+    method: "test"
+  });
+
+  // JSON with a leading ANSI escape injected by the terminal.
+  client.handleLine('\x1b[?2004h{"id":1,"result":{"ok":true}}');
+
+  assert.equal(exited, false, "handleExit should not be called");
+  assert.equal(resolved, true, "pending request should be resolved");
+});
+
+test("handleLine still errors on genuinely invalid JSON", () => {
+  const client = createTestClient();
+  let exited = false;
+  client.handleExit = () => { exited = true; };
+
+  client.handleLine("{not valid json}");
+
+  assert.equal(exited, true, "handleExit should be called for real JSON errors");
+});


### PR DESCRIPTION
## Summary

- Strips ANSI escape sequences (CSI, OSC, charset designators) from lines before JSON parsing in `app-server.mjs`
- Prevents bracketed paste mode escape `\x1b[?2004h` and similar terminal artifacts from crashing the JSONL protocol handler
- Lines that become empty after stripping are silently skipped; genuinely malformed JSON still triggers `handleExit` as before
- Exported `AppServerClientBase` for direct unit testing

## Test plan

- [x] Added `tests/app-server.test.mjs` with 3 cases: pure ANSI lines ignored, JSON with inline ANSI parsed correctly, invalid JSON still errors
- [x] Full test suite passes (67/67)
- [ ] Manual: configure shell with bracketed paste mode enabled, run `/codex:review` — should no longer crash with JSONL parse error

Closes #23