### PR TITLE
fix: quote $ARGUMENTS in cancel, result, and status commands

### DIFF
--- a/plugins/codex/commands/cancel.md
+++ b/plugins/codex/commands/cancel.md
@@ -5,4 +5,4 @@ disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 
-!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" cancel $ARGUMENTS`
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" cancel "$ARGUMENTS"`

--- a/plugins/codex/commands/result.md
+++ b/plugins/codex/commands/result.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 
-!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" result $ARGUMENTS`
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" result "$ARGUMENTS"`
 
 Present the full command output to the user. Do not summarize or condense it. Preserve all details including:
 - Job ID and status

--- a/plugins/codex/commands/status.md
+++ b/plugins/codex/commands/status.md
@@ -5,7 +5,7 @@ disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 
-!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" status $ARGUMENTS`
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" status "$ARGUMENTS"`
 
 If the user did not pass a job ID:
 - Render the command output as a single Markdown table for the current and past runs in this session.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`cancel.md`, `result.md`, and `status.md` all invoke `codex-companion.mjs` via a `!`-prefix shell command with an unquoted `$ARGUMENTS`:

```
!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" cancel $ARGUMENTS`
```

Because the shell expands `$ARGUMENTS` before Node receives it, a user-supplied job ID containing shell metacharacters (e.g., `task-123; malicious-cmd`) would be split by the shell and execute the trailing command.

## Why it matters

This is inconsistent with `review.md` and `adversarial-review.md`, which both correctly wrap the argument in double quotes:

```
node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" review "$ARGUMENTS"
```

The three simple `!`-prefix commands share this defect while the more complex Bash-code-block commands get it right.

## Fix

Wrap `$ARGUMENTS` in double quotes in all three affected commands:

```
!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" cancel "$ARGUMENTS"`
```

This matches the quoting style already used in `review.md` and `adversarial-review.md`.