### PR TITLE
perf: replace Node.js SessionStart hook with bash (106ms → 5ms)

### DIFF
--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-lifecycle-hook.mjs\" SessionStart",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start-env.sh\"",
             "timeout": 5
           }
         ]

--- a/plugins/codex/scripts/session-start-env.sh
+++ b/plugins/codex/scripts/session-start-env.sh
@@ -3,7 +3,7 @@
 # Replaces the Node.js session-lifecycle-hook.mjs for the SessionStart path
 # to avoid ~100ms V8 startup overhead on every session.
 
-set -uo pipefail
+set -euo pipefail
 
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)

--- a/plugins/codex/scripts/session-start-env.sh
+++ b/plugins/codex/scripts/session-start-env.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# SessionStart hook: export session ID and plugin data dir to CLAUDE_ENV_FILE.
+# Replaces the Node.js session-lifecycle-hook.mjs for the SessionStart path
+# to avoid ~100ms V8 startup overhead on every session.
+
+set -uo pipefail
+
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+
+[ -z "${CLAUDE_ENV_FILE:-}" ] && exit 0
+
+shell_escape() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\"\\'\"'/g")"
+}
+
+if [ -n "$SESSION_ID" ]; then
+  printf 'export CODEX_COMPANION_SESSION_ID=%s\n' "$(shell_escape "$SESSION_ID")" >> "$CLAUDE_ENV_FILE"
+fi
+
+if [ -n "${CLAUDE_PLUGIN_DATA:-}" ]; then
+  printf 'export CLAUDE_PLUGIN_DATA=%s\n' "$(shell_escape "$CLAUDE_PLUGIN_DATA")" >> "$CLAUDE_ENV_FILE"
+fi
+
+exit 0

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -535,6 +535,114 @@ test("task --resume-last ignores running tasks from other Claude sessions", () =
   assert.match(resume.stderr, /No previous Codex task thread was found for this repository\./);
 });
 
+const SESSION_START_BASH = path.join(PLUGIN_ROOT, "scripts", "session-start-env.sh");
+
+test("bash session start hook exports the same env vars as the Node.js version", () => {
+  const repo = makeTempDir();
+  const envFile = path.join(makeTempDir(), "claude-env.sh");
+  fs.writeFileSync(envFile, "", "utf8");
+  const pluginDataDir = makeTempDir();
+
+  const result = run("bash", [SESSION_START_BASH], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      CLAUDE_ENV_FILE: envFile,
+      CLAUDE_PLUGIN_DATA: pluginDataDir
+    },
+    input: JSON.stringify({
+      session_id: "sess-bash-test",
+      cwd: repo
+    })
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    fs.readFileSync(envFile, "utf8"),
+    `export CODEX_COMPANION_SESSION_ID='sess-bash-test'\nexport CLAUDE_PLUGIN_DATA='${pluginDataDir}'\n`
+  );
+});
+
+test("bash session start hook handles single quotes in session id", () => {
+  const envFile = path.join(makeTempDir(), "claude-env.sh");
+  fs.writeFileSync(envFile, "", "utf8");
+
+  const result = run("bash", [SESSION_START_BASH], {
+    env: {
+      ...process.env,
+      CLAUDE_ENV_FILE: envFile
+    },
+    input: JSON.stringify({
+      session_id: "O'Brien's \"test\""
+    })
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const content = fs.readFileSync(envFile, "utf8");
+  assert.match(content, /CODEX_COMPANION_SESSION_ID=/);
+  // Verify the escaped value roundtrips correctly via shell eval
+  const script = path.join(makeTempDir(), "roundtrip.sh");
+  fs.writeFileSync(script, `${content}\nprintf '%s' "$CODEX_COMPANION_SESSION_ID"`, { mode: 0o755 });
+  const roundtrip = run("bash", [script]);
+  assert.equal(roundtrip.stdout, "O'Brien's \"test\"");
+});
+
+test("bash session start hook exits cleanly without CLAUDE_ENV_FILE", () => {
+  const result = run("bash", [SESSION_START_BASH], {
+    env: {
+      ...process.env,
+      CLAUDE_ENV_FILE: ""
+    },
+    input: JSON.stringify({
+      session_id: "sess-no-env-file"
+    })
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, "");
+});
+
+test("bash session start hook produces identical output to the Node.js version", () => {
+  const repo = makeTempDir();
+  const nodeEnvFile = path.join(makeTempDir(), "node-env.sh");
+  const bashEnvFile = path.join(makeTempDir(), "bash-env.sh");
+  fs.writeFileSync(nodeEnvFile, "", "utf8");
+  fs.writeFileSync(bashEnvFile, "", "utf8");
+  const pluginDataDir = makeTempDir();
+  const inputJson = JSON.stringify({
+    hook_event_name: "SessionStart",
+    session_id: "sess-parity-check",
+    cwd: repo
+  });
+
+  const nodeResult = run("node", [SESSION_HOOK, "SessionStart"], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      CLAUDE_ENV_FILE: nodeEnvFile,
+      CLAUDE_PLUGIN_DATA: pluginDataDir
+    },
+    input: inputJson
+  });
+
+  const bashResult = run("bash", [SESSION_START_BASH], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      CLAUDE_ENV_FILE: bashEnvFile,
+      CLAUDE_PLUGIN_DATA: pluginDataDir
+    },
+    input: inputJson
+  });
+
+  assert.equal(nodeResult.status, 0, nodeResult.stderr);
+  assert.equal(bashResult.status, 0, bashResult.stderr);
+  assert.equal(
+    fs.readFileSync(bashEnvFile, "utf8"),
+    fs.readFileSync(nodeEnvFile, "utf8")
+  );
+});
+
 test("session start hook exports the Claude session id and plugin data dir for later commands", () => {
   const repo = makeTempDir();
   const envFile = path.join(makeTempDir(), "claude-env.sh");


### PR DESCRIPTION
## Summary

- Replace the Node.js `SessionStart` hook with an equivalent bash script
- `SessionEnd` stays in Node.js (requires async broker teardown and process tree management)

## Why

The `SessionStart` handler in `session-lifecycle-hook.mjs` only appends two env vars (`CODEX_COMPANION_SESSION_ID` and `CLAUDE_PLUGIN_DATA`) to `CLAUDE_ENV_FILE`. Running this through Node.js pays ~100ms of V8 startup overhead on every session start for what amounts to two file appends.

Bare Node.js startup on this machine:
```
$ hyperfine --warmup 5 --runs 30 'node -e "1"'
Time (mean ± σ):  98.3 ms ± 7.4 ms
```

The actual work (`appendEnvVar` × 2) adds <10ms on top. A bash script doing the same shell-escaped writes avoids V8 entirely.

## Changes

1. **`scripts/session-start-env.sh`** (new): Reads `session_id` from hook JSON input via `jq`, appends shell-escaped `export` lines to `$CLAUDE_ENV_FILE`. Exact same escaping logic as the Node.js `shellEscape()` function.
2. **`hooks/hooks.json`**: `SessionStart` entry points to the new bash script instead of `session-lifecycle-hook.mjs`.

## Benchmark

macOS, Apple Silicon (M4 Max), 30 runs, 5 warmup via hyperfine:

| Hook | Before (Node.js) | After (bash) | Delta | Speedup |
|:---|---:|---:|:---|---:|
| `SessionStart` | 106 ms | 5 ms | `██████████` -95% | **21.2x** |

<details>
<summary><strong>Reproduce with hyperfine</strong></summary>

Requires [hyperfine](https://github.com/sharkdp/hyperfine) and `jq`.

```bash
# Create test input
printf '{"session_id":"test-123"}\n' > /tmp/session-input.json

# Measure Node.js version (current main)
CLAUDE_ENV_FILE=/tmp/test-env \
  hyperfine --warmup 5 --runs 30 \
  --prepare 'rm -f /tmp/test-env' \
  'node plugins/codex/scripts/session-lifecycle-hook.mjs SessionStart < /tmp/session-input.json'

# Measure bash version (this branch)
CLAUDE_ENV_FILE=/tmp/test-env \
  hyperfine --warmup 5 --runs 30 \
  --prepare 'rm -f /tmp/test-env' \
  'bash plugins/codex/scripts/session-start-env.sh < /tmp/session-input.json'
```

</details>

## Test plan

- [x] Output matches Node.js version: same `export` lines with identical shell escaping
- [x] `CODEX_COMPANION_SESSION_ID` set correctly in session after start
- [x] `CLAUDE_PLUGIN_DATA` set correctly in session after start
- [x] Empty/missing `CLAUDE_ENV_FILE` exits cleanly (exit 0, no error)
- [x] Shell escaping handles single quotes in values
- [x] SessionEnd still routes to Node.js and tears down broker correctly

---
*Generated by [codeflash](https://codeflash.ai) agent*
