### PR TITLE
fix: strip ANSI escape sequences from JSONL parsing

### DIFF
--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -8,6 +8,7 @@ import process from "node:process";
 import { parseArgs } from "./lib/args.mjs";
 import { BROKER_BUSY_RPC_CODE, CodexAppServerClient } from "./lib/app-server.mjs";
 import { parseBrokerEndpoint } from "./lib/broker-endpoint.mjs";
+import { stripAnsi } from "./lib/strings.mjs";
 
 const STREAMING_METHODS = new Set(["turn/start", "review/start", "thread/compact/start"]);
 
@@ -124,11 +125,12 @@ async function main() {
       buffer += chunk;
       let newlineIndex = buffer.indexOf("\n");
       while (newlineIndex !== -1) {
-        const line = buffer.slice(0, newlineIndex);
+        const rawLine = buffer.slice(0, newlineIndex);
         buffer = buffer.slice(newlineIndex + 1);
         newlineIndex = buffer.indexOf("\n");
 
-        if (!line.trim()) {
+        const line = stripAnsi(rawLine).trim();
+        if (!line) {
           continue;
         }
 

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -13,6 +13,7 @@ import process from "node:process";
 import { spawn } from "node:child_process";
 import readline from "node:readline";
 import { parseBrokerEndpoint } from "./broker-endpoint.mjs";
+import { stripAnsi } from "./strings.mjs";
 import { ensureBrokerSession } from "./broker-lifecycle.mjs";
 import { terminateProcessTree } from "./process.mjs";
 
@@ -114,8 +115,9 @@ class AppServerClientBase {
     }
   }
 
-  handleLine(line) {
-    if (!line.trim()) {
+  handleLine(rawLine) {
+    const line = stripAnsi(rawLine).trim();
+    if (!line) {
       return;
     }
 

--- a/plugins/codex/scripts/lib/strings.mjs
+++ b/plugins/codex/scripts/lib/strings.mjs
@@ -1,0 +1,20 @@
+/**
+ * Strip ANSI escape sequences from a string.
+ *
+ * Terminals (and shells like zsh/bash) may emit control sequences such as
+ * bracketed-paste-mode markers (`\e[?2004h`) into subprocess stdout.  When
+ * the JSONL protocol reader encounters these bytes it fails to parse the
+ * line as JSON.  Stripping them before `JSON.parse()` makes the protocol
+ * resilient to noisy terminal environments.
+ *
+ * Covers:
+ *  - CSI sequences   \x1b[ … <letter>        (e.g. \x1b[?2004h, \x1b[0m)
+ *  - OSC sequences   \x1b] … <BEL|ST>        (e.g. window-title sets)
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function stripAnsi(text) {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "");
+}

--- a/tests/strings.test.mjs
+++ b/tests/strings.test.mjs
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { stripAnsi } from "../plugins/codex/scripts/lib/strings.mjs";
+
+test("stripAnsi removes bracketed paste mode sequences", () => {
+  assert.equal(stripAnsi('\x1b[?2004h{"id":1}'), '{"id":1}');
+  assert.equal(stripAnsi('{"id":1}\x1b[?2004l'), '{"id":1}');
+});
+
+test("stripAnsi removes SGR color codes", () => {
+  assert.equal(stripAnsi('\x1b[0m{"id":1}\x1b[1;31m'), '{"id":1}');
+});
+
+test("stripAnsi removes OSC sequences (BEL terminated)", () => {
+  assert.equal(stripAnsi('\x1b]0;title\x07{"id":1}'), '{"id":1}');
+});
+
+test("stripAnsi removes OSC sequences (ST terminated)", () => {
+  assert.equal(stripAnsi('\x1b]0;title\x1b\\{"id":1}'), '{"id":1}');
+});
+
+test("stripAnsi passes through clean JSON unchanged", () => {
+  const json = '{"jsonrpc":"2.0","id":1,"method":"initialize"}';
+  assert.equal(stripAnsi(json), json);
+});
+
+test("stripAnsi handles empty string", () => {
+  assert.equal(stripAnsi(""), "");
+});
+
+test("stripAnsi handles multiple escape sequences in one line", () => {
+  assert.equal(
+    stripAnsi('\x1b[?2004h\x1b[0m{"id":1}\x1b[?2004l'),
+    '{"id":1}'
+  );
+});


### PR DESCRIPTION
## Summary

- Adds `stripAnsi()` utility (`plugins/codex/scripts/lib/strings.mjs`) that removes CSI and OSC terminal escape sequences
- Applies stripping in both JSONL parsing paths before `JSON.parse()`:
  - `app-server.mjs` — `handleLine()` (readline-based client)
  - `app-server-broker.mjs` — socket `data` handler (broker multiplexer)
- Adds 7 unit tests covering bracketed paste mode, SGR codes, OSC sequences, clean passthrough, and edge cases

## Problem

Shells like zsh emit `\e[?2004h` (bracketed paste mode) during initialization. When Codex CLI is spawned as a subprocess, these escape sequences leak into stdout. The JSONL protocol reader then fails:

```
Failed to parse codex app-server JSONL: Unexpected token '', "[?2004h" is not valid JSON
```

This makes `/codex:review` and `/codex:adversarial-review` unusable for users with default zsh/bash configurations.

## Test plan

- [x] All 7 new `strings.test.mjs` tests pass
- [x] All 66 existing tests still pass (73 total, 0 failures)
- [ ] Manual verification: run `/codex:review` in Claude Code with zsh default shell

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)