### PR TITLE
fix: use codex-namespaced clientInfo.name instead of host application name

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -25,7 +25,7 @@ export const BROKER_BUSY_RPC_CODE = -32001;
 /** @type {ClientInfo} */
 const DEFAULT_CLIENT_INFO = {
   title: "Codex Plugin",
-  name: "Claude Code",
+  name: "codex_claude_code",
   version: PLUGIN_MANIFEST.version ?? "0.0.0"
 };
 


### PR DESCRIPTION
Closes #199

## Summary

- Rename `clientInfo.name` from `"Claude Code"` to `"codex_claude_code"` in `DEFAULT_CLIENT_INFO`
- Aligns with the established `codex_` + host platform naming convention used by all other Codex surfaces (`codex_cli_rs`, `codex-tui`, `codex_vscode`, `Codex Desktop`)
- Prevents user-agent collision with the host application (Claude Code already uses `Claude Code/x.x.x` for its own Anthropic API requests)
- Fixes compliance log misattribution where Codex usage was incorrectly attributed to Claude Code

## Test plan

- [x] Verified no other code paths depend on the old `"Claude Code"` value (`clientInfo` is only consumed by `DEFAULT_CLIENT_INFO` and passed through to `initialize`)
- [x] `node --check` passes on the modified file
- [x] Manual test: run `/codex:review` from Claude Code and verify the upstream request UA is `codex_claude_code/x.x.x`