### PR TITLE
fix: isolate session and plugin-data env vars in tests

### DIFF
--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -750,8 +750,11 @@ test("status shows phases, hints, and the latest finished job", () => {
     "utf8"
   );
 
+  const env = { ...process.env };
+  delete env.CODEX_COMPANION_SESSION_ID;
   const result = run("node", [SCRIPT, "status"], {
-    cwd: workspace
+    cwd: workspace,
+    env
   });
 
   assert.equal(result.status, 0, result.stderr);
@@ -894,8 +897,11 @@ test("status preserves adversarial review kind labels", () => {
     "utf8"
   );
 
+  const env = { ...process.env };
+  delete env.CODEX_COMPANION_SESSION_ID;
   const result = run("node", [SCRIPT, "status"], {
-    cwd: workspace
+    cwd: workspace,
+    env
   });
 
   assert.equal(result.status, 0, result.stderr);
@@ -1017,8 +1023,11 @@ test("result returns the stored output for the latest finished job by default", 
     "utf8"
   );
 
+  const env = { ...process.env };
+  delete env.CODEX_COMPANION_SESSION_ID;
   const result = run("node", [SCRIPT, "result"], {
-    cwd: workspace
+    cwd: workspace,
+    env
   });
 
   assert.equal(result.status, 0, result.stderr);

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -9,11 +9,22 @@ import { resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, s
 
 test("resolveStateDir uses a temp-backed per-workspace directory", () => {
   const workspace = makeTempDir();
-  const stateDir = resolveStateDir(workspace);
+  const previousPluginDataDir = process.env.CLAUDE_PLUGIN_DATA;
+  delete process.env.CLAUDE_PLUGIN_DATA;
 
-  assert.equal(stateDir.startsWith(os.tmpdir()), true);
-  assert.match(path.basename(stateDir), /.+-[a-f0-9]{16}$/);
-  assert.match(stateDir, new RegExp(`^${os.tmpdir().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  try {
+    const stateDir = resolveStateDir(workspace);
+
+    assert.equal(stateDir.startsWith(os.tmpdir()), true);
+    assert.match(path.basename(stateDir), /.+-[a-f0-9]{16}$/);
+    assert.match(stateDir, new RegExp(`^${os.tmpdir().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  } finally {
+    if (previousPluginDataDir == null) {
+      delete process.env.CLAUDE_PLUGIN_DATA;
+    } else {
+      process.env.CLAUDE_PLUGIN_DATA = previousPluginDataDir;
+    }
+  }
 });
 
 test("resolveStateDir uses CLAUDE_PLUGIN_DATA when it is provided", () => {


### PR DESCRIPTION
## Summary

4 tests fail when run inside a Claude Code session because environment variables leak into test subprocesses. This strips those env vars in the affected tests so the suite passes regardless of the calling environment.

## Root cause

- **3 tests in runtime.test.mjs** (`status shows phases`, `status preserves adversarial review kind labels`, `result returns the stored output`): write jobs without a `sessionId` field, then spawn a subprocess that inherits `CODEX_COMPANION_SESSION_ID` from the environment. `filterJobsForCurrentSession()` drops all jobs that don't match the session ID, producing "No jobs recorded yet." instead of the expected output.

- **1 test in state.test.mjs** (`resolveStateDir uses a temp-backed per-workspace directory`): asserts the state dir starts with `os.tmpdir()`, but `CLAUDE_PLUGIN_DATA` is set in Claude Code sessions, so `resolveStateDir` returns the plugin data path instead.

## Changes

- `tests/runtime.test.mjs`: delete `CODEX_COMPANION_SESSION_ID` from the subprocess env for the 3 tests that don't exercise session filtering
- `tests/state.test.mjs`: save/restore `CLAUDE_PLUGIN_DATA` around the tmpdir assertion

The session-scoped tests that already pass (e.g., "status without a job id only shows jobs from the current Claude session") are unchanged since they correctly set `CODEX_COMPANION_SESSION_ID` and include `sessionId` in their job data.

## Testing

- `npm test`: 64/64 pass, 0 fail (was 4 failures on main)
- `npm run build`: passes

This contribution was developed with AI assistance (Claude Code).