### PR TITLE
feat: add --fast flag to task command for service_tier support

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -77,7 +77,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--fast] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
       "  node scripts/codex-companion.mjs cancel [job-id] [--json]"
@@ -486,6 +486,7 @@ async function executeTaskRun(request) {
     model: request.model,
     effort: request.effort,
     sandbox: request.write ? "workspace-write" : "read-only",
+    serviceTier: request.fast ? "fast" : null,
     onProgress: request.onProgress,
     persistThread: true,
     threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
@@ -598,7 +599,7 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId, fast }) {
   return {
     cwd,
     model,
@@ -606,7 +607,8 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     prompt,
     write,
     resumeLast,
-    jobId
+    jobId,
+    fast
   };
 }
 
@@ -732,7 +734,7 @@ async function handleReview(argv) {
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["model", "effort", "cwd", "prompt-file"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
+    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background", "fast"],
     aliasMap: {
       m: "model"
     }
@@ -750,6 +752,7 @@ async function handleTask(argv) {
     throw new Error("Choose either --resume/--resume-last or --fresh.");
   }
   const write = Boolean(options.write);
+  const fast = Boolean(options.fast);
   const taskMetadata = buildTaskRunMetadata({
     prompt,
     resumeLast
@@ -767,7 +770,8 @@ async function handleTask(argv) {
       prompt,
       write,
       resumeLast,
-      jobId: job.id
+      jobId: job.id,
+      fast
     });
     const { payload } = enqueueBackgroundTask(cwd, job, request);
     outputCommandResult(payload, renderQueuedTaskLaunch(payload), options.json);
@@ -784,6 +788,7 @@ async function handleTask(argv) {
         effort,
         prompt,
         write,
+        fast,
         resumeLast,
         jobId: job.id,
         onProgress: progress

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -54,7 +54,7 @@ function cleanCodexStderr(stderr) {
 
 /** @returns {ThreadStartParams} */
 function buildThreadParams(cwd, options = {}) {
-  return {
+  const params = {
     cwd,
     model: options.model ?? null,
     approvalPolicy: options.approvalPolicy ?? "never",
@@ -63,17 +63,25 @@ function buildThreadParams(cwd, options = {}) {
     ephemeral: options.ephemeral ?? true,
     experimentalRawEvents: false
   };
+  if (options.serviceTier) {
+    params.serviceTier = options.serviceTier;
+  }
+  return params;
 }
 
 /** @returns {ThreadResumeParams} */
 function buildResumeParams(threadId, cwd, options = {}) {
-  return {
+  const params = {
     threadId,
     cwd,
     model: options.model ?? null,
     approvalPolicy: options.approvalPolicy ?? "never",
     sandbox: options.sandbox ?? "read-only"
   };
+  if (options.serviceTier) {
+    params.serviceTier = options.serviceTier;
+  }
+  return params;
 }
 
 /** @returns {UserInput[]} */
@@ -975,6 +983,7 @@ export async function runAppServerTurn(cwd, options = {}) {
       const response = await resumeThread(client, options.resumeThreadId, cwd, {
         model: options.model,
         sandbox: options.sandbox,
+        serviceTier: options.serviceTier,
         ephemeral: false
       });
       threadId = response.thread.id;
@@ -983,6 +992,7 @@ export async function runAppServerTurn(cwd, options = {}) {
       const response = await startThread(client, cwd, {
         model: options.model,
         sandbox: options.sandbox,
+        serviceTier: options.serviceTier,
         ephemeral: options.persistThread ? false : true,
         threadName: options.persistThread ? options.threadName : options.threadName ?? null
       });


### PR DESCRIPTION
## Summary
- Adds `--fast` boolean flag to the `task` command that sets `serviceTier: "fast"` on thread start/resume requests
- Threads the parameter through `buildTaskRequest` → `executeTaskRun` → `runAppServerTurn` → `buildThreadParams`/`buildResumeParams`
- Enables programmatic access to the Codex fast tier (1.5x speed at 2x credits) from the companion script

## Motivation

The Codex CLI supports `service_tier = "fast"` via `config.toml` and `/fast on` in interactive mode, but the companion script (`codex-companion.mjs`) has no way to request fast tier programmatically. This is needed for CI/automation workflows and Claude Code plugin integrations that invoke Codex via the companion script and want to trade credits for speed on time-sensitive tasks.

## Usage

```bash
# Fast mode on a task
node codex-companion.mjs task --fast --prompt "analyze this code"

# Combined with other flags
node codex-companion.mjs task --fast --prompt-file prompt.md --effort high --write

# Background fast task
node codex-companion.mjs task --fast --background --prompt-file prompt.md
```

## Changes

| File | Change |
|------|--------|
| `plugins/codex/scripts/codex-companion.mjs` | Parse `--fast` flag, thread through `buildTaskRequest` and `executeTaskRun` |
| `plugins/codex/scripts/lib/codex.mjs` | Pass `serviceTier` to `buildThreadParams` and `buildResumeParams` when provided |

## Test plan
- [ ] `task --fast` with simple prompt — verify faster response
- [ ] `task` without `--fast` — verify no regression (serviceTier is null, not sent)
- [ ] `task --fast --background` — verify fast tier applies to background tasks
- [ ] `--help` shows `--fast` in task usage line

🤖 Generated with [Claude Code](https://claude.com/claude-code)