### PR TITLE
fix: namespace app-server client info

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -25,7 +25,7 @@ export const BROKER_BUSY_RPC_CODE = -32001;
 /** @type {ClientInfo} */
 const DEFAULT_CLIENT_INFO = {
   title: "Codex Plugin",
-  name: "Claude Code",
+  name: "codex_claude_code",
   version: PLUGIN_MANIFEST.version ?? "0.0.0"
 };
 

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -18,7 +18,7 @@ const readline = require("node:readline");
 
 	function loadState() {
 	  if (!fs.existsSync(STATE_PATH)) {
-	    return { nextThreadId: 1, nextTurnId: 1, appServerStarts: 0, threads: [], capabilities: null, lastInterrupt: null };
+	    return { nextThreadId: 1, nextTurnId: 1, appServerStarts: 0, threads: [], capabilities: null, lastInitialize: null, lastInterrupt: null };
 	  }
 	  return JSON.parse(fs.readFileSync(STATE_PATH, "utf8"));
 	}
@@ -271,6 +271,7 @@ rl.on("line", (line) => {
     switch (message.method) {
       case "initialize":
         state.capabilities = message.params.capabilities || null;
+        state.lastInitialize = message.params || null;
         saveState(state);
         send({ id: message.id, result: { userAgent: "fake-codex-app-server" } });
         break;

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -44,6 +44,22 @@ test("setup reports ready when fake codex is installed and authenticated", () =>
   assert.equal(payload.sessionRuntime.mode, "direct");
 });
 
+test("setup initializes the app server with a codex-namespaced client name", () => {
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+
+  const result = run("node", [SCRIPT, "setup", "--json"], {
+    cwd: ROOT,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(state.lastInitialize?.clientInfo?.title, "Codex Plugin");
+  assert.equal(state.lastInitialize?.clientInfo?.name, "codex_claude_code");
+});
+
 test("setup is ready without npm when Codex is already installed and authenticated", () => {
   const binDir = makeTempDir();
   installFakeCodex(binDir);


### PR DESCRIPTION
Closes #199
Fixes #276

## Summary
- rename the default app-server client name to the namespaced plugin identifier
- capture the app-server initialize payload in the fake fixture
- add a regression test that verifies the initialize payload uses the namespaced client name

## Verification
- `npm test`
- `npm run build`
