### PR TITLE
feat(task): add --resume-id <threadId> option for explicit thread resumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ Use it when you want Codex to:
 > [!NOTE]
 > Depending on the task and the model you choose these tasks might take a long time and it's generally recommended to force the task to be in the background or move the agent to the background.
 
-It supports `--background`, `--wait`, `--resume`, and `--fresh`. If you omit `--resume` and `--fresh`, the plugin can offer to continue the latest rescue thread for this repo.
+It supports `--background`, `--wait`, `--resume`, `--resume-id <threadId>`, and `--fresh`. If you omit `--resume` and `--fresh`, the plugin can offer to continue the latest rescue thread for this repo.
+
+Use `--resume-id <threadId>` to resume a specific thread by ID. This is useful when managing multiple concurrent threads (e.g., parallel PR reviews) where `--resume` would pick the wrong thread.
 
 Examples:
 
@@ -145,6 +147,7 @@ Examples:
 /codex:rescue investigate why the tests started failing
 /codex:rescue fix the failing test with the smallest safe patch
 /codex:rescue --resume apply the top fix from the last run
+/codex:rescue --resume-id thread_abc123 continue from the specific thread
 /codex:rescue --model gpt-5.4-mini --effort medium investigate the flaky integration test
 /codex:rescue --model spark fix the issue quickly
 /codex:rescue --background investigate the regression

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.1.0",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -461,11 +461,13 @@ async function executeTaskRun(request) {
 
   const taskMetadata = buildTaskRunMetadata({
     prompt: request.prompt,
-    resumeLast: request.resumeLast
+    resumeLast: request.resumeLast || Boolean(request.resumeId)
   });
 
   let resumeThreadId = null;
-  if (request.resumeLast) {
+  if (request.resumeId) {
+    resumeThreadId = request.resumeId;
+  } else if (request.resumeLast) {
     const latestThread = await resolveLatestTrackedTaskThread(workspaceRoot, {
       excludeJobId: request.jobId
     });
@@ -598,7 +600,7 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, resumeId, jobId }) {
   return {
     cwd,
     model,
@@ -606,6 +608,7 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     prompt,
     write,
     resumeLast,
+    resumeId,
     jobId
   };
 }
@@ -731,8 +734,8 @@ async function handleReview(argv) {
 
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["model", "effort", "cwd", "prompt-file"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
+    valueOptions: ["model", "effort", "cwd", "prompt-file", "resume"],
+    booleanOptions: ["json", "write", "resume-last", "fresh", "background"],
     aliasMap: {
       m: "model"
     }
@@ -744,20 +747,21 @@ async function handleTask(argv) {
   const effort = normalizeReasoningEffort(options.effort);
   const prompt = readTaskPrompt(cwd, options, positionals);
 
-  const resumeLast = Boolean(options["resume-last"] || options.resume);
+  const resumeId = typeof options.resume === "string" ? options.resume : null;
+  const resumeLast = Boolean(options["resume-last"]);
   const fresh = Boolean(options.fresh);
-  if (resumeLast && fresh) {
+  if ((resumeLast || resumeId) && fresh) {
     throw new Error("Choose either --resume/--resume-last or --fresh.");
   }
   const write = Boolean(options.write);
   const taskMetadata = buildTaskRunMetadata({
     prompt,
-    resumeLast
+    resumeLast: resumeLast || Boolean(resumeId)
   });
 
   if (options.background) {
     ensureCodexAvailable(cwd);
-    requireTaskRequest(prompt, resumeLast);
+    requireTaskRequest(prompt, resumeLast || Boolean(resumeId));
 
     const job = buildTaskJob(workspaceRoot, taskMetadata, write);
     const request = buildTaskRequest({
@@ -767,6 +771,7 @@ async function handleTask(argv) {
       prompt,
       write,
       resumeLast,
+      resumeId,
       jobId: job.id
     });
     const { payload } = enqueueBackgroundTask(cwd, job, request);
@@ -785,6 +790,7 @@ async function handleTask(argv) {
         prompt,
         write,
         resumeLast,
+        resumeId,
         jobId: job.id,
         onProgress: progress
       }),

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -77,7 +77,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--resume-id <threadId>|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
       "  node scripts/codex-companion.mjs cancel [job-id] [--json]"
@@ -734,8 +734,8 @@ async function handleReview(argv) {
 
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["model", "effort", "cwd", "prompt-file", "resume"],
-    booleanOptions: ["json", "write", "resume-last", "fresh", "background"],
+    valueOptions: ["model", "effort", "cwd", "prompt-file", "resume-id"],
+    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
     aliasMap: {
       m: "model"
     }
@@ -747,11 +747,11 @@ async function handleTask(argv) {
   const effort = normalizeReasoningEffort(options.effort);
   const prompt = readTaskPrompt(cwd, options, positionals);
 
-  const resumeId = typeof options.resume === "string" ? options.resume : null;
-  const resumeLast = Boolean(options["resume-last"]);
+  const resumeId = typeof options["resume-id"] === "string" ? options["resume-id"] : null;
+  const resumeLast = Boolean(options["resume-last"] || options.resume);
   const fresh = Boolean(options.fresh);
   if ((resumeLast || resumeId) && fresh) {
-    throw new Error("Choose either --resume/--resume-last or --fresh.");
+    throw new Error("Choose either --resume/--resume-last/--resume-id or --fresh.");
   }
   const write = Boolean(options.write);
   const taskMetadata = buildTaskRunMetadata({

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -747,7 +747,11 @@ async function handleTask(argv) {
   const effort = normalizeReasoningEffort(options.effort);
   const prompt = readTaskPrompt(cwd, options, positionals);
 
-  const resumeId = typeof options["resume-id"] === "string" ? options["resume-id"] : null;
+  const rawResumeId = typeof options["resume-id"] === "string" ? options["resume-id"] : null;
+  if (rawResumeId && rawResumeId.startsWith("-")) {
+    throw new Error(`Invalid --resume-id value: "${rawResumeId}". Provide a thread ID, not a flag.`);
+  }
+  const resumeId = rawResumeId;
   const resumeLast = Boolean(options["resume-last"] || options.resume);
   const fresh = Boolean(options.fresh);
   if ((resumeLast || resumeId) && fresh) {


### PR DESCRIPTION
## Summary

- Add `--resume-id <threadId>` value option to the `task` command for resuming a specific thread by ID
- Existing `--resume` (boolean) and `--resume-last` behavior is unchanged

Using a separate `--resume-id` flag instead of overloading `--resume` preserves backward compatibility with the rescue command routing that uses bare `--resume` as a boolean continue signal.

Closes #230

## Changes

- `handleTask()`: add `--resume-id` as a value option, extract `resumeId`
- `buildTaskRequest()`: pass `resumeId` through the request object
- `executeTaskRun()`: use `resumeId` directly when provided, fall back to `resolveLatestTrackedTaskThread()` for `--resume-last`
- Usage text updated to show `--resume-id <threadId>`

## Test plan

- [ ] `task --resume-id <valid-threadId> "prompt"` resumes the specified thread
- [ ] `task --resume "prompt"` still works as boolean resume (unchanged)
- [ ] `task --resume-last "prompt"` still resumes the latest thread (unchanged)
- [ ] `task --resume-id <id> --fresh` throws an error
- [ ] `task --resume-id <id> --background` works correctly
- [ ] `task "prompt"` without resume flags creates a new thread (unchanged)