### PR TITLE
fix: handle EAGAIN when reading hook stdin in non-blocking mode

### DIFF
--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -20,7 +20,15 @@ export const SESSION_ID_ENV = "CODEX_COMPANION_SESSION_ID";
 const PLUGIN_DATA_ENV = "CLAUDE_PLUGIN_DATA";
 
 function readHookInput() {
-  const raw = fs.readFileSync(0, "utf8").trim();
+  let raw;
+  try {
+    raw = fs.readFileSync(0, "utf8").trim();
+  } catch (e) {
+    if (e.code === "EAGAIN") {
+      return {};
+    }
+    throw e;
+  }
   if (!raw) {
     return {};
   }

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -19,7 +19,15 @@ const ROOT_DIR = path.resolve(SCRIPT_DIR, "..");
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
 
 function readHookInput() {
-  const raw = fs.readFileSync(0, "utf8").trim();
+  let raw;
+  try {
+    raw = fs.readFileSync(0, "utf8").trim();
+  } catch (e) {
+    if (e.code === "EAGAIN") {
+      return {};
+    }
+    throw e;
+  }
   if (!raw) {
     return {};
   }


### PR DESCRIPTION
## Summary

Fixes #120.

Both `stop-review-gate-hook.mjs` and `session-lifecycle-hook.mjs` call `fs.readFileSync(0, "utf8")` to read stdin. When Claude Code invokes hooks with stdin as a non-blocking pipe, the kernel returns `EAGAIN` instead of blocking. Node.js synchronous APIs do not retry — they throw immediately. This causes intermittent crashes when multiple hooks fire in quick succession.

- Wrap `readFileSync(0, ...)` in a try/catch in both hook scripts
- On `EAGAIN`, return `{}` (same as the empty-string path that already exists)
- All other errors are re-thrown so genuine failures still surface

## Test plan

- [ ] Verify the hook no longer crashes with `EAGAIN` when stdin is non-blocking (macOS, multiple concurrent hooks)
- [ ] Verify existing hook behaviour is unchanged when stdin contains valid JSON
- [ ] Verify empty stdin still returns `{}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)