### PR TITLE
fix: inherit process.env in app-server spawn

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -188,7 +188,7 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
   async initialize() {
     this.proc = spawn("codex", ["app-server"], {
       cwd: this.cwd,
-      env: this.options.env,
+      env: this.options.env ?? process.env,
       stdio: ["pipe", "pipe", "pipe"],
       shell: process.platform === "win32",
       windowsHide: true


### PR DESCRIPTION
Fixes #160

## Summary

- `SpawnedCodexAppServerClient.initialize()` spawns `codex app-server` with `env: this.options.env`, but no caller ever passes `env` in options — so it's always `undefined`
- In Node.js, `spawn()` with `env: undefined` gives the child process **zero** environment variables, breaking any model provider configured via env vars (e.g. `DATABRICKS_TOKEN`, custom `env_key` in `~/.codex/config.toml`)
- Falls back to `process.env` when no explicit env is provided, matching the existing pattern in `broker-lifecycle.mjs` (line 146) and `codex-companion.mjs` (line 617)

## Test plan

- [ ] Configure a non-OpenAI model provider in `~/.codex/config.toml` that requires an env var (e.g. `env_key = "DATABRICKS_TOKEN"`)
- [ ] Set that env var in the shell
- [ ] Invoke `codex` through the Claude Code plugin and confirm it no longer errors with `Missing environment variable`
- [ ] Verify that explicitly passing `env` in options still takes precedence over `process.env`
