### PR TITLE
fix: allow model invocation for codex commands except review

### DIFF
--- a/plugins/codex/commands/adversarial-review.md
+++ b/plugins/codex/commands/adversarial-review.md
@@ -1,7 +1,6 @@
 ---
 description: Run a Codex review that challenges the implementation approach and design choices
 argument-hint: '[--wait|--background] [--base <ref>] [--scope auto|working-tree|branch] [focus ...]'
-disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---
 
@@ -17,6 +16,7 @@ Core constraint:
 - Do not fix issues, apply patches, or suggest that you are about to make changes.
 - Your only job is to run the review and return Codex's output verbatim to the user.
 - Keep the framing focused on whether the current approach is the right one, what assumptions it depends on, and where the design could fail under real-world conditions.
+- Only run this command when the user has explicitly asked for an adversarial Codex review — by slash command, by naming it in a message, or through another skill or workflow that clearly invokes it. Do not run it on your own initiative as a speculative quality check.
 
 Execution mode rules:
 - If the raw arguments include `--wait`, do not ask. Run in the foreground.

--- a/plugins/codex/commands/cancel.md
+++ b/plugins/codex/commands/cancel.md
@@ -1,7 +1,6 @@
 ---
 description: Cancel an active background Codex job in this repository
 argument-hint: '[job-id]'
-disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 

--- a/plugins/codex/commands/cancel.md
+++ b/plugins/codex/commands/cancel.md
@@ -4,4 +4,6 @@ argument-hint: '[job-id]'
 allowed-tools: Bash(node:*)
 ---
 
+Only cancel a job when the user has explicitly asked to cancel or stop it. Do not cancel jobs on your own initiative.
+
 !`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" cancel "$ARGUMENTS"`

--- a/plugins/codex/commands/result.md
+++ b/plugins/codex/commands/result.md
@@ -1,7 +1,6 @@
 ---
 description: Show the stored final output for a finished Codex job in this repository
 argument-hint: '[job-id]'
-disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 

--- a/plugins/codex/commands/status.md
+++ b/plugins/codex/commands/status.md
@@ -1,7 +1,6 @@
 ---
 description: Show active and recent Codex jobs for this repository, including review-gate status
 argument-hint: '[job-id] [--wait] [--timeout-ms <ms>] [--all]'
-disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -164,12 +164,30 @@ test("result and cancel commands are exposed as deterministic runtime entrypoint
   const cancel = read("commands/cancel.md");
   const resultHandling = read("skills/codex-result-handling/SKILL.md");
 
-  assert.match(result, /disable-model-invocation:\s*true/);
-  assert.match(result, /codex-companion\.mjs" result \$ARGUMENTS/);
-  assert.match(cancel, /disable-model-invocation:\s*true/);
-  assert.match(cancel, /codex-companion\.mjs" cancel \$ARGUMENTS/);
+  assert.match(result, /codex-companion\.mjs" result "\$ARGUMENTS"/);
+  assert.match(cancel, /codex-companion\.mjs" cancel "\$ARGUMENTS"/);
   assert.match(resultHandling, /do not turn a failed or incomplete Codex run into a Claude-side implementation attempt/i);
   assert.match(resultHandling, /if Codex was never successfully invoked, do not generate a substitute answer at all/i);
+});
+
+test("model invocation policy: review is user-only, other commands are model-invokable", () => {
+  const review = read("commands/review.md");
+  const adversarialReview = read("commands/adversarial-review.md");
+  const cancel = read("commands/cancel.md");
+  const result = read("commands/result.md");
+  const status = read("commands/status.md");
+
+  // review is intentionally kept user-only to avoid proactive Codex spend
+  assert.match(review, /disable-model-invocation:\s*true/);
+
+  // other commands are model-invokable so Claude can route explicit user requests
+  assert.doesNotMatch(adversarialReview, /disable-model-invocation:\s*true/);
+  assert.doesNotMatch(cancel, /disable-model-invocation:\s*true/);
+  assert.doesNotMatch(result, /disable-model-invocation:\s*true/);
+  assert.doesNotMatch(status, /disable-model-invocation:\s*true/);
+
+  // adversarial-review has explicit guardrail against proactive invocation
+  assert.match(adversarialReview, /Only run this command when the user has explicitly asked/i);
 });
 
 test("internal docs use task terminology for rescue runs", () => {

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -186,8 +186,9 @@ test("model invocation policy: review is user-only, other commands are model-inv
   assert.doesNotMatch(result, /disable-model-invocation:\s*true/);
   assert.doesNotMatch(status, /disable-model-invocation:\s*true/);
 
-  // adversarial-review has explicit guardrail against proactive invocation
+  // commands with side effects have explicit guardrails against proactive invocation
   assert.match(adversarialReview, /Only run this command when the user has explicitly asked/i);
+  assert.match(cancel, /Only cancel a job when the user has explicitly asked/i);
 });
 
 test("internal docs use task terminology for rescue runs", () => {

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -173,9 +173,7 @@ test("result and cancel commands are exposed as deterministic runtime entrypoint
   const cancel = read("commands/cancel.md");
   const resultHandling = read("skills/codex-result-handling/SKILL.md");
 
-  assert.match(result, /disable-model-invocation:\s*true/);
   assert.match(result, /codex-companion\.mjs" result "\$ARGUMENTS"/);
-  assert.match(cancel, /disable-model-invocation:\s*true/);
   assert.match(cancel, /codex-companion\.mjs" cancel "\$ARGUMENTS"/);
   assert.match(resultHandling, /do not turn a failed or incomplete Codex run into a Claude-side implementation attempt/i);
   assert.match(resultHandling, /if Codex was never successfully invoked, do not generate a substitute answer at all/i);


### PR DESCRIPTION
## Summary

- Remove `disable-model-invocation: true` from `adversarial-review`, `cancel`, `result`, and `status` commands so Claude can route explicit user requests and skills/workflows can invoke them
- Keep the flag on `review` intentionally — it's a heavyweight Codex call most at risk of proactive invocation
- Add explicit guardrail to `adversarial-review` preventing Claude from running it on its own initiative
- Fix pre-existing test regression from #168 where quoted `$ARGUMENTS` was not reflected in the test regex
- Add new "model invocation policy" test that locks in the intentional asymmetry across all 5 commands

Closes #211
Supersedes #156 #157

## Context

`disable-model-invocation: true` conflates two concerns: preventing proactive model invocation and hiding commands from Claude entirely. With the flag set, Claude cannot invoke the command even when the user explicitly asks for it in a message, and other skills/workflows cannot compose with it. There is no native Claude Code frontmatter option that separates "known" from "invokable" ([confirmed in docs](https://code.claude.com/docs/en/skills.md#control-who-invokes-a-skill)).

The fix removes the flag from 4 of 5 affected commands. `review` keeps the flag because it's expensive and takes no user-supplied focus text, making it the most likely target for unwanted proactive invocation. `adversarial-review` gets an explicit prompt-level guardrail instead.

## Test plan

- [x] `commands.test.mjs` passes 9/9 (was 8/9 before — pre-existing `$ARGUMENTS` quoting regression fixed)
- [x] Verify `/codex:adversarial-review` appears in Claude's skill list after plugin reload
- [x] Verify `/codex:status`, `/codex:result`, `/codex:cancel` can be invoked by Claude when user asks in a message
- [x] Verify `/codex:review` remains user-only (typing it in a message should not route)
- [x] Verify Claude does not proactively invoke `adversarial-review` without being asked

🤖 Generated with [Claude Code](https://claude.com/claude-code)