### PR TITLE
fix(captureTurn): race state.completion with exitPromise to surface transport close

### DIFF
--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -597,7 +597,17 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
       completeTurn(state, response.turn);
     }
 
-    return await state.completion;
+    // Race state.completion with client.exitPromise so a transport close after
+    // turn/start surfaces as a loud error instead of hanging indefinitely.
+    // Without this, a dropped app-server connection (after the turn/start RPC
+    // has already resolved, so handleExit() has no pending requests to reject)
+    // leaves captureTurn awaiting state.completion forever, producing a
+    // "Turn started → silence → manual cancel" pattern with no error surface.
+    const transportClosed = client.exitPromise.then(() => {
+      throw client.exitError
+        ?? new Error("codex app-server connection closed during active turn");
+    });
+    return await Promise.race([state.completion, transportClosed]);
   } finally {
     clearCompletionTimer(state);
     client.setNotificationHandler(previousHandler ?? null);


### PR DESCRIPTION
## Summary

If the codex app-server transport drops after `turn/start` resolves (subprocess dies, broker socket closes, etc.), `captureTurn()` waits on `state.completion` forever. `handleExit()` only rejects entries in the pending-request map, but the initial RPC has already resolved — the pending map is empty at that point — so there is nothing for it to reject, and the caller sees no error.

Observed in the wild (local repro on plugin v1.0.2):

- Job log shows `Turn started (019db...)`
- Then 20–30 minutes of silence
- User cancels manually
- No `Codex stream disconnected` line, no rejected promise

Fix: race `state.completion` with `client.exitPromise` in the same try block. When the exit promise resolves, throw the stored `client.exitError` (or a generic fallback). The existing `finally` block still runs cleanup.

Purely additive — no new state, no additional timers, no change to the happy path.

## Test plan

- [x] `node --check` on modified file
- [x] Behavioral repro: trigger transport close mid-turn → `captureTurn` now rejects with the exit error instead of hanging (previously observed three consecutive hangs on the same client against plugin v1.0.2)

## Notes

Companion PRs I'm filing separately:
- `fix(plugin): use danger-full-access sandbox so MCP tool calls work`
- `fix(broker-lifecycle): add PID-alive + age-based staleness check before reusing broker`

All three surfaced during forensic triage of /codex:rescue reliability issues; they are independent.