### PR TITLE
fix: gracefully handle unsupported thread/name/set on older Codex CLI

### DIFF
--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -641,8 +641,13 @@ async function startThread(client, cwd, options = {}) {
   if (options.threadName) {
     try {
       await client.request("thread/name/set", { threadId, name: options.threadName });
-    } catch {
-      // thread/name/set not supported on this Codex CLI version
+    } catch (err) {
+      // Only suppress "unknown variant/method" errors from older CLI versions
+      // that don't support thread/name/set. Rethrow auth, network, or server errors.
+      const msg = String(err?.message ?? err ?? "");
+      if (!msg.includes("unknown variant") && !msg.includes("unknown method")) {
+        throw err;
+      }
     }
   }
   return response;


### PR DESCRIPTION
## Summary

`startThread()` in `codex.mjs` calls `thread/name/set` unconditionally, which throws on Codex CLI v0.118.0 because that version doesn't support the method. This wraps the call in a try/catch so thread creation succeeds even when naming is unsupported.

## Changes

One file: `plugins/codex/scripts/lib/codex.mjs`, function `startThread()` (line 639-645).

Thread naming is cosmetic (used for job log labels) and should not prevent thread creation. The try/catch allows the plugin to work with both older and newer Codex CLI versions.

## Testing

- `npm test`: same results as main (pre-existing failures in commands.test.mjs, unrelated)
- `npm run build`: passes

This contribution was developed with AI assistance (Codex).

Fixes #119