### PR TITLE
fix: handle EAGAIN error when reading stdin in hook scripts

### DIFF
--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -20,7 +20,15 @@ export const SESSION_ID_ENV = "CODEX_COMPANION_SESSION_ID";
 const PLUGIN_DATA_ENV = "CLAUDE_PLUGIN_DATA";
 
 function readHookInput() {
-  const raw = fs.readFileSync(0, "utf8").trim();
+  let raw;
+  try {
+    raw = fs.readFileSync(0, "utf8").trim();
+  } catch (err) {
+    if (err.code === "EAGAIN" || err.code === "EWOULDBLOCK") {
+      return {};
+    }
+    throw err;
+  }
   if (!raw) {
     return {};
   }

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -19,7 +19,15 @@ const ROOT_DIR = path.resolve(SCRIPT_DIR, "..");
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
 
 function readHookInput() {
-  const raw = fs.readFileSync(0, "utf8").trim();
+  let raw;
+  try {
+    raw = fs.readFileSync(0, "utf8").trim();
+  } catch (err) {
+    if (err.code === "EAGAIN" || err.code === "EWOULDBLOCK") {
+      return {};
+    }
+    throw err;
+  }
   if (!raw) {
     return {};
   }


### PR DESCRIPTION
## Summary

- Fix `EAGAIN` ("resource temporarily unavailable") crash in `readHookInput()` when stdin (fd 0) is in non-blocking mode and no data is available
- Wraps `fs.readFileSync(0, "utf8")` with try-catch in both `stop-review-gate-hook.mjs` and `session-lifecycle-hook.mjs`, treating `EAGAIN`/`EWOULDBLOCK` the same as empty input (returns `{}`)

## Problem

When Claude Code runs hook scripts, stdin may be set to non-blocking mode (`O_NONBLOCK`). If no data is available on fd 0, `fs.readFileSync(0, "utf8")` throws:

```
Error: EAGAIN: resource temporarily unavailable, read
    at Object.readFileSync (node:fs:442:20)
    at readHookInput (stop-review-gate-hook.mjs:22:18)
```

This causes the stop hook to crash instead of gracefully proceeding with no input.

## Test plan

- [ ] Verified the fix locally — hooks no longer crash on session stop
- [ ] Confirmed that normal stdin piping (when data IS available) still works — the try-catch only intercepts `EAGAIN`/`EWOULDBLOCK`, all other errors re-throw
- [ ] Behavior is backward-compatible: when stdin has data, parsing works identically; when stdin is empty or unavailable, returns `{}` (same as before for empty string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)