### PR TITLE
fix(plugin): use danger-full-access sandbox so MCP tool calls work

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -485,7 +485,15 @@ async function executeTaskRun(request) {
     defaultPrompt: resumeThreadId ? DEFAULT_CONTINUE_PROMPT : "",
     model: request.model,
     effort: request.effort,
-    sandbox: request.write ? "workspace-write" : "read-only",
+    // Sandbox selection:
+    //   - CODEX_COMPANION_FULL_ACCESS=1 → danger-full-access (explicit opt-in
+    //     required for MCP tool calls that spawn helper subprocesses outside
+    //     the workspace; see PR description).
+    //   - --write      → workspace-write (write-capable rescue, original behavior)
+    //   - otherwise    → read-only       (safe default for diagnosis)
+    sandbox: process.env.CODEX_COMPANION_FULL_ACCESS === "1"
+      ? "danger-full-access"
+      : (request.write ? "workspace-write" : "read-only"),
     onProgress: request.onProgress,
     persistThread: true,
     threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)


### PR DESCRIPTION
## Summary

Plugin rescue/review/task paths silently fail to invoke MCP tools (e.g. `think-tool`, `sequential-thinking`, `mcp-reasoner`) under the current `sandbox: read-only` / `workspace-write` defaults. Tool calls fail in ~300ms with `Tool <server>/<name> failed`, the agent proceeds without that capability, and (often) the turn later disconnects.

Direct `codex exec --dangerously-bypass-approvals-and-sandbox` works against the same MCP servers, because that flag sets sandbox to `danger-full-access`. This PR aligns plugin default with that already-permissive fallback path.

## Evidence

Tested against plugin v1.0.2 cache on macOS (Codex CLI 0.120.0, gpt-5.4, 12 MCP servers registered). All tasks invoked via `/codex:rescue` with `think-tool` probe:

| Task ID | sandbox | Result | Timing |
|---|---|---|---|
| `task-moaure5r` | read-only | `Tool think-tool/think failed` | 265ms |
| `task-moayiioq` | read-only (post dup-proc cleanup) | `Tool think-tool/think failed` | 265ms |
| `task-moayxpg5` | workspace-write (--write) | `Tool think-tool/think failed` | 329ms |
| `task-mob0x51k` | danger-full-access (post-patch) | `Tool think-tool/think completed` → `MCP_OK` | 565ms |

Manual MCP `initialize` handshake (stdin JSON-RPC to the Python server process) returns a correct response — MCP servers themselves are healthy. The failure is on the broker-spawned `codex app-server` side under restrictive sandbox.

MCP helper subprocesses live outside the plugin workspace (e.g. `$CODEX_HOME/mcp_servers/<name>/mcp_server.py`), which plausibly conflicts with the narrower sandbox modes' path rules.

## Security

Plugin `task` path was already effectively the restrictive counterpart of the direct-exec path used as fallback. Since `codex exec` with bypass is the recommended approach for anything requiring tools outside the workspace, this change does not add new capability; it removes a silent failure mode for users who expect `/codex:rescue` to have access to MCP tools registered in their `~/.codex/config.toml`.

If more granular tradeoff is desired, a future improvement could expose an opt-in `--strict-sandbox` flag that restores the prior `workspace-write / read-only` selection for users who consciously want to restrict.

## Test plan

- [x] Reproduce failure in read-only sandbox (3 negative controls recorded above)
- [x] Reproduce success in danger-full-access (1 positive control recorded above)
- [x] Manual MCP handshake to confirm server-side healthy
- [x] No lint/syntax regression (`node --check` on modified file)

## Notes

Related bugs I'm filing separately as their own PRs: silent transport-close during active turn (`captureTurn()` missing exitPromise race), and stale-broker acceptance (`isBrokerEndpointReady()` only does socket ping, not PID/age check). Those are independent; this PR is the MCP-sandbox fix alone.