### PR TITLE
fix: allow model invocation for adversarial-review command

### DIFF
--- a/plugins/codex/commands/adversarial-review.md
+++ b/plugins/codex/commands/adversarial-review.md
@@ -1,7 +1,6 @@
 ---
 description: Run a Codex review that challenges the implementation approach and design choices
 argument-hint: '[--wait|--background] [--base <ref>] [--scope auto|working-tree|branch] [focus ...]'
-disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---
 


### PR DESCRIPTION
## Summary

Removes `disable-model-invocation: true` from the `adversarial-review` command frontmatter.

## Motivation

The `disable-model-invocation` flag prevents skills from invoking `/codex:adversarial-review` via the Skill tool. When a skill tries to call it, Claude Code returns:

```
Skill codex:adversarial-review cannot be used with Skill tool due to disable-model-invocation
```

This blocks workflow composition — any skill or agent that wants to include an adversarial review as one step in a multi-step workflow cannot do so programmatically (example: [adversarial-dev-plugin](https://github.com/parthpm/adversarial-dev-plugin)). Users who build custom skills (e.g., a review-then-implement pipeline, a plan-and-validate loop, or a CI-like pre-merge check) hit this wall when they try to chain `/codex:adversarial-review` into their flow.

The flag was likely added because the command delegates to an external process (the companion script) rather than using Claude's model directly. But preventing programmatic invocation is a separate concern from preventing model invocation — the Skill tool just needs to run the command's prompt, which then runs the companion script via its `allowed-tools`.

## Why this is safe

The command already has two independent safety layers:
- **`allowed-tools`** restricts the tool set to `Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion` — no edit or write access.
- **Prompt instructions** enforce review-only behavior ("Do not fix issues, apply patches, or suggest that you are about to make changes").

The `disable-model-invocation` gate adds no additional safety beyond these — it only prevents orchestration by other skills.

## Test plan

- [x] `/codex:adversarial-review --wait "test"` still works when invoked directly from the prompt
- [x] A custom skill that calls `/codex:adversarial-review` via the Skill tool now succeeds instead of erroring
- [x] The command's review-only constraint remains enforced (no edits produced)