### PR TITLE
fix(runtime): prevent tracked jobs hanging forever on broker disconnect

### DIFF
--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -70,6 +70,7 @@ async function main() {
   let activeStreamSocket = null;
   let activeStreamThreadIds = null;
   const sockets = new Set();
+  let shuttingDown = false;
 
   function clearSocketOwnership(socket) {
     if (activeRequestSocket === socket) {
@@ -100,7 +101,25 @@ async function main() {
   }
 
   async function shutdown(server) {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    // Notify any client whose request is still in flight that the broker is
+    // going down. Without this they would hang on a half-open socket waiting
+    // for a response that will never arrive.
+    const fanoutMessage = {
+      method: "notifications/broker/shuttingDown",
+      params: {
+        reason: appClient.exitError ? String(appClient.exitError.message ?? appClient.exitError) : "broker shutdown"
+      }
+    };
     for (const socket of sockets) {
+      try {
+        send(socket, fanoutMessage);
+      } catch {
+        // Best-effort fanout. Continue tearing down.
+      }
       socket.end();
     }
     await appClient.close().catch(() => {});
@@ -114,6 +133,21 @@ async function main() {
   }
 
   appClient.setNotificationHandler(routeNotification);
+
+  // If the underlying codex CLI app-server dies (crashes, OOM, exits), tear
+  // down the broker rather than zombify with a dead client. The next companion
+  // process will detect a dead endpoint via ensureBrokerSession and respawn.
+  // See: openai/codex-plugin-cc#183.
+  appClient.exitPromise.then(() => {
+    if (shuttingDown) {
+      return;
+    }
+    const detail = appClient.exitError instanceof Error ? appClient.exitError.message : String(appClient.exitError ?? "unknown");
+    process.stderr.write(`[broker] underlying codex app-server exited: ${detail}\n`);
+    shutdown(server)
+      .catch(() => {})
+      .finally(() => process.exit(1));
+  });
 
   const server = net.createServer((socket) => {
     sockets.add(socket);

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -597,7 +597,37 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
       completeTurn(state, response.turn);
     }
 
-    return await state.completion;
+    // Race the turn completion against the client's exit promise so that if
+    // the underlying codex app-server (or broker socket) dies mid-turn, we
+    // reject instead of hanging forever waiting for a terminal event that
+    // will never arrive. See: openai/codex-plugin-cc#183.
+    const exitWatch = client.exitPromise.then(() => {
+      if (state.completed) {
+        return;
+      }
+      const reason =
+        client.exitError instanceof Error
+          ? client.exitError
+          : new Error(
+              client.exitError
+                ? String(client.exitError)
+                : "codex app-server connection closed before the turn completed."
+            );
+      emitProgress(
+        state.onProgress,
+        `Codex app-server disconnected mid-turn: ${reason.message}`,
+        "failed"
+      );
+      state.rejectCompletion(reason);
+    });
+
+    try {
+      return await state.completion;
+    } finally {
+      // Detach the exit watcher so its rejection (if any) does not surface
+      // as an unhandled rejection after we have already settled the turn.
+      exitWatch.catch(() => {});
+    }
   } finally {
     clearCompletionTimer(state);
     client.setNotificationHandler(previousHandler ?? null);

--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -48,12 +48,17 @@ export function markDeadPidJobFailed(workspaceRoot, jobId, pid) {
   const completedAt = new Date().toISOString();
   const errorMessage = `Tracked process PID ${pid} exited unexpectedly without writing a terminal status.`;
 
+  // writeJobFile is a raw write; bump updatedAt explicitly so that a re-sort
+  // after reconciliation moves the freshly-failed job to the front of the
+  // newest-first list (otherwise it stays in its pre-reconciliation slot and
+  // can be dropped by the maxJobs slice in buildStatusSnapshot).
   const failedPatch = {
     status: "failed",
     phase: "failed",
     pid: null,
     errorMessage,
-    completedAt
+    completedAt,
+    updatedAt: completedAt
   };
 
   writeJobFile(workspaceRoot, jobId, {
@@ -311,8 +316,11 @@ export function buildStatusSnapshot(cwd, options = {}) {
   const config = getConfig(workspaceRoot);
   const rawJobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot), options));
   // Reconcile any active jobs whose tracked PID is dead before partitioning,
-  // so a single status read surfaces stuck workers immediately.
-  const jobs = rawJobs.map((job) => reconcileIfDead(workspaceRoot, job));
+  // so a single status read surfaces stuck workers immediately. Re-sort after
+  // reconciliation because markDeadPidJobFailed bumps updatedAt to now, which
+  // means a stale `running` job that lived near the end of the pre-sort list
+  // must move to the front to survive the maxJobs slice below.
+  const jobs = sortJobsNewestFirst(rawJobs.map((job) => reconcileIfDead(workspaceRoot, job)));
   const maxJobs = options.maxJobs ?? DEFAULT_MAX_STATUS_JOBS;
   const maxProgressLines = options.maxProgressLines ?? DEFAULT_MAX_PROGRESS_LINES;
 

--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -1,12 +1,108 @@
 import fs from "node:fs";
 
 import { getSessionRuntimeStatus } from "./codex.mjs";
-import { getConfig, listJobs, readJobFile, resolveJobFile } from "./state.mjs";
+import { getConfig, listJobs, readJobFile, resolveJobFile, upsertJob, writeJobFile } from "./state.mjs";
+import { isProcessAlive } from "./process.mjs";
 import { SESSION_ID_ENV } from "./tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./workspace.mjs";
 
 export const DEFAULT_MAX_STATUS_JOBS = 8;
 export const DEFAULT_MAX_PROGRESS_LINES = 4;
+
+function isActiveJobStatus(status) {
+  return status === "queued" || status === "running";
+}
+
+/**
+ * Marks a job as failed when its tracked process has died unexpectedly.
+ * Re-reads the latest persisted state from disk before writing to guard
+ * against races where the job completes legitimately at the same moment.
+ *
+ * @param {string} workspaceRoot
+ * @param {string} jobId
+ * @param {number} pid - The PID we observed as dead
+ * @returns {boolean} true if the job was reconciled, false if skipped
+ */
+export function markDeadPidJobFailed(workspaceRoot, jobId, pid) {
+  const jobFile = resolveJobFile(workspaceRoot, jobId);
+
+  let latestJob;
+  try {
+    latestJob = readJobFile(jobFile);
+  } catch {
+    return false;
+  }
+
+  // Only overwrite active states; never downgrade completed/failed/cancelled.
+  if (!isActiveJobStatus(latestJob.status)) {
+    return false;
+  }
+
+  // Only overwrite if the PID still matches what we observed as dead. This
+  // guards against a job that legitimately restarted with a new PID between
+  // our liveness probe and the write.
+  if (latestJob.pid !== pid) {
+    return false;
+  }
+
+  const completedAt = new Date().toISOString();
+  const errorMessage = `Tracked process PID ${pid} exited unexpectedly without writing a terminal status.`;
+
+  const failedPatch = {
+    status: "failed",
+    phase: "failed",
+    pid: null,
+    errorMessage,
+    completedAt
+  };
+
+  writeJobFile(workspaceRoot, jobId, {
+    ...latestJob,
+    ...failedPatch
+  });
+
+  upsertJob(workspaceRoot, {
+    id: jobId,
+    ...failedPatch
+  });
+
+  return true;
+}
+
+/**
+ * If a job is still marked active but its tracked PID is dead, reconcile it
+ * to failed and return the updated record. Otherwise return the original.
+ *
+ * Called from every status read path so a single status query is enough to
+ * surface dead workers - no need to wait for a polling watcher.
+ *
+ * @param {string} workspaceRoot
+ * @param {object} job
+ * @returns {object}
+ */
+function reconcileIfDead(workspaceRoot, job) {
+  if (!job || !isActiveJobStatus(job.status)) {
+    return job;
+  }
+  const pid = Number.isFinite(job.pid) ? job.pid : null;
+  if (pid === null) {
+    return job;
+  }
+  if (isProcessAlive(pid)) {
+    return job;
+  }
+
+  try {
+    markDeadPidJobFailed(workspaceRoot, job.id, pid);
+  } catch {
+    // Never let reconciliation errors crash a status read.
+    return job;
+  }
+
+  // Re-read so the caller sees the reconciled fields.
+  const refreshed = readStoredJob(workspaceRoot, job.id);
+  return refreshed ? { ...job, ...refreshed } : job;
+}
 
 export function sortJobsNewestFirst(jobs) {
   return [...jobs].sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")));
@@ -213,19 +309,22 @@ function matchJobReference(jobs, reference, predicate = () => true) {
 export function buildStatusSnapshot(cwd, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const config = getConfig(workspaceRoot);
-  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot), options));
+  const rawJobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot), options));
+  // Reconcile any active jobs whose tracked PID is dead before partitioning,
+  // so a single status read surfaces stuck workers immediately.
+  const jobs = rawJobs.map((job) => reconcileIfDead(workspaceRoot, job));
   const maxJobs = options.maxJobs ?? DEFAULT_MAX_STATUS_JOBS;
   const maxProgressLines = options.maxProgressLines ?? DEFAULT_MAX_PROGRESS_LINES;
 
   const running = jobs
-    .filter((job) => job.status === "queued" || job.status === "running")
+    .filter((job) => isActiveJobStatus(job.status))
     .map((job) => enrichJob(job, { maxProgressLines }));
 
-  const latestFinishedRaw = jobs.find((job) => job.status !== "queued" && job.status !== "running") ?? null;
+  const latestFinishedRaw = jobs.find((job) => !isActiveJobStatus(job.status)) ?? null;
   const latestFinished = latestFinishedRaw ? enrichJob(latestFinishedRaw, { maxProgressLines }) : null;
 
   const recent = (options.all ? jobs : jobs.slice(0, maxJobs))
-    .filter((job) => job.status !== "queued" && job.status !== "running" && job.id !== latestFinished?.id)
+    .filter((job) => !isActiveJobStatus(job.status) && job.id !== latestFinished?.id)
     .map((job) => enrichJob(job, { maxProgressLines }));
 
   return {
@@ -247,9 +346,11 @@ export function buildSingleJobSnapshot(cwd, reference, options = {}) {
     throw new Error(`No job found for "${reference}". Run /codex:status to inspect known jobs.`);
   }
 
+  const reconciled = reconcileIfDead(workspaceRoot, selected);
+
   return {
     workspaceRoot,
-    job: enrichJob(selected, { maxProgressLines: options.maxProgressLines })
+    job: enrichJob(reconciled, { maxProgressLines: options.maxProgressLines })
   };
 }
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -54,6 +54,26 @@ function looksLikeMissingProcessMessage(text) {
   return /not found|no running instance|cannot find|does not exist|no such process/i.test(text);
 }
 
+/**
+ * Checks whether a process with the given PID is still running.
+ * Uses signal 0 which does not affect the process - it only checks existence.
+ *
+ * @param {number | null | undefined} pid
+ * @returns {boolean}
+ */
+export function isProcessAlive(pid) {
+  if (pid == null || !Number.isFinite(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // ESRCH = no such process (dead). EPERM = exists but no signal permission.
+    return error?.code === "EPERM";
+  }
+}
+
 export function terminateProcessTree(pid, options = {}) {
   if (!Number.isFinite(pid)) {
     return { attempted: false, delivered: false, method: null };

--- a/plugins/codex/scripts/lib/tracked-jobs.mjs
+++ b/plugins/codex/scripts/lib/tracked-jobs.mjs
@@ -5,6 +5,22 @@ import { readJobFile, resolveJobFile, resolveJobLogFile, upsertJob, writeJobFile
 
 export const SESSION_ID_ENV = "CODEX_COMPANION_SESSION_ID";
 
+// Hard ceiling for any single tracked job. Default 30 minutes is generous
+// enough for long Codex turns but bounded so a hung captureTurn cannot keep
+// the companion process alive forever. Override via CODEX_COMPANION_JOB_TIMEOUT_MS.
+const DEFAULT_JOB_TIMEOUT_MS = 30 * 60 * 1000;
+
+function resolveJobTimeoutMs(options = {}) {
+  if (Number.isFinite(options.timeoutMs) && options.timeoutMs > 0) {
+    return options.timeoutMs;
+  }
+  const fromEnv = Number(process.env.CODEX_COMPANION_JOB_TIMEOUT_MS);
+  if (Number.isFinite(fromEnv) && fromEnv > 0) {
+    return fromEnv;
+  }
+  return DEFAULT_JOB_TIMEOUT_MS;
+}
+
 export function nowIso() {
   return new Date().toISOString();
 }
@@ -151,8 +167,30 @@ export async function runTrackedJob(job, runner, options = {}) {
   writeJobFile(job.workspaceRoot, job.id, runningRecord);
   upsertJob(job.workspaceRoot, runningRecord);
 
+  // Race the runner against a hard timeout. If captureTurn or any other
+  // long-poll inside the runner hangs (e.g. underlying app-server died and
+  // never produced a terminal event), this guarantees the companion exits
+  // and the job transitions to a terminal status. See: openai/codex-plugin-cc#183.
+  const timeoutMs = resolveJobTimeoutMs(options);
+  let timeoutHandle = null;
+  const timeoutPromise = new Promise((_resolve, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(
+        new Error(
+          `Tracked job ${job.id} exceeded the ${Math.round(timeoutMs / 1000)}s hard timeout. ` +
+            "The runner did not produce a terminal status. Set CODEX_COMPANION_JOB_TIMEOUT_MS to adjust."
+        )
+      );
+    }, timeoutMs);
+    timeoutHandle.unref?.();
+  });
+
   try {
-    const execution = await runner();
+    const execution = await Promise.race([runner(), timeoutPromise]);
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+      timeoutHandle = null;
+    }
     const completionStatus = execution.exitStatus === 0 ? "completed" : "failed";
     const completedAt = nowIso();
     writeJobFile(job.workspaceRoot, job.id, {
@@ -179,6 +217,10 @@ export async function runTrackedJob(job, runner, options = {}) {
     appendLogBlock(options.logFile ?? job.logFile ?? null, "Final output", execution.rendered);
     return execution;
   } catch (error) {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+      timeoutHandle = null;
+    }
     const errorMessage = error instanceof Error ? error.message : String(error);
     const existing = readStoredJobOrNull(job.workspaceRoot, job.id) ?? runningRecord;
     const completedAt = nowIso();

--- a/tests/dead-pid-reconcile.test.mjs
+++ b/tests/dead-pid-reconcile.test.mjs
@@ -1,0 +1,133 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { makeTempDir } from "./helpers.mjs";
+import {
+  buildSingleJobSnapshot,
+  buildStatusSnapshot,
+  markDeadPidJobFailed
+} from "../plugins/codex/scripts/lib/job-control.mjs";
+import { ensureStateDir, upsertJob, writeJobFile } from "../plugins/codex/scripts/lib/state.mjs";
+
+// Pick a PID that is virtually guaranteed to be dead. PID 999999 is well above
+// the default macOS/Linux pid_max for short-lived workloads.
+const DEAD_PID = 999_999;
+
+// Stamp test jobs with the inherited session id (if any) so they survive
+// filterJobsForCurrentSession when running under Claude Code's harness.
+const TEST_SESSION_ID = process.env.CODEX_COMPANION_SESSION_ID ?? null;
+
+function seedRunningJobWithDeadPid(workspace, jobId, pid = DEAD_PID) {
+  ensureStateDir(workspace);
+  const record = {
+    id: jobId,
+    kind: "task",
+    kindLabel: "rescue",
+    title: "Codex Task",
+    workspaceRoot: workspace,
+    jobClass: "task",
+    summary: "test job",
+    write: false,
+    createdAt: new Date(Date.now() - 60_000).toISOString(),
+    startedAt: new Date(Date.now() - 60_000).toISOString(),
+    updatedAt: new Date(Date.now() - 60_000).toISOString(),
+    status: "running",
+    phase: "running",
+    pid,
+    logFile: null,
+    ...(TEST_SESSION_ID ? { sessionId: TEST_SESSION_ID } : {})
+  };
+  writeJobFile(workspace, jobId, record);
+  upsertJob(workspace, record);
+}
+
+test("markDeadPidJobFailed transitions a running job to failed", () => {
+  const workspace = makeTempDir();
+  seedRunningJobWithDeadPid(workspace, "task-deadpid-1");
+
+  const reconciled = markDeadPidJobFailed(workspace, "task-deadpid-1", DEAD_PID);
+  assert.equal(reconciled, true);
+
+  const snapshot = buildSingleJobSnapshot(workspace, "task-deadpid-1");
+  assert.equal(snapshot.job.status, "failed");
+  assert.equal(snapshot.job.phase, "failed");
+  assert.equal(snapshot.job.pid, null);
+  assert.match(snapshot.job.errorMessage ?? "", /exited unexpectedly/);
+});
+
+test("markDeadPidJobFailed is a no-op when the job already finished", () => {
+  const workspace = makeTempDir();
+  ensureStateDir(workspace);
+  const finishedRecord = {
+    id: "task-finished",
+    kind: "task",
+    kindLabel: "rescue",
+    title: "Codex Task",
+    workspaceRoot: workspace,
+    jobClass: "task",
+    summary: "test job",
+    createdAt: new Date().toISOString(),
+    startedAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    completedAt: new Date().toISOString(),
+    status: "completed",
+    phase: "done",
+    pid: null,
+    ...(TEST_SESSION_ID ? { sessionId: TEST_SESSION_ID } : {})
+  };
+  writeJobFile(workspace, "task-finished", finishedRecord);
+  upsertJob(workspace, finishedRecord);
+
+  const reconciled = markDeadPidJobFailed(workspace, "task-finished", DEAD_PID);
+  assert.equal(reconciled, false);
+
+  const snapshot = buildSingleJobSnapshot(workspace, "task-finished");
+  assert.equal(snapshot.job.status, "completed");
+});
+
+test("markDeadPidJobFailed refuses to overwrite a job whose PID has rotated", () => {
+  const workspace = makeTempDir();
+  // Use the current process PID so the job's stored PID is alive and the
+  // snapshot reconciler does not interfere with what we are testing here.
+  seedRunningJobWithDeadPid(workspace, "task-rotated", process.pid);
+
+  // Caller saw 999999 as dead, but the job is now tracking a different PID.
+  const reconciled = markDeadPidJobFailed(workspace, "task-rotated", DEAD_PID);
+  assert.equal(reconciled, false);
+
+  const snapshot = buildSingleJobSnapshot(workspace, "task-rotated");
+  assert.equal(snapshot.job.status, "running");
+});
+
+test("buildSingleJobSnapshot reconciles a running job with a dead PID without --wait", () => {
+  const workspace = makeTempDir();
+  seedRunningJobWithDeadPid(workspace, "task-snapshot-dead");
+
+  const snapshot = buildSingleJobSnapshot(workspace, "task-snapshot-dead");
+  assert.equal(snapshot.job.status, "failed");
+  assert.equal(snapshot.job.phase, "failed");
+  assert.match(snapshot.job.errorMessage ?? "", /exited unexpectedly/);
+});
+
+test("buildStatusSnapshot moves dead-pid jobs out of the running list", () => {
+  const workspace = makeTempDir();
+  seedRunningJobWithDeadPid(workspace, "task-status-dead");
+
+  // Pass an env without a session id so filterJobsForCurrentSession does not
+  // exclude our seeded jobs (the test runner inherits CODEX_COMPANION_SESSION_ID
+  // from Claude Code).
+  const snapshot = buildStatusSnapshot(workspace, { env: {} });
+  assert.equal(snapshot.running.length, 0);
+  assert.equal(snapshot.latestFinished?.id, "task-status-dead");
+  assert.equal(snapshot.latestFinished?.status, "failed");
+});
+
+test("buildStatusSnapshot leaves a running job alone when its PID is alive", () => {
+  const workspace = makeTempDir();
+  seedRunningJobWithDeadPid(workspace, "task-status-alive", process.pid);
+
+  const snapshot = buildStatusSnapshot(workspace, { env: {} });
+  assert.equal(snapshot.running.length, 1);
+  assert.equal(snapshot.running[0].id, "task-status-alive");
+  assert.equal(snapshot.running[0].status, "running");
+});

--- a/tests/dead-pid-reconcile.test.mjs
+++ b/tests/dead-pid-reconcile.test.mjs
@@ -131,3 +131,66 @@ test("buildStatusSnapshot leaves a running job alone when its PID is alive", () 
   assert.equal(snapshot.running[0].id, "task-status-alive");
   assert.equal(snapshot.running[0].status, "running");
 });
+
+test("buildStatusSnapshot surfaces a reconciled dead-pid job even when newer completed jobs would push it past maxJobs", () => {
+  const workspace = makeTempDir();
+  ensureStateDir(workspace);
+
+  // Seed a stale running job whose updatedAt is older than every other entry.
+  // After reconciliation its updatedAt is bumped to now, so without a re-sort
+  // it would keep its old position at the tail of the list and disappear under
+  // the maxJobs slice. This is the codex bot's exact PR184 scenario.
+  const oldIso = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const staleRunning = {
+    id: "task-stale-running",
+    kind: "task",
+    kindLabel: "rescue",
+    title: "Codex Task",
+    workspaceRoot: workspace,
+    jobClass: "task",
+    summary: "stale",
+    createdAt: oldIso,
+    startedAt: oldIso,
+    updatedAt: oldIso,
+    status: "running",
+    phase: "running",
+    pid: DEAD_PID,
+    logFile: null,
+    ...(TEST_SESSION_ID ? { sessionId: TEST_SESSION_ID } : {})
+  };
+  writeJobFile(workspace, staleRunning.id, staleRunning);
+  upsertJob(workspace, staleRunning);
+
+  // Add 10 newer completed jobs, all with timestamps after the stale one.
+  for (let i = 0; i < 10; i += 1) {
+    const completedAt = new Date(Date.now() - (10 - i) * 60_000).toISOString();
+    const completed = {
+      id: `task-completed-${i}`,
+      kind: "task",
+      kindLabel: "rescue",
+      title: "Codex Task",
+      workspaceRoot: workspace,
+      jobClass: "task",
+      summary: `completed-${i}`,
+      createdAt: completedAt,
+      startedAt: completedAt,
+      updatedAt: completedAt,
+      completedAt,
+      status: "completed",
+      phase: "done",
+      pid: null,
+      logFile: null,
+      ...(TEST_SESSION_ID ? { sessionId: TEST_SESSION_ID } : {})
+    };
+    writeJobFile(workspace, completed.id, completed);
+    upsertJob(workspace, completed);
+  }
+
+  const snapshot = buildStatusSnapshot(workspace, { env: {}, maxJobs: 8 });
+  assert.equal(snapshot.running.length, 0, "reconciled dead job must leave the running list");
+
+  const surfaced =
+    snapshot.latestFinished?.id === "task-stale-running" ||
+    snapshot.recent.some((job) => job.id === "task-stale-running");
+  assert.ok(surfaced, "reconciled dead job must appear in latestFinished or recent");
+});

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -1,7 +1,30 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 
-import { terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+import { isProcessAlive, terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+
+test("isProcessAlive returns false for null and invalid pids", () => {
+  assert.equal(isProcessAlive(null), false);
+  assert.equal(isProcessAlive(undefined), false);
+  assert.equal(isProcessAlive(0), false);
+  assert.equal(isProcessAlive(-5), false);
+  assert.equal(isProcessAlive(Number.NaN), false);
+  assert.equal(isProcessAlive("123"), false);
+});
+
+test("isProcessAlive returns true for the current process", () => {
+  assert.equal(isProcessAlive(process.pid), true);
+});
+
+test("isProcessAlive returns false after a child has exited", async () => {
+  const child = spawn(process.execPath, ["-e", "process.exit(0)"], { stdio: "ignore" });
+  const pid = child.pid;
+  await new Promise((resolve) => child.on("exit", resolve));
+  // Give the kernel a moment to fully reap the entry on Linux/macOS.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  assert.equal(isProcessAlive(pid), false);
+});
 
 test("terminateProcessTree uses taskkill on Windows", () => {
   let captured = null;

--- a/tests/tracked-jobs-timeout.test.mjs
+++ b/tests/tracked-jobs-timeout.test.mjs
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { makeTempDir } from "./helpers.mjs";
+import { runTrackedJob } from "../plugins/codex/scripts/lib/tracked-jobs.mjs";
+import { listJobs } from "../plugins/codex/scripts/lib/state.mjs";
+
+test("runTrackedJob enforces a hard timeout when the runner hangs", async () => {
+  const workspace = makeTempDir();
+  const job = {
+    id: "task-hang-1",
+    kind: "task",
+    kindLabel: "rescue",
+    title: "Hung Task",
+    workspaceRoot: workspace,
+    jobClass: "task",
+    summary: "test job",
+    write: false,
+    createdAt: new Date().toISOString()
+  };
+
+  // Hold the event loop open with a ref'd timer for the duration of this test.
+  // The production timeout uses unref so it does not keep the process alive
+  // when paired with a real long-running runner; in the test the hanging
+  // runner has nothing keeping the loop alive on its own.
+  const keepAlive = setInterval(() => {}, 1_000);
+
+  let resolveRunner;
+  const hangingRunner = () =>
+    new Promise((resolve) => {
+      resolveRunner = resolve;
+    });
+
+  try {
+    await assert.rejects(
+      () => runTrackedJob(job, hangingRunner, { timeoutMs: 50 }),
+      /exceeded the .+ hard timeout/
+    );
+
+    const jobs = listJobs(workspace);
+    const stored = jobs.find((entry) => entry.id === "task-hang-1");
+    assert.ok(stored, "expected the hung job to be persisted");
+    assert.equal(stored.status, "failed");
+    assert.equal(stored.phase, "failed");
+    assert.equal(stored.pid, null);
+    assert.match(stored.errorMessage ?? "", /hard timeout/);
+  } finally {
+    // Drain the leaked runner promise and free the event loop.
+    resolveRunner?.({ exitStatus: 1, payload: null, rendered: "", summary: "drained" });
+    clearInterval(keepAlive);
+  }
+});
+
+test("runTrackedJob still records a normal completion when the runner settles in time", async () => {
+  const workspace = makeTempDir();
+  const job = {
+    id: "task-ok-1",
+    kind: "task",
+    kindLabel: "rescue",
+    title: "Quick Task",
+    workspaceRoot: workspace,
+    jobClass: "task",
+    summary: "test job",
+    write: false,
+    createdAt: new Date().toISOString()
+  };
+
+  const result = await runTrackedJob(
+    job,
+    () =>
+      Promise.resolve({
+        exitStatus: 0,
+        threadId: "thread-1",
+        turnId: "turn-1",
+        payload: { ok: true },
+        rendered: "ok",
+        summary: "summary"
+      }),
+    { timeoutMs: 5_000 }
+  );
+
+  assert.equal(result.exitStatus, 0);
+  const jobs = listJobs(workspace);
+  const stored = jobs.find((entry) => entry.id === "task-ok-1");
+  assert.equal(stored.status, "completed");
+  assert.equal(stored.phase, "done");
+  assert.equal(stored.pid, null);
+});


### PR DESCRIPTION
## Summary

A Codex task can become stuck in `status: running` indefinitely with no way to recover short of manually wiping the job-store and broker session. The user-visible symptom is that `/codex:status` keeps reporting a job as running for many minutes after the underlying codex CLI worker has died, and the next `/codex:cancel` reports `ECONNREFUSED` on the broker socket. This PR fixes four independent root causes that combine to produce the wedge.

Closes #183. Refs #176, #164.

## Reproduction

Run any moderately heavy task that exercises the broker for ~3-5 minutes. In my case it was a Codex review of a ~4,500-line markdown corpus. After the codex CLI processed several `nl`/`jq`/`rg` shell commands and started reasoning about the result, the worker fell silent. The job-store kept reporting `phase: running` for 9+ minutes with no log progress. `/codex:cancel` returned `ECONNREFUSED /var/folders/.../cxc-XXXXXX/broker.sock`. Both the companion PID and the broker PID were dead by the time I cancelled.

## Root causes

1. **`captureTurn` hangs forever on disconnection.** `lib/codex.mjs` awaits `state.completion` with no race against the client's `exitPromise`. When the underlying codex app-server (or the broker socket) dies mid-turn, no terminal event is delivered, so the await never resolves. Pending RPC requests are rejected by `handleExit` but the turn-completion promise is unrelated to those, so it sits forever.

2. **`runTrackedJob` has no timeout fallback.** `lib/tracked-jobs.mjs` awaits the runner without a timeout. When `captureTurn` hangs, the entire companion process hangs and the per-job state file is never transitioned to a terminal status.

3. **The broker zombifies on app-server death.** `app-server-broker.mjs` never listens for the underlying app-server client's exit. When the codex CLI process dies, the broker keeps running with a dead client, accepting new connections but unable to serve them. The next companion sees a stale `broker.json` that points at a half-dead broker.

4. **Status reads do not probe PID liveness.** `buildStatusSnapshot` and `buildSingleJobSnapshot` never check whether tracked PIDs are still alive. Once a job is wedged, every `/codex:status` query reports it as running.

## Fixes

- **`captureTurn` races against client exit (lib/codex.mjs).** A new `exitWatch` promise rejects `state.completion` with the recorded exit error when the client closes before a terminal event arrives. Progress emits a `failed` notification so the user sees what happened.

- **`runTrackedJob` enforces a hard timeout (lib/tracked-jobs.mjs).** Default 30 minutes, override via `CODEX_COMPANION_JOB_TIMEOUT_MS` env var or the `timeoutMs` option. On timeout the job transitions to `failed` with a clear error message instead of leaving the companion stuck.

- **Broker subscribes to appClient exit (app-server-broker.mjs).** When the underlying codex CLI exits unexpectedly the broker logs the reason, fans out a `notifications/broker/shuttingDown` event to any connected socket, tears down the unix socket and pid file, then exits with status 1. The next companion will detect a dead endpoint via `ensureBrokerSession` and respawn cleanly.

- **`isProcessAlive` helper (lib/process.mjs).** Uses `kill(pid, 0)` to probe pid liveness without affecting the process.

- **`markDeadPidJobFailed` + `reconcileIfDead` (lib/job-control.mjs).** Reconcile any active job whose tracked PID is gone. Reconciliation runs on every status read path now, not only the `--wait` polling loop, so a single `/codex:status` call surfaces dead workers immediately. This is broader than #176, which only reconciled inside `waitForSingleJobSnapshot`.

## Relationship to existing PRs/issues

- **#183** (runTrackedJob/captureTurn hang in finalizing) — fully addressed by the captureTurn race + the hard timeout.
- **#176** (Fix stuck running jobs by detecting dead review/task PIDs) — this PR includes equivalent dead-PID detection but also reconciles on every status read, not only `status --wait`. If #176 lands first, the overlap is small (the helper functions and a couple of import lines).
- **#164** (Review jobs stuck in 'running' after process death) — also addressed.

## Test plan

- New unit tests (11 cases, all pass):
  - `tests/process.test.mjs` — 3 new cases for `isProcessAlive` (invalid input, current pid, exited child).
  - `tests/dead-pid-reconcile.test.mjs` — 6 new cases covering `markDeadPidJobFailed` guards and reconcile-on-status for both single-job and full snapshots.
  - `tests/tracked-jobs-timeout.test.mjs` — 2 new cases proving the hard timeout transitions a hung job to `failed` and that fast runners still complete normally.
- Full suite: `node --test tests/*.test.mjs` → 91 pass, 5 fail. The 5 failures (`collectReviewContext skips untracked directories`, three `runtime.test.mjs` snapshot tests, and `resolveStateDir uses a temp-backed per-workspace directory`) are **pre-existing on `main` and unrelated to this patch** — I confirmed by running the same suite against pristine `main`.

## Test plan (manual)

- [x] Reproduced the wedge with a long-running Codex task on macOS.
- [x] Verified `/codex:status` now reconciles a dead job to `failed` on a single call.
- [x] Verified the new hard timeout fires and writes a `failed` status.
- [ ] Smoke-test on Windows (I do not have a Windows host; the changes use only `process.kill(pid, 0)` on Unix paths and the platform branch in `terminateProcessTree` is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)