### PR TITLE
fix: handle EAGAIN in hook scripts when stdin is non-blocking

### DIFF
--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -42,7 +42,7 @@ function readHookInput() {
       if (eagainCount >= MAX_RETRIES) {
         // Gracefully degrade: session_id won't be set in CLAUDE_ENV_FILE,
         // but the hook succeeds instead of surfacing a startup error.
-        break;
+        return {};
       }
       eagainCount++;
       Atomics.wait(sleepBuf, 0, 0, RETRY_DELAY_MS);

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -39,7 +39,7 @@ function readHookInput() {
         throw err;
       }
       if (eagainCount >= MAX_RETRIES) {
-        break;
+        return {};
       }
       eagainCount++;
       Atomics.wait(sleepBuf, 0, 0, RETRY_DELAY_MS);


### PR DESCRIPTION
## Problem

Claude Code invokes hooks with stdin as a non-blocking pipe on macOS and Linux. This causes `fs.readFileSync(0)` in `readHookInput()` to throw `EAGAIN: resource temporarily unavailable`, making the hook exit with code 1. The result is a **`SessionStart:startup hook error`** banner shown on every session start.

Reported in #120.

## Root cause

```js
function readHookInput() {
  const raw = fs.readFileSync(0, "utf8").trim(); // throws EAGAIN on non-blocking stdin
  ...
}
```

## Fix

Retry `readFileSync` up to 20 times (200ms total) when `EAGAIN` is received, using `Atomics.wait` for synchronous sleeping. If all retries are exhausted, returns `{}` so the hook exits cleanly (graceful degradation) instead of surfacing a startup error.

```js
const MAX_RETRIES = 20;
const RETRY_DELAY_MS = 10;
const sleepBuf = new Int32Array(new SharedArrayBuffer(4));

for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
  try {
    const raw = fs.readFileSync(0, "utf8").trim();
    return raw ? JSON.parse(raw) : {};
  } catch (err) {
    if (err.code !== "EAGAIN") throw err;
    if (attempt === MAX_RETRIES) return {};
    Atomics.wait(sleepBuf, 0, 0, RETRY_DELAY_MS);
  }
}
```

Applied to both `session-lifecycle-hook.mjs` and `stop-review-gate-hook.mjs`.

## Relation to PR #123

PR #123 addresses the same issue with a more complex buffered approach. This PR offers a simpler implementation with the same intent.

Fixes #120