### PR TITLE
fix: keep rescue task calls in foreground

### DIFF
--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -20,8 +20,10 @@ Selection guidance:
 Forwarding rules:
 
 - Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ...`.
-- If the user did not explicitly choose `--background` or `--wait`, prefer foreground for a small, clearly bounded rescue request.
-- If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution.
+- Always wait for that single `Bash` call to finish. Do not set `run_in_background: true` on the inner `task` invocation.
+- If the user chose `--background`, that applies to Claude Code's handling of the outer `codex:codex-rescue` subagent. It does not authorize backgrounding the inner `task` Bash call.
+- If the user chose `--wait`, keep the outer rescue subagent in the foreground and still wait on the inner `task` Bash call.
+- If neither flag is present, default to foreground behavior and still wait on the inner `task` Bash call.
 - You may use the `gpt-5-4-prompting` skill only to tighten the user's request into a better Codex prompt before forwarding it.
 - Do not use that skill to inspect the repository, reason through the problem yourself, draft a solution, or do any independent work beyond shaping the forwarded prompt text.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -26,6 +26,8 @@ Execution rules:
 Command selection:
 - Use exactly one `task` invocation per rescue handoff.
 - If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only. Strip it before calling `task`, and do not treat it as part of the natural-language task text.
+- Never set `run_in_background: true` on the `Bash` call that invokes `task`. The rescue subagent must wait for Codex to finish and return that stdout directly.
+- If the user wants background behavior, let Claude Code background the outer `codex:codex-rescue` subagent itself. Do not detach the inner `task` process.
 - If the forwarded request includes `--model`, normalize `spark` to `gpt-5.3-codex-spark` and pass it through to `task`.
 - If the forwarded request includes `--effort`, pass it through to `task`.
 - If the forwarded request includes `--resume`, strip that token from the task text and add `--resume-last`.

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -117,8 +117,10 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(agent, /--resume/);
   assert.match(agent, /--fresh/);
   assert.match(agent, /thin forwarding wrapper/i);
-  assert.match(agent, /prefer foreground for a small, clearly bounded rescue request/i);
-  assert.match(agent, /If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution/i);
+  assert.match(agent, /Always wait for that single `Bash` call to finish/i);
+  assert.match(agent, /Do not set `run_in_background: true` on the inner `task` invocation/i);
+  assert.match(agent, /If the user chose `--background`, that applies to Claude Code's handling of the outer `codex:codex-rescue` subagent/i);
+  assert.match(agent, /If neither flag is present, default to foreground behavior and still wait on the inner `task` Bash call/i);
   assert.match(agent, /Use exactly one `Bash` call/i);
   assert.match(agent, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(agent, /Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`/i);
@@ -140,6 +142,8 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /Map `spark` to `--model gpt-5\.3-codex-spark`/i);
   assert.match(runtimeSkill, /If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only/i);
   assert.match(runtimeSkill, /Strip it before calling `task`/i);
+  assert.match(runtimeSkill, /Never set `run_in_background: true` on the `Bash` call that invokes `task`/i);
+  assert.match(runtimeSkill, /let Claude Code background the outer `codex:codex-rescue` subagent itself/i);
   assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`/i);
   assert.match(runtimeSkill, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);


### PR DESCRIPTION
## Problem
`codex:codex-rescue` can orphan Codex runs in worktree isolation when the rescue agent backgrounds its single `task` Bash call. Claude Code cleans up the temporary worktree as soon as the agent returns, leaving Codex running in a deleted directory.

## Root Cause
The rescue forwarding instructions still allow backgrounding the inner `codex-companion.mjs task ...` Bash call, and the command-contract tests do not enforce that the inner task must always run in the foreground.

## Fix
Update the rescue agent and runtime skill to require foreground execution for the inner `task` Bash call in all cases. `--background` and `--wait` remain outer Claude-side controls, but they no longer authorize `run_in_background: true` on the inner task invocation.

## Validation
- `node --test --test-name-pattern='rescue command absorbs continue semantics|internal docs use task terminology' tests/commands.test.mjs`
- Note: `node --test tests/commands.test.mjs` still has an unrelated pre-existing failure in the `result and cancel commands are exposed as deterministic runtime entrypoints` assertion on `main`

Closes #198
