### PR TITLE
Add /codex:agent-team for tmux split-pane multi-agent spawning

### DIFF
--- a/plugins/codex/commands/agent-team.md
+++ b/plugins/codex/commands/agent-team.md
@@ -1,0 +1,60 @@
+---
+description: Spawn a team of Codex agents in tmux split panes for parallel work
+argument-hint: "[<count>] [--names <name1,name2,...>]"
+allowed-tools: Bash(node:*)
+---
+
+Spawn Codex agent instances as visible tmux split panes for parallel work.
+Each agent runs `codex --dangerously-bypass-approvals-and-sandbox` in its own
+pane with a colored border and title matching Claude Code's agent team layout.
+
+Raw user request:
+$ARGUMENTS
+
+## Execution
+
+1. Run:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" agent-team --json $ARGUMENTS
+```
+
+2. Parse the JSON result. Each agent entry has `name`, `paneId`, and `color`.
+   The script waits for Codex to boot and sends a confirmation Enter to each pane
+   before returning, so agents are ready to accept tasks immediately.
+3. Report the spawned agents to the user with their names, colors, and pane IDs.
+
+## After spawning
+
+You are the CTO. You do not write code. You coordinate the Codex agents.
+Use the `agent-team` skill for orchestration patterns.
+
+### Send a task to an agent
+
+```bash
+tmux send-keys -t <paneId> "<task text>" Enter
+sleep 2
+tmux send-keys -t <paneId> Enter
+```
+
+### Check agent output
+
+```bash
+tmux capture-pane -t <paneId> -p -S -80
+```
+
+### Kill agents when done
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" agent-team-kill <paneId1>,<paneId2>,...
+```
+
+## Operating rules
+
+- Default count is 3 agents. Maximum is 8.
+- Agent names default to codex-1, codex-2, etc. Custom names via `--names`.
+- Never assign the same file to multiple agents. One owner per file.
+- Commit work frequently; all agents share one working tree with no isolation.
+- One task at a time per agent. Verify completion before sending the next.
+- If an agent's Codex exits (shell prompt visible), relaunch with `codex --dangerously-bypass-approvals-and-sandbox`.
+- Every task must include what to do, why, which files to touch, and how to verify.

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -50,8 +50,10 @@ import {
   runTrackedJob,
   SESSION_ID_ENV
 } from "./lib/tracked-jobs.mjs";
+import { spawnAgentTeam, killAllAgents } from "./lib/tmux-team.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
 import {
+  renderAgentTeamResult,
   renderNativeReviewResult,
   renderReviewResult,
   renderStoredJobResult,
@@ -80,7 +82,9 @@ function printUsage() {
       "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
-      "  node scripts/codex-companion.mjs cancel [job-id] [--json]"
+      "  node scripts/codex-companion.mjs cancel [job-id] [--json]",
+      "  node scripts/codex-companion.mjs agent-team [<count>] [--names <name1,name2,...>] [--json]",
+      "  node scripts/codex-companion.mjs agent-team-kill <paneId1>,<paneId2>,... [--json]"
     ].join("\n")
   );
 }
@@ -958,6 +962,51 @@ async function handleCancel(argv) {
   outputCommandResult(payload, renderCancelReport(nextJob), options.json);
 }
 
+async function handleAgentTeam(argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["count", "names", "cwd"],
+    booleanOptions: ["json"]
+  });
+
+  const countArg = positionals[0] || options.count;
+  const count = Math.max(1, Math.min(8, Number(countArg) || 3));
+  const cwd = resolveCommandCwd(options);
+  const names = options.names
+    ? options.names.split(",").map((n) => n.trim()).filter(Boolean)
+    : undefined;
+
+  const result = await spawnAgentTeam(count, { cwd, names });
+  const payload = {
+    count: result.agents.length,
+    leaderPaneId: result.leaderPaneId,
+    windowTarget: result.windowTarget,
+    cwd: result.cwd,
+    agents: result.agents.map((a) => ({
+      name: a.name,
+      paneId: a.paneId,
+      color: a.color
+    }))
+  };
+
+  outputCommandResult(payload, renderAgentTeamResult(payload), options.json);
+}
+
+function handleAgentTeamKill(argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    booleanOptions: ["json"]
+  });
+
+  const paneIds = positionals.flatMap((p) => p.split(",")).filter(Boolean);
+  if (paneIds.length === 0) {
+    throw new Error("Provide one or more pane IDs to kill.");
+  }
+
+  const killed = killAllAgents(paneIds);
+  const payload = { killed, total: paneIds.length };
+  const rendered = `Killed ${killed} of ${paneIds.length} agent pane(s).\n`;
+  outputCommandResult(payload, rendered, options.json);
+}
+
 async function main() {
   const [subcommand, ...argv] = process.argv.slice(2);
   if (!subcommand || subcommand === "help" || subcommand === "--help") {
@@ -994,6 +1043,12 @@ async function main() {
       break;
     case "cancel":
       await handleCancel(argv);
+      break;
+    case "agent-team":
+      await handleAgentTeam(argv);
+      break;
+    case "agent-team-kill":
+      handleAgentTeamKill(argv);
       break;
     default:
       throw new Error(`Unknown subcommand: ${subcommand}`);

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -463,3 +463,21 @@ export function renderCancelReport(job) {
 
   return `${lines.join("\n").trimEnd()}\n`;
 }
+
+export function renderAgentTeamResult(result) {
+  const lines = [
+    "# Codex Agent Team",
+    "",
+    `Spawned ${result.agents.length} agent(s):`,
+    ""
+  ];
+
+  for (const agent of result.agents) {
+    lines.push(`- ${agent.name} (${agent.color}) pane ${agent.paneId}`);
+  }
+
+  lines.push("");
+  lines.push("Codex is booting (~10s). Wait, then send tasks to each pane.");
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}

--- a/plugins/codex/scripts/lib/tmux-team.mjs
+++ b/plugins/codex/scripts/lib/tmux-team.mjs
@@ -1,0 +1,341 @@
+/**
+ * Tmux-based multi-agent pane management for Codex agent teams.
+ *
+ * Creates split panes in the current tmux window, launches Codex instances,
+ * and provides send/capture primitives for coordinating parallel agents.
+ * Follows the same pane layout strategy as Claude Code's TmuxBackend:
+ * the leader (Claude Code) stays in the left 30%, agents fill the right 70%
+ * with alternating horizontal and vertical splits.
+ */
+
+import { spawnSync } from "node:child_process";
+
+const TMUX = "tmux";
+const SHELL_INIT_DELAY_MS = 200;
+const CODEX_BOOT_DELAY_MS = 8000;
+const CODEX_COMMAND = "codex --dangerously-bypass-approvals-and-sandbox";
+
+/** Single-quote a value for safe shell interpolation. */
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Tmux color names matching Claude Code's TmuxBackend color scheme.
+ * Up to 8 agents can have distinct border colors.
+ * @type {Array<{ name: string, tmux: string }>}
+ */
+const AGENT_COLORS = [
+  { name: "red", tmux: "red" },
+  { name: "blue", tmux: "blue" },
+  { name: "green", tmux: "green" },
+  { name: "yellow", tmux: "yellow" },
+  { name: "purple", tmux: "magenta" },
+  { name: "orange", tmux: "colour208" },
+  { name: "pink", tmux: "colour205" },
+  { name: "cyan", tmux: "cyan" }
+];
+
+/**
+ * @typedef {{
+ *   name: string,
+ *   paneId: string,
+ *   color: string,
+ *   tmuxColor: string,
+ *   index: number
+ * }} AgentInfo
+ */
+
+/**
+ * @typedef {{
+ *   leaderPaneId: string,
+ *   windowTarget: string,
+ *   agents: AgentInfo[],
+ *   cwd: string
+ * }} AgentTeamResult
+ */
+
+// ---------------------------------------------------------------------------
+// Low-level tmux helpers
+// ---------------------------------------------------------------------------
+
+/** @returns {{ stdout: string, stderr: string, code: number }} */
+function tmux(args) {
+  const result = spawnSync(TMUX, args, { encoding: "utf8", timeout: 5000 });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    code: result.status ?? 1
+  };
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Tmux environment detection
+// ---------------------------------------------------------------------------
+
+/** Checks whether the tmux binary is available on PATH. */
+export function isTmuxAvailable() {
+  return spawnSync(TMUX, ["-V"], { encoding: "utf8", timeout: 3000 }).status === 0;
+}
+
+/** Checks whether the current process is running inside a tmux session. */
+export function isInsideTmux() {
+  return Boolean(process.env.TMUX);
+}
+
+// ---------------------------------------------------------------------------
+// Window and pane queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the current tmux pane ID.
+ * Prefers the TMUX_PANE env var captured at process start so the leader's
+ * pane is always identified even if the user switches focus.
+ */
+function getCurrentPaneId() {
+  if (process.env.TMUX_PANE) {
+    return process.env.TMUX_PANE;
+  }
+  const result = tmux(["display-message", "-p", "#{pane_id}"]);
+  return result.code === 0 ? result.stdout.trim() : null;
+}
+
+/**
+ * Returns the current tmux session:window target, queried relative to the
+ * leader pane so that focus changes do not affect the result.
+ */
+function getCurrentWindowTarget() {
+  const paneId = getCurrentPaneId();
+  const args = ["display-message"];
+  if (paneId) {
+    args.push("-t", paneId);
+  }
+  args.push("-p", "#{session_name}:#{window_index}");
+  const result = tmux(args);
+  return result.code === 0 ? result.stdout.trim() : null;
+}
+
+/** Returns pane IDs for a given window target. */
+function listPaneIds(windowTarget) {
+  const result = tmux(["list-panes", "-t", windowTarget, "-F", "#{pane_id}"]);
+  if (result.code !== 0) {
+    return [];
+  }
+  return result.stdout.trim().split("\n").filter(Boolean);
+}
+
+// ---------------------------------------------------------------------------
+// Pane styling (border color + title)
+// ---------------------------------------------------------------------------
+
+/** Sets the border color for a pane (requires tmux 3.2+). */
+function setPaneBorderColor(paneId, tmuxColor) {
+  tmux(["select-pane", "-t", paneId, "-P", `bg=default,fg=${tmuxColor}`]);
+  tmux(["set-option", "-p", "-t", paneId, "pane-border-style", `fg=${tmuxColor}`]);
+  tmux(["set-option", "-p", "-t", paneId, "pane-active-border-style", `fg=${tmuxColor}`]);
+}
+
+/** Sets the title for a pane, shown in the pane border. */
+function setPaneTitle(paneId, name, tmuxColor) {
+  tmux(["select-pane", "-t", paneId, "-T", name]);
+  tmux([
+    "set-option", "-p", "-t", paneId, "pane-border-format",
+    `#[fg=${tmuxColor},bold] #{pane_title} #[default]`
+  ]);
+}
+
+/** Enables pane border status on a window so pane titles are visible. */
+function enablePaneBorderStatus(windowTarget) {
+  tmux(["set-option", "-w", "-t", windowTarget, "pane-border-status", "top"]);
+}
+
+// ---------------------------------------------------------------------------
+// Layout rebalancing
+// ---------------------------------------------------------------------------
+
+/**
+ * Rebalances panes with the leader at 30% width and agents sharing the
+ * right 70%. Uses tmux's main-vertical layout, matching Claude Code's
+ * TmuxBackend rebalancing strategy.
+ */
+function rebalancePanes(windowTarget) {
+  const panes = listPaneIds(windowTarget);
+  if (panes.length <= 2) {
+    return;
+  }
+  tmux(["select-layout", "-t", windowTarget, "main-vertical"]);
+  if (panes[0]) {
+    tmux(["resize-pane", "-t", panes[0], "-x", "30%"]);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pane creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a single agent pane using the TmuxBackend split strategy.
+ *
+ * First agent: horizontal split from the leader pane, taking 70% width.
+ * Additional agents: alternating vertical and horizontal splits from
+ * existing agent panes, keeping the layout balanced.
+ */
+function createAgentPane(leaderPaneId, windowTarget, name, color, agentPanes) {
+  const isFirst = agentPanes.length === 0;
+
+  let result;
+  if (isFirst) {
+    result = tmux([
+      "split-window", "-t", leaderPaneId, "-h", "-l", "70%",
+      "-P", "-F", "#{pane_id}"
+    ]);
+  } else {
+    const count = agentPanes.length;
+    const splitVertically = count % 2 === 1;
+    const targetIndex = Math.floor((count - 1) / 2);
+    const targetPane = agentPanes[targetIndex] || agentPanes[agentPanes.length - 1];
+    result = tmux([
+      "split-window", "-t", targetPane, splitVertically ? "-v" : "-h",
+      "-P", "-F", "#{pane_id}"
+    ]);
+  }
+
+  if (result.code !== 0) {
+    throw new Error(`Failed to create pane for ${name}: ${result.stderr.trim()}`);
+  }
+
+  const paneId = result.stdout.trim();
+  setPaneBorderColor(paneId, color.tmux);
+  setPaneTitle(paneId, name, color.tmux);
+
+  if (isFirst) {
+    enablePaneBorderStatus(windowTarget);
+  }
+
+  return paneId;
+}
+
+// ---------------------------------------------------------------------------
+// Public API: agent lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Sends text to an agent pane followed by Enter.
+ * @param {string} paneId
+ * @param {string} text
+ */
+export function sendToAgent(paneId, text) {
+  const result = tmux(["send-keys", "-t", paneId, text, "Enter"]);
+  if (result.code !== 0) {
+    throw new Error(`Failed to send to pane ${paneId}: ${result.stderr.trim()}`);
+  }
+}
+
+/**
+ * Captures recent scrollback from an agent pane.
+ * @param {string} paneId
+ * @param {number} [lines=80]
+ * @returns {string}
+ */
+export function captureAgentOutput(paneId, lines = 80) {
+  const result = tmux(["capture-pane", "-t", paneId, "-p", "-S", `-${lines}`]);
+  return result.code === 0 ? result.stdout : "";
+}
+
+/**
+ * Kills a single agent pane.
+ * @param {string} paneId
+ * @returns {boolean} True if the pane was killed.
+ */
+export function killAgent(paneId) {
+  return tmux(["kill-pane", "-t", paneId]).code === 0;
+}
+
+/**
+ * Kills all agent panes in the given list.
+ * @param {string[]} paneIds
+ * @returns {number} Count of panes successfully killed.
+ */
+export function killAllAgents(paneIds) {
+  let killed = 0;
+  for (const paneId of paneIds) {
+    if (killAgent(paneId)) {
+      killed += 1;
+    }
+  }
+  return killed;
+}
+
+/**
+ * Checks whether a tmux pane is still alive.
+ * @param {string} paneId
+ * @returns {boolean}
+ */
+export function isPaneAlive(paneId) {
+  return tmux(["display-message", "-t", paneId, "-p", "#{pane_id}"]).code === 0;
+}
+
+/**
+ * Spawns N Codex agents in tmux split panes.
+ *
+ * Each agent gets its own pane with a colored border and title, and has
+ * `codex --dangerously-bypass-approvals-and-sandbox` launched inside it.
+ * Returns metadata for each agent so the caller can send tasks and
+ * capture output via the pane IDs.
+ *
+ * @param {number} count - Number of agents to spawn (clamped to 1-8).
+ * @param {{ cwd?: string, names?: string[] }} [options]
+ * @returns {Promise<AgentTeamResult>}
+ */
+export async function spawnAgentTeam(count, options = {}) {
+  if (!isTmuxAvailable()) {
+    throw new Error("tmux is not installed. Install it with `brew install tmux`.");
+  }
+  if (!isInsideTmux()) {
+    throw new Error("agent-team requires running inside a tmux session. Start tmux first.");
+  }
+
+  const leaderPaneId = getCurrentPaneId();
+  const windowTarget = getCurrentWindowTarget();
+  if (!leaderPaneId || !windowTarget) {
+    throw new Error("Could not detect current tmux pane or window.");
+  }
+
+  const cwd = options.cwd || process.cwd();
+  const max = AGENT_COLORS.length;
+  const safeCount = Math.max(1, Math.min(max, count));
+  const agents = [];
+
+  const agentPaneIds = [];
+
+  for (let i = 0; i < safeCount; i++) {
+    const name = options.names?.[i] || `codex-${i + 1}`;
+    const color = AGENT_COLORS[i % max];
+
+    const paneId = createAgentPane(leaderPaneId, windowTarget, name, color, agentPaneIds);
+    agentPaneIds.push(paneId);
+    await sleep(SHELL_INIT_DELAY_MS);
+
+    sendToAgent(paneId, `cd ${shellQuote(cwd)} && ${CODEX_COMMAND}`);
+
+    agents.push({ name, paneId, color: color.name, tmuxColor: color.tmux, index: i });
+  }
+
+  rebalancePanes(windowTarget);
+
+  // Wait for Codex to boot in all panes, then send a confirmation Enter
+  // to each one so the prompt is ready to accept tasks. Matches the
+  // sleep-then-Enter pattern from /ship-it and /tmux.
+  await sleep(CODEX_BOOT_DELAY_MS);
+  for (const agent of agents) {
+    tmux(["send-keys", "-t", agent.paneId, "", "Enter"]);
+  }
+
+  return { leaderPaneId, windowTarget, agents, cwd };
+}
+
+export { AGENT_COLORS };

--- a/plugins/codex/skills/agent-team/SKILL.md
+++ b/plugins/codex/skills/agent-team/SKILL.md
@@ -1,0 +1,232 @@
+---
+name: agent-team
+description: Orchestration patterns for coordinating a team of parallel Codex agents in tmux split panes
+user-invocable: false
+---
+
+# Codex Agent Team — Orchestration
+
+## Identity
+
+You are the CTO. You do not write code. You explore the codebase, decompose work into tasks, assign tasks to Codex agents, prevent file conflicts, track progress, and keep the user informed.
+
+Your Codex agents are senior engineers in tmux split panes. Each runs `codex --dangerously-bypass-approvals-and-sandbox` with full access to the codebase, all CLI tools, and all MCP servers. They write code, run tests, and verify their own work. You direct. They execute.
+
+**Your job: delegation, coordination, and conflict prevention. Not implementation.**
+
+---
+
+## Primitives
+
+### Send a task to an agent
+
+For short tasks, send inline:
+
+```bash
+tmux send-keys -t <paneId> "<task text>" Enter
+sleep 2
+tmux send-keys -t <paneId> Enter
+```
+
+For longer tasks, write to a temp file and send the content:
+
+```bash
+cat > /tmp/codex-task.md << 'TASK'
+# Task: <title>
+
+<context and instructions>
+
+## What to Do
+<specific deliverables>
+
+## Constraints
+- Only modify <these files>
+- Do NOT touch <these files> — another agent owns them
+
+## Verification
+- Run <test command> and confirm it passes
+TASK
+TASK_TEXT=$(cat /tmp/codex-task.md)
+tmux send-keys -t <paneId> "$TASK_TEXT" Enter
+sleep 2
+tmux send-keys -t <paneId> Enter
+```
+
+### Check agent output
+
+```bash
+tmux capture-pane -t <paneId> -p -S -80 | tail -40
+```
+
+### Kill an agent
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" agent-team-kill <paneId>
+```
+
+### Relaunch a dead agent
+
+If capture-pane shows a shell prompt instead of the Codex interface, the agent exited:
+
+```bash
+tmux send-keys -t <paneId> "codex --dangerously-bypass-approvals-and-sandbox" Enter
+```
+
+Wait 10 seconds, then resend the current task.
+
+---
+
+## Codex Agent Rules
+
+1. **Codex auto-compacts.** Never restart an agent because its context is low. Never factor context percentage into decisions. If an agent seems confused, resend the task.
+2. **One task at a time per agent.** Do not batch. Send a task, verify completion, then send the next.
+3. **Double-Enter.** After every task send, sleep 2 seconds, then send a second Enter. This ensures Codex processes the input.
+4. **Codex has all tools.** Every MCP server, every skill, every CLI tool available in this environment. Tell agents to use them in the task prompt when relevant.
+
+---
+
+## Task Writing
+
+Every task sent to an agent must include four sections:
+
+### 1. What to Do
+Specific deliverables — files to create or modify, functions to implement, behavior to fix.
+
+### 2. Why
+Context, reasoning, tradeoffs. An agent picking this up cold should understand the full picture.
+
+### 3. Constraints
+Which files this agent owns. Which files are off-limits (owned by other agents). What NOT to do (no new dependencies, no refactoring unrelated code).
+
+### 4. Verification
+How to prove the work is correct. Test command, expected output, or specific behavior to observe.
+
+### Example
+
+Bad: "Fix auth"
+
+Good:
+```
+Fix JWT token refresh in src/auth/refresh.ts.
+
+The token is not refreshed when it expires during a long request. The interceptor
+in src/auth/interceptor.ts catches 401 responses but does not queue concurrent
+refresh attempts — parallel expired requests race.
+
+## What to Do
+1. Add a mutex to the refresh interceptor — only one refresh runs at a time.
+2. Queue other 401 responses to retry after the refresh completes.
+
+## Constraints
+- Only modify files in src/auth/.
+- Do NOT touch src/api/ — another agent owns those files.
+- Follow the error handling pattern in src/auth/login.ts.
+
+## Verification
+- Run `npm test -- --grep auth` — all tests pass.
+- Add a test for concurrent refresh (two 401s arriving simultaneously).
+```
+
+---
+
+## File Conflict Prevention
+
+**Your most critical coordination job.** All agents share one working tree. No git worktrees, no branches, no isolation. If two agents edit the same file, one silently overwrites the other.
+
+### Rules
+
+1. Before assigning any task, identify every file it will touch.
+2. Maintain a file ownership map: which agent owns which files right now.
+3. **Never assign overlapping files to parallel agents.**
+4. For shared files (types, config, constants), designate ONE agent as the owner. Other agents that need changes to a shared file send their request through you.
+5. When an agent finishes a task, release its file ownership before assigning new files.
+
+### File ownership tracking
+
+Keep this map updated with every assignment:
+
+```
+codex-1 owns: src/auth/refresh.ts, src/auth/interceptor.ts
+codex-2 owns: src/api/routes.ts, src/api/middleware.ts
+codex-3 owns: tests/auth.test.ts, tests/api.test.ts
+```
+
+---
+
+## Monitoring
+
+Check each agent every 2–3 minutes:
+
+```bash
+tmux capture-pane -t <paneId> -p -S -80 | tail -20
+```
+
+### Assess and act
+
+- **Working:** Agent is active, making progress. Do nothing.
+- **Done:** Agent shows idle prompt or reports completion. Verify, then assign next task immediately. Do not let agents sit idle.
+- **Stuck:** Same output for 5+ minutes. Resend the task with a different approach or more specific context.
+- **Dead:** Shell prompt visible (Codex exited). Relaunch and resend the current task.
+
+### Cron (for long sessions)
+
+For sessions with 4+ agents or extended work, set up a monitoring cron at 2-minute intervals:
+
+1. Capture output from each agent pane.
+2. Check task state: what is done, what is in progress, what is next.
+3. If any agent is idle and tasks remain, feed the next task.
+4. If any agent is stuck, intervene with more specific guidance.
+5. Report significant events to the user.
+
+---
+
+## Commit Cadence
+
+Commit after every meaningful batch of completed work. One bad edit by any agent can destroy hours of parallel output.
+
+```bash
+git add -A && git commit -m "<description>"
+```
+
+**Never let uncommitted work accumulate.** Commit after each batch of completed tasks — not at the end of the session.
+
+---
+
+## Task Assignment Strategy
+
+### Parallel (default)
+
+Assign independent tasks to all agents simultaneously. Independent means:
+- Different files
+- No dependency on each other's output
+- Can be verified independently
+
+### Sequential
+
+When task B depends on task A's output:
+1. Assign task A to one agent.
+2. Wait for completion and verification.
+3. Commit the result.
+4. Then assign task B (to any available agent).
+
+### Mixed
+
+Most real work is mixed. Maximize parallelism within dependency constraints. Two agents on independent features while a third waits for a shared dependency to be committed.
+
+---
+
+## Anti-Patterns
+
+| Don't | Why | Instead |
+|---|---|---|
+| Write code yourself | You are the CTO | Delegate ALL code to agents |
+| Assign same file to two agents | Silent overwrites, no isolation | One owner per file, always |
+| Give vague tasks | Vague results | Be specific: files, patterns, test commands |
+| Skip verification in tasks | Agent cannot self-check | Always include how to prove it worked |
+| Let agents sit idle | Wasted compute | Assign next task immediately |
+| Batch multiple tasks per agent | Agent loses focus | One task at a time, verify, then next |
+| Wait until end to commit | Risk losing hours of work | Commit after each completed batch |
+| Forget file ownership | Agents collide silently | Track and update ownership map |
+| Send tasks without constraints | Agent touches wrong files | Always specify what NOT to touch |
+| Ignore stuck agents | Burned compute | Check every 2–3 min, intervene early |
+| Restart agents for low context | Codex auto-compacts | Just resend the task if confused |

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -74,6 +74,7 @@ test("continue is not exposed as a user-facing command", () => {
   const commandFiles = fs.readdirSync(path.join(PLUGIN_ROOT, "commands")).sort();
   assert.deepEqual(commandFiles, [
     "adversarial-review.md",
+    "agent-team.md",
     "cancel.md",
     "rescue.md",
     "result.md",
@@ -193,6 +194,27 @@ test("hooks keep session-end cleanup and stop gating enabled", () => {
   assert.match(source, /SessionEnd/);
   assert.match(source, /stop-review-gate-hook\.mjs/);
   assert.match(source, /session-lifecycle-hook\.mjs/);
+});
+
+test("agent-team command spawns Codex agents in tmux split panes", () => {
+  const source = read("commands/agent-team.md");
+  const skill = read("skills/agent-team/SKILL.md");
+
+  assert.match(source, /tmux split panes/i);
+  assert.match(source, /codex --dangerously-bypass-approvals-and-sandbox/);
+  assert.match(source, /codex-companion\.mjs" agent-team --json \$ARGUMENTS/);
+  assert.match(source, /tmux send-keys/);
+  assert.match(source, /tmux capture-pane/);
+  assert.match(source, /agent-team-kill/);
+  assert.match(source, /allowed-tools:\s*Bash\(node:\*\)/);
+  assert.match(source, /one owner per file/i);
+  assert.match(source, /one task at a time per agent/i);
+  assert.match(skill, /user-invocable:\s*false/);
+  assert.match(skill, /tmux send-keys/);
+  assert.match(skill, /tmux capture-pane/);
+  assert.match(skill, /file conflict/i);
+  assert.match(skill, /one owner per file/i);
+  assert.match(skill, /codex auto-compacts/i);
 });
 
 test("setup command can offer Codex install and still points users to codex login", () => {


### PR DESCRIPTION
Spins up N Codex instances as visible tmux split panes so you can coordinate parallel work from a single Claude Code session. I built this because the existing agent-team pattern (Claude Code subagents) doesn't give you visibility into what each agent is doing. Tmux panes fix that: you can watch all of them work at once.

## What it does

`/codex:agent-team 3` creates a tmux layout with Claude Code in the left 30% and three Codex agents filling the right 70%. Each agent gets a colored border from an 8-color palette, a pane title visible in the border, and `codex --dangerously-bypass-approvals-and-sandbox` launched inside it. The script waits for boot (~8s) and sends a confirmation Enter so agents are ready for tasks immediately.

Layout follows the same split strategy as Claude Code's TmuxBackend: first agent takes 70% horizontal, additional agents alternate vertical and horizontal splits to keep things balanced.

![thisgif-compressed](https://github.com/user-attachments/assets/3f82e240-cc77-4293-bbae-8371a80b3d2c)


## Files

**New:**
- `scripts/lib/tmux-team.mjs` (pane creation, layout, send/capture/kill)
- `commands/agent-team.md` (command definition)
- `skills/agent-team/SKILL.md` (orchestration patterns for task writing, file ownership, and monitoring)

**Modified:**
- `codex-companion.mjs` (agent-team + agent-team-kill subcommands)
- `render.mjs` (renderAgentTeamResult)
- `tests/commands.test.mjs` (assertions for the new command and skill)

## Usage

```
/codex:agent-team 5
/codex:agent-team 3 --names alpha,bravo,charlie
```

## Testing

- `npm test` passes
- Manually spawned 3 agents, sent tasks, captured output, killed panes