### PR TITLE
Add /codex:plan-review command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ they already have.
 
 - `/codex:review` for a normal read-only Codex review
 - `/codex:adversarial-review` for a steerable challenge review
+- `/codex:plan-review` to validate a Claude Code plan against the codebase before implementation
 - `/codex:rescue`, `/codex:status`, `/codex:result`, and `/codex:cancel` to delegate work and manage background jobs
 
 ## Requirements
@@ -123,6 +124,32 @@ Examples:
 
 This command is read-only. It does not fix code.
 
+### `/codex:plan-review`
+
+Validates a **Claude Code plan** against the actual codebase before implementation begins.
+
+Codex searches the repository to verify the plan's claims, check for missed references, and identify risks. It automatically uses the most recently modified plan in `~/.claude/plans/`, or you can specify one with `--plan <name>`.
+
+It supports `--wait` and `--background`. Focus text after the flags gives Codex additional review guidance.
+
+Use it when you want:
+
+- to validate that a plan accounts for all relevant code references before starting work
+- a second opinion on whether the plan's exclusions and ordering are safe
+- to catch edge cases like database triggers, callbacks, or framework hooks the plan might miss
+
+Examples:
+
+```bash
+/codex:plan-review
+/codex:plan-review --background
+/codex:plan-review --plan my-refactor-plan
+/codex:plan-review include reference to the RFC at /tmp/rfc.md
+/codex:plan-review focus on data migration safety
+```
+
+This command is read-only. It does not fix code or modify the plan.
+
 ### `/codex:rescue`
 
 Hands a task to Codex through the `codex:codex-rescue` subagent.
@@ -227,6 +254,12 @@ When the review gate is enabled, the plugin uses a `Stop` hook to run a targeted
 
 ```bash
 /codex:review
+```
+
+### Validate A Plan Before Implementing
+
+```bash
+/codex:plan-review
 ```
 
 ### Hand A Problem To Codex

--- a/plugins/codex/commands/plan-review.md
+++ b/plugins/codex/commands/plan-review.md
@@ -1,0 +1,53 @@
+---
+description: Run a Codex review of the current Claude Code plan against the codebase
+argument-hint: '[--wait|--background] [--plan <name>] [--model <model>] [focus ...]'
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
+---
+
+Run a Codex plan review through the shared plugin runtime.
+Codex will search the codebase to validate the plan's claims, check for missed references, and identify risks before implementation begins.
+
+Raw slash-command arguments:
+`$ARGUMENTS`
+
+Core constraint:
+- This command is review-only.
+- Do not fix issues, apply patches, or suggest that you are about to make changes.
+- Your only job is to run the review and return Codex's output verbatim to the user.
+
+Execution mode rules:
+- If the raw arguments include `--wait`, do not ask. Run in the foreground.
+- If the raw arguments include `--background`, do not ask. Run in a Claude background task.
+- Otherwise, recommend background since plan reviews require Codex to search the codebase extensively.
+- Use `AskUserQuestion` exactly once with two options, putting the recommended option first and suffixing its label with `(Recommended)`:
+  - `Run in background`
+  - `Wait for results`
+
+Argument handling:
+- Preserve the user's arguments exactly.
+- Do not strip `--wait` or `--background` yourself.
+- The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
+- If `--plan <name>` is provided, that plan is used. Otherwise the most recently modified plan in `~/.claude/plans/` is used automatically.
+- Focus text after the flags is passed to Codex as additional review guidance (e.g. "include reference to the RFC at /tmp/rfc.md", "focus on data migration safety").
+
+Foreground flow:
+- Run:
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" plan-review "$ARGUMENTS"
+```
+- Return the command stdout verbatim, exactly as-is.
+- Do not paraphrase, summarize, or add commentary before or after it.
+- Do not fix any issues mentioned in the review output.
+
+Background flow:
+- Launch the review with `Bash` in the background:
+```typescript
+Bash({
+  command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" plan-review "$ARGUMENTS"`,
+  description: "Codex plan review",
+  run_in_background: true
+})
+```
+- Do not call `BashOutput` or wait for completion in this turn.
+- After launching the command, tell the user: "Codex plan review started in the background. Check `/codex:status` for progress."

--- a/plugins/codex/prompts/plan-review.md
+++ b/plugins/codex/prompts/plan-review.md
@@ -1,0 +1,70 @@
+<role>
+You are Codex performing a plan review.
+Your job is to validate an implementation plan against the actual codebase before work begins.
+</role>
+
+<task>
+Review the provided plan by searching the codebase to verify its claims, check for completeness, and identify risks.
+Plan: {{PLAN_NAME}}
+User focus: {{USER_FOCUS}}
+</task>
+
+<operating_stance>
+Treat the plan as a hypothesis.
+Every file reference, line number, and behavioral claim in the plan is an assertion that must be verified against the current codebase.
+Do not trust the plan's claims — check them.
+</operating_stance>
+
+<review_dimensions>
+Prioritize in this order:
+1. **Completeness** — search the codebase for references the plan may have missed. Grep for key identifiers, column names, method names, or patterns mentioned in the plan. Are there files or call sites the plan does not account for?
+2. **Safety** — will the proposed changes break tests, remove behavior that is still depended on, or cause runtime failures? Could removing a factory default or test assertion mask a real regression?
+3. **Correctness of exclusions** — if the plan lists items it intentionally does not change, verify those exclusions are actually safe. Do the kept items truly not depend on what is being removed or changed?
+4. **Ordering and dependencies** — are the plan steps in the right order? Could executing step N before step M cause a transient failure? Are there implicit dependencies between steps?
+5. **Edge cases** — are there database triggers, callbacks, observers, concerns, or framework hooks that fire on the data being changed? Could any of these create surprising behavior?
+</review_dimensions>
+
+<review_method>
+Use your tools to search the repository.
+Grep for key terms from the plan. Read the specific files and lines the plan references to confirm they match the current state of the code.
+Look for references the plan does not mention.
+If the user supplied a focus area, weight it heavily, but still report any other material finding you can defend.
+</review_method>
+
+<finding_bar>
+Report only material findings.
+A finding should answer:
+1. What does the plan get wrong or miss?
+2. What is the evidence from the codebase?
+3. What is the likely impact if the plan is executed as-is?
+4. What concrete change to the plan would fix it?
+</finding_bar>
+
+<structured_output_contract>
+Return only valid JSON matching the provided schema.
+Keep the output compact and specific.
+Use `needs-attention` if the plan has material gaps, incorrect claims, or missing references.
+Use `approve` only if every claim in the plan checks out against the codebase.
+Every finding must include:
+- the affected file
+- `line_start` and `line_end`
+- a confidence score from 0 to 1
+- a concrete recommendation
+Write the summary as a terse assessment of plan readiness, not a neutral recap.
+</structured_output_contract>
+
+<grounding_rules>
+Every finding must be backed by evidence from the codebase — a file you read, a grep result, or a concrete code path.
+Do not invent references or speculate about code you have not examined.
+If a conclusion depends on an inference, state that explicitly and keep the confidence honest.
+</grounding_rules>
+
+<calibration_rules>
+Prefer one strong finding over several weak ones.
+Do not pad the review with minor suggestions.
+If the plan is solid, say so directly and return no findings.
+</calibration_rules>
+
+<plan_content>
+{{PLAN_CONTENT}}
+</plan_content>

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -711,11 +711,14 @@ function findPlanFile(planName) {
 
   if (planName) {
     const candidate = planName.endsWith(".md") ? planName : `${planName}.md`;
-    const planPath = path.join(plansDir, candidate);
+    const planPath = path.resolve(plansDir, candidate);
+    if (!planPath.startsWith(plansDir + path.sep) && planPath !== plansDir) {
+      throw new Error("--plan must be a filename inside ~/.claude/plans/, not a path.");
+    }
     if (!fs.existsSync(planPath)) {
       throw new Error(`Plan not found: ${candidate}`);
     }
-    return { name: candidate.replace(/\.md$/, ""), path: planPath };
+    return { name: path.basename(planPath, ".md"), path: planPath };
   }
 
   const files = fs.readdirSync(plansDir)

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -2,6 +2,7 @@
 
 import { spawn } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
@@ -77,6 +78,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
+      "  node scripts/codex-companion.mjs plan-review [--wait|--background] [--plan <name>] [--model <model>] [focus text]",
       "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
@@ -701,6 +703,136 @@ async function handleReview(argv) {
   });
 }
 
+function findPlanFile(planName) {
+  const plansDir = path.join(os.homedir(), ".claude", "plans");
+  if (!fs.existsSync(plansDir)) {
+    throw new Error("No Claude Code plans directory found at ~/.claude/plans/.");
+  }
+
+  if (planName) {
+    const candidate = planName.endsWith(".md") ? planName : `${planName}.md`;
+    const planPath = path.join(plansDir, candidate);
+    if (!fs.existsSync(planPath)) {
+      throw new Error(`Plan not found: ${candidate}`);
+    }
+    return { name: candidate.replace(/\.md$/, ""), path: planPath };
+  }
+
+  const files = fs.readdirSync(plansDir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => {
+      const fullPath = path.join(plansDir, f);
+      const stat = fs.statSync(fullPath);
+      return { name: f.replace(/\.md$/, ""), path: fullPath, mtime: stat.mtimeMs };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+
+  if (files.length === 0) {
+    throw new Error("No plan files found in ~/.claude/plans/.");
+  }
+
+  return files[0];
+}
+
+function buildPlanReviewPrompt(planContent, planName, focusText) {
+  const template = loadPromptTemplate(ROOT_DIR, "plan-review");
+  return interpolateTemplate(template, {
+    PLAN_NAME: planName,
+    USER_FOCUS: focusText || "No extra focus provided.",
+    PLAN_CONTENT: planContent
+  });
+}
+
+async function executePlanReviewRun(request) {
+  ensureCodexReady(request.cwd);
+
+  const planFile = findPlanFile(request.planName);
+  const planContent = fs.readFileSync(planFile.path, "utf8");
+  const workspaceRoot = resolveWorkspaceRoot(request.cwd);
+  const focusText = request.focusText?.trim() ?? "";
+  const reviewName = "Plan Review";
+
+  const prompt = buildPlanReviewPrompt(planContent, planFile.name, focusText);
+  const result = await runAppServerTurn(workspaceRoot, {
+    prompt,
+    model: request.model,
+    sandbox: "read-only",
+    outputSchema: readOutputSchema(REVIEW_SCHEMA),
+    onProgress: request.onProgress
+  });
+  const parsed = parseStructuredOutput(result.finalMessage, {
+    status: result.status,
+    failureMessage: result.error?.message ?? result.stderr
+  });
+  const payload = {
+    review: reviewName,
+    plan: { name: planFile.name, path: planFile.path },
+    threadId: result.threadId,
+    codex: {
+      status: result.status,
+      stderr: result.stderr,
+      stdout: result.finalMessage,
+      reasoning: result.reasoningSummary
+    },
+    result: parsed.parsed,
+    rawOutput: parsed.rawOutput,
+    parseError: parsed.parseError,
+    reasoningSummary: result.reasoningSummary
+  };
+
+  return {
+    exitStatus: result.status,
+    threadId: result.threadId,
+    turnId: result.turnId,
+    payload,
+    rendered: renderReviewResult(parsed, {
+      reviewLabel: reviewName,
+      targetLabel: `plan: ${planFile.name}`,
+      reasoningSummary: result.reasoningSummary
+    }),
+    summary: parsed.parsed?.summary ?? parsed.parseError ?? firstMeaningfulLine(result.finalMessage, `${reviewName} finished.`),
+    jobTitle: `Codex ${reviewName}`,
+    jobClass: "review",
+    targetLabel: `plan: ${planFile.name}`
+  };
+}
+
+async function handlePlanReview(argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["plan", "model", "cwd"],
+    booleanOptions: ["json", "background", "wait"],
+    aliasMap: {
+      m: "model"
+    }
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+  const focusText = positionals.join(" ").trim();
+
+  const planFile = findPlanFile(options.plan ?? null);
+  const job = createCompanionJob({
+    prefix: "review",
+    kind: "plan-review",
+    title: "Codex Plan Review",
+    workspaceRoot,
+    jobClass: "review",
+    summary: `Plan Review: ${planFile.name}`
+  });
+  await runForegroundCommand(
+    job,
+    (progress) =>
+      executePlanReviewRun({
+        cwd,
+        model: options.model,
+        planName: options.plan ?? null,
+        focusText,
+        onProgress: progress
+      }),
+    { json: options.json }
+  );
+}
+
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["model", "effort", "cwd", "prompt-file"],
@@ -976,6 +1108,9 @@ async function main() {
       await handleReviewCommand(argv, {
         reviewName: "Adversarial Review"
       });
+      break;
+    case "plan-review":
+      await handlePlanReview(argv);
       break;
     case "task":
       await handleTask(argv);

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -70,11 +70,34 @@ test("adversarial review command uses AskUserQuestion and background Bash while 
   assert.match(source, /can still take extra focus text after the flags/i);
 });
 
+test("plan review command uses AskUserQuestion and background Bash while staying review-only", () => {
+  const source = read("commands/plan-review.md");
+  assert.match(source, /AskUserQuestion/);
+  assert.match(source, /\bBash\(/);
+  assert.match(source, /Do not fix issues/i);
+  assert.match(source, /review-only/i);
+  assert.match(source, /return Codex's output verbatim to the user/i);
+  assert.match(source, /```bash/);
+  assert.match(source, /```typescript/);
+  assert.match(source, /plan-review "\$ARGUMENTS"/);
+  assert.match(source, /run_in_background:\s*true/);
+  assert.match(source, /command:\s*`node "\$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/codex-companion\.mjs" plan-review "\$ARGUMENTS"`/);
+  assert.match(source, /description:\s*"Codex plan review"/);
+  assert.match(source, /Do not call `BashOutput`/);
+  assert.match(source, /Return the command stdout verbatim, exactly as-is/i);
+  assert.match(source, /The companion script parses `--wait` and `--background`/i);
+  assert.match(source, /Claude Code's `Bash\(..., run_in_background: true\)` is what actually detaches the run/i);
+  assert.match(source, /\(Recommended\)/);
+  assert.match(source, /most recently modified plan/i);
+  assert.match(source, /~\/\.claude\/plans\//);
+});
+
 test("continue is not exposed as a user-facing command", () => {
   const commandFiles = fs.readdirSync(path.join(PLUGIN_ROOT, "commands")).sort();
   assert.deepEqual(commandFiles, [
     "adversarial-review.md",
     "cancel.md",
+    "plan-review.md",
     "rescue.md",
     "result.md",
     "review.md",


### PR DESCRIPTION
## Summary

- Adds `/codex:plan-review` — validates a Claude Code plan against the codebase before implementation
- Codex searches the repo to check completeness, safety, exclusion correctness, ordering risks, and edge cases
- Picks the most recently modified plan from `~/.claude/plans/` by default, or accepts `--plan <name>`
- Supports `--background`, `--wait`, `--model`, and free-form focus text

## Motivation

Common workflow: write a detailed plan in Claude Code's plan mode, then want a second opinion from Codex before executing. Currently requires manually constructing a `codex exec` command with the plan content piped in. This automates that into a single slash command.

## Changes

- `plugins/codex/commands/plan-review.md` — command definition
- `plugins/codex/prompts/plan-review.md` — prompt template with 5 review dimensions
- `plugins/codex/scripts/codex-companion.mjs` — `plan-review` subcommand (+135 lines)
- `tests/commands.test.mjs` — test for new command, updated command list assertion
- `README.md` — documentation and typical flows