### PR TITLE
feat: add --full-access flag for sandboxed execution (#145)

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -457,7 +457,7 @@ async function executeTaskRun(request) {
     defaultPrompt: resumeThreadId ? DEFAULT_CONTINUE_PROMPT : "",
     model: request.model,
     effort: request.effort,
-    sandbox: request.write ? "workspace-write" : "read-only",
+    sandbox: request.fullAccess ? "danger-full-access" : (request.write ? "workspace-write" : "read-only"),
     onProgress: request.onProgress,
     persistThread: true,
     threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
@@ -704,7 +704,7 @@ async function handleReview(argv) {
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["model", "effort", "cwd", "prompt-file"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
+    booleanOptions: ["json", "write", "full-access", "resume-last", "resume", "fresh", "background"],
     aliasMap: {
       m: "model"
     }


### PR DESCRIPTION
## Summary

Adds `--full-access` flag to the `codex-companion.mjs` task command mapping to `sandbox: "danger-full-access"`, enabling GPU/CUDA access for ML workflows.

## Changes

1. **booleanOptions**: Added `"full-access"` to the array
2. **executeTaskRun sandbox logic**: `sandbox: request.fullAccess ? "danger-full-access" : (request.write ? "workspace-write" : "read-only")`

## Motivation

Currently only `--write` (workspace-write) and default (read-only) sandboxes are available. Users running GPU/CUDA workloads must use `codex exec --dangerously-bypass-approvals-and-sandbox`. This change enables companion script usage for GPU workflows.

Fixes #145

*— 一筒 🦀*