### PR TITLE
Fix stale companion job reconcile and bounded cancel

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -22,7 +22,7 @@ import {
   } from "./lib/codex.mjs";
 import { readStdinIfPiped } from "./lib/fs.mjs";
 import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./lib/git.mjs";
-import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
+import { binaryAvailable, inspectProcess, terminateProcessTree } from "./lib/process.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
 import {
   generateJobId,
@@ -66,6 +66,7 @@ const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json");
 const DEFAULT_STATUS_WAIT_TIMEOUT_MS = 240000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
+const DEFAULT_CANCEL_INTERRUPT_TIMEOUT_MS = 5000;
 const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
 const MODEL_ALIASES = new Map([["spark", "gpt-5.3-codex-spark"]]);
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
@@ -133,6 +134,11 @@ function normalizeArgv(argv) {
     return splitRawArgumentString(raw);
   }
   return argv;
+}
+
+function resolveCancelInterruptTimeoutMs(env = process.env) {
+  const parsed = Number(env.CODEX_COMPANION_CANCEL_INTERRUPT_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : DEFAULT_CANCEL_INTERRUPT_TIMEOUT_MS;
 }
 
 function parseCommandInput(argv, config = {}) {
@@ -929,8 +935,19 @@ async function handleCancel(argv) {
   const existing = readStoredJob(workspaceRoot, job.id) ?? {};
   const threadId = existing.threadId ?? job.threadId ?? null;
   const turnId = existing.turnId ?? job.turnId ?? null;
+  const previousStatus = job.status;
+  const pidInspection = inspectProcess(job.pid);
+  const interruptTimeoutMs = resolveCancelInterruptTimeoutMs();
 
-  const interrupt = await interruptAppServerTurn(cwd, { threadId, turnId });
+  const interrupt =
+    pidInspection.live === false
+      ? {
+          attempted: false,
+          interrupted: false,
+          transport: null,
+          detail: `Skipped Codex turn interrupt because job process is stale (${pidInspection.detail}).`
+        }
+      : await interruptAppServerTurn(cwd, { threadId, turnId, timeoutMs: interruptTimeoutMs });
   if (interrupt.attempted) {
     appendLogLine(
       job.logFile,
@@ -940,16 +957,29 @@ async function handleCancel(argv) {
     );
   }
 
-  terminateProcessTree(job.pid ?? Number.NaN);
+  let termination;
+  try {
+    termination = terminateProcessTree(job.pid ?? Number.NaN);
+  } catch (error) {
+    termination = {
+      attempted: true,
+      delivered: false,
+      method: null,
+      error: error instanceof Error ? error.message : String(error)
+    };
+  }
   appendLogLine(job.logFile, "Cancelled by user.");
 
   const completedAt = nowIso();
   const nextJob = {
     ...job,
+    previousStatus,
     status: "cancelled",
     phase: "cancelled",
     pid: null,
     completedAt,
+    cancelledAt: completedAt,
+    staleReconciliationReason: pidInspection.live === false ? pidInspection.reason : null,
     errorMessage: "Cancelled by user."
   };
 
@@ -971,6 +1001,16 @@ async function handleCancel(argv) {
     jobId: job.id,
     status: "cancelled",
     title: job.title,
+    previousStatus,
+    pid: pidInspection.pid,
+    cancelledAt: completedAt,
+    staleReconciliationReason: pidInspection.live === false ? pidInspection.reason : null,
+    process: pidInspection,
+    interrupt: {
+      ...interrupt,
+      timeoutMs: interrupt.attempted ? interruptTimeoutMs : null
+    },
+    termination,
     turnInterruptAttempted: interrupt.attempted,
     turnInterrupted: interrupt.interrupted
   };

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -40,6 +40,63 @@ const DEFAULT_CAPABILITIES = {
   ]
 };
 
+function parsePositiveInteger(value, fallback = 0) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : fallback;
+}
+
+export function forceCloseAppServerClient(client) {
+  if (!client) {
+    return;
+  }
+
+  try {
+    client.readline?.close();
+  } catch {
+    // Best-effort cleanup after a bounded initialize timeout.
+  }
+  try {
+    client.socket?.destroy();
+  } catch {
+    // Best-effort cleanup after a bounded initialize timeout.
+  }
+  try {
+    if (client.proc && !client.proc.killed && client.proc.exitCode === null) {
+      client.proc.kill("SIGTERM");
+      setTimeout(() => {
+        try {
+          if (client.proc && !client.proc.killed && client.proc.exitCode === null) {
+            client.proc.kill("SIGKILL");
+          }
+        } catch {
+          // Best-effort cleanup from an unref'd timer.
+        }
+      }, 50).unref?.();
+    }
+  } catch {
+    // Best-effort cleanup after a bounded initialize timeout.
+  }
+  client.close?.().catch(() => {});
+}
+
+function initializeWithTimeout(client, timeoutMs) {
+  let timeout = null;
+  return Promise.race([
+    client.initialize(),
+    new Promise((_, reject) => {
+      timeout = setTimeout(
+        () => reject(new Error(`Timed out after ${timeoutMs}ms while connecting to codex app-server.`)),
+        timeoutMs
+      );
+      timeout.unref?.();
+    })
+  ]).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
+}
+
 function buildJsonRpcError(code, message, data) {
   return data === undefined ? { code, message } : { code, message, data };
 }
@@ -344,7 +401,17 @@ export class CodexAppServerClient {
     const client = brokerEndpoint
       ? new BrokerCodexAppServerClient(cwd, { ...options, brokerEndpoint })
       : new SpawnedCodexAppServerClient(cwd, options);
-    await client.initialize();
-    return client;
+    try {
+      const initializeTimeoutMs = parsePositiveInteger(options.initializeTimeoutMs);
+      if (initializeTimeoutMs > 0) {
+        await initializeWithTimeout(client, initializeTimeoutMs);
+      } else {
+        await client.initialize();
+      }
+      return client;
+    } catch (error) {
+      forceCloseAppServerClient(client);
+      throw error;
+    }
   }
 }

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -35,7 +35,7 @@
  * }} TurnCaptureState
  */
 import { readJsonFile } from "./fs.mjs";
-import { BROKER_BUSY_RPC_CODE, BROKER_ENDPOINT_ENV, CodexAppServerClient } from "./app-server.mjs";
+import { BROKER_BUSY_RPC_CODE, BROKER_ENDPOINT_ENV, CodexAppServerClient, forceCloseAppServerClient } from "./app-server.mjs";
 import { loadBrokerSession } from "./broker-lifecycle.mjs";
 import { binaryAvailable } from "./process.mjs";
 
@@ -863,7 +863,27 @@ export async function getCodexAuthStatus(cwd, options = {}) {
   }
 }
 
-export async function interruptAppServerTurn(cwd, { threadId, turnId }) {
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.trunc(parsed) : fallback;
+}
+
+function withTimeout(promise, timeoutMs, message) {
+  let timeout = null;
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+      timeout.unref?.();
+    })
+  ]).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
+}
+
+export async function interruptAppServerTurn(cwd, { threadId, turnId, timeoutMs = null } = {}) {
   if (!threadId || !turnId) {
     return {
       attempted: false,
@@ -884,9 +904,22 @@ export async function interruptAppServerTurn(cwd, { threadId, turnId }) {
   }
 
   let client = null;
+  let forceClosed = false;
   try {
-    client = await CodexAppServerClient.connect(cwd, { reuseExistingBroker: true });
-    await client.request("turn/interrupt", { threadId, turnId });
+    const boundMs = parsePositiveInteger(timeoutMs, 0);
+    client =
+      boundMs > 0
+        ? await CodexAppServerClient.connect(cwd, { reuseExistingBroker: true, initializeTimeoutMs: boundMs })
+        : await CodexAppServerClient.connect(cwd, { reuseExistingBroker: true });
+    if (boundMs > 0) {
+      await withTimeout(
+        client.request("turn/interrupt", { threadId, turnId }),
+        boundMs,
+        `Timed out after ${boundMs}ms while interrupting ${turnId} on ${threadId}.`
+      );
+    } else {
+      await client.request("turn/interrupt", { threadId, turnId });
+    }
     return {
       attempted: true,
       interrupted: true,
@@ -894,6 +927,8 @@ export async function interruptAppServerTurn(cwd, { threadId, turnId }) {
       detail: `Interrupted ${turnId} on ${threadId}.`
     };
   } catch (error) {
+    forceCloseAppServerClient(client);
+    forceClosed = true;
     return {
       attempted: true,
       interrupted: false,
@@ -901,7 +936,9 @@ export async function interruptAppServerTurn(cwd, { threadId, turnId }) {
       detail: error instanceof Error ? error.message : String(error)
     };
   } finally {
-    await client?.close().catch(() => {});
+    if (!forceClosed) {
+      await client?.close().catch(() => {});
+    }
   }
 }
 

--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 
 import { getSessionRuntimeStatus } from "./codex.mjs";
-import { getConfig, listJobs, readJobFile, resolveJobFile } from "./state.mjs";
+import { getConfig, listJobs, readJobFile, reconcileActiveJobs, resolveJobFile } from "./state.mjs";
 import { SESSION_ID_ENV } from "./tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./workspace.mjs";
 
@@ -212,8 +212,11 @@ function matchJobReference(jobs, reference, predicate = () => true) {
 
 export function buildStatusSnapshot(cwd, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const reconciliation = reconcileActiveJobs(workspaceRoot, {
+    predicate: (job) => filterJobsForCurrentSession([job], options).length > 0
+  });
   const config = getConfig(workspaceRoot);
-  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot), options));
+  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(reconciliation.jobs, options));
   const maxJobs = options.maxJobs ?? DEFAULT_MAX_STATUS_JOBS;
   const maxProgressLines = options.maxProgressLines ?? DEFAULT_MAX_PROGRESS_LINES;
 
@@ -235,13 +238,15 @@ export function buildStatusSnapshot(cwd, options = {}) {
     running,
     latestFinished,
     recent,
+    reconciled: reconciliation.reconciled,
     needsReview: Boolean(config.stopReviewGate)
   };
 }
 
 export function buildSingleJobSnapshot(cwd, reference, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
-  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot));
+  const reconciliation = reconcileActiveJobs(workspaceRoot);
+  const jobs = sortJobsNewestFirst(reconciliation.jobs);
   const selected = matchJobReference(jobs, reference);
   if (!selected) {
     throw new Error(`No job found for "${reference}". Run /codex:status to inspect known jobs.`);

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -54,8 +54,63 @@ function looksLikeMissingProcessMessage(text) {
   return /not found|no running instance|cannot find|does not exist|no such process/i.test(text);
 }
 
+export function normalizePid(pidValue) {
+  const pid = Number(pidValue);
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return null;
+  }
+  return Math.trunc(pid);
+}
+
+export function inspectProcess(pidValue, options = {}) {
+  const pid = normalizePid(pidValue);
+  if (pid == null) {
+    return {
+      pid: null,
+      live: false,
+      reason: "missing_pid",
+      detail: "Job has no valid pid."
+    };
+  }
+
+  const killImpl = options.killImpl ?? process.kill.bind(process);
+  try {
+    killImpl(pid, 0);
+    return {
+      pid,
+      live: true,
+      reason: null,
+      detail: "Process is running."
+    };
+  } catch (error) {
+    if (error?.code === "EPERM") {
+      return {
+        pid,
+        live: true,
+        reason: null,
+        detail: "Process exists but cannot be signalled."
+      };
+    }
+    if (error?.code === "ESRCH") {
+      return {
+        pid,
+        live: false,
+        reason: "dead_pid",
+        detail: `Process ${pid} is not running.`
+      };
+    }
+    return {
+      pid,
+      live: null,
+      reason: "liveness_check_error",
+      detail: error instanceof Error ? error.message : String(error)
+    };
+  }
+}
+
 export function terminateProcessTree(pid, options = {}) {
-  if (!Number.isFinite(pid)) {
+  const normalizedPid = normalizePid(pid);
+  if (normalizedPid == null) {
     return { attempted: false, delivered: false, method: null };
   }
 
@@ -64,7 +119,7 @@ export function terminateProcessTree(pid, options = {}) {
   const killImpl = options.killImpl ?? process.kill.bind(process);
 
   if (platform === "win32") {
-    const result = runCommandImpl("taskkill", ["/PID", String(pid), "/T", "/F"], {
+    const result = runCommandImpl("taskkill", ["/PID", String(normalizedPid), "/T", "/F"], {
       cwd: options.cwd,
       env: options.env
     });
@@ -80,7 +135,7 @@ export function terminateProcessTree(pid, options = {}) {
 
     if (result.error?.code === "ENOENT") {
       try {
-        killImpl(pid);
+        killImpl(normalizedPid);
         return { attempted: true, delivered: true, method: "kill" };
       } catch (error) {
         if (error?.code === "ESRCH") {
@@ -98,12 +153,12 @@ export function terminateProcessTree(pid, options = {}) {
   }
 
   try {
-    killImpl(-pid, "SIGTERM");
+    killImpl(-normalizedPid, "SIGTERM");
     return { attempted: true, delivered: true, method: "process-group" };
   } catch (error) {
     if (error?.code !== "ESRCH") {
       try {
-        killImpl(pid, "SIGTERM");
+        killImpl(normalizedPid, "SIGTERM");
         return { attempted: true, delivered: true, method: "process" };
       } catch (innerError) {
         if (innerError?.code === "ESRCH") {

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { inspectProcess } from "./process.mjs";
 import { resolveWorkspaceRoot } from "./workspace.mjs";
 
 const STATE_VERSION = 1;
@@ -87,6 +88,113 @@ function removeFileIfExists(filePath) {
   if (filePath && fs.existsSync(filePath)) {
     fs.unlinkSync(filePath);
   }
+}
+
+function isActiveJob(job) {
+  return job?.status === "queued" || job?.status === "running";
+}
+
+function staleReasonDetail(inspection) {
+  if (inspection.reason === "missing_pid") {
+    return "missing pid";
+  }
+  if (inspection.reason === "dead_pid") {
+    return inspection.pid == null ? "dead pid" : `pid ${inspection.pid} is not running`;
+  }
+  return inspection.detail ?? "stale process";
+}
+
+function appendStaleJobLog(job, message) {
+  if (!job?.logFile) {
+    return;
+  }
+  try {
+    fs.appendFileSync(job.logFile, `[${nowIso()}] ${message}\n`, "utf8");
+  } catch {
+    // Best-effort diagnostics; reconciliation should not fail on log writes.
+  }
+}
+
+function persistJobFilePatch(cwd, jobId, patch) {
+  const jobFile = resolveJobFile(cwd, jobId);
+  if (!fs.existsSync(jobFile)) {
+    return;
+  }
+  try {
+    writeJobFile(cwd, jobId, {
+      ...readJobFile(jobFile),
+      ...patch
+    });
+  } catch {
+    // Ignore malformed or concurrently removed job files; state.json remains authoritative.
+  }
+}
+
+function buildStaleActiveJobPatch(job, inspection, timestamp) {
+  const reason = inspection.reason ?? "stale_process";
+  const detail = staleReasonDetail(inspection);
+  return {
+    ...job,
+    previousStatus: job.status,
+    status: "failed",
+    phase: "failed",
+    pid: null,
+    completedAt: timestamp,
+    staleReconciledAt: timestamp,
+    staleReconciliationReason: reason,
+    errorMessage: `Codex job was ${job.status} but its tracked process is stale (${detail}); auto-reconciled as failed.`,
+    updatedAt: timestamp
+  };
+}
+
+export function reconcileActiveJobs(cwd, options = {}) {
+  const state = loadState(cwd);
+  const timestamp = nowIso();
+  const reconciled = [];
+  let changed = false;
+
+  const jobs = (state.jobs ?? []).map((job) => {
+    if (!isActiveJob(job)) {
+      return job;
+    }
+    if (options.predicate && !options.predicate(job)) {
+      return job;
+    }
+
+    const inspection = inspectProcess(job.pid, options);
+    if (inspection.live !== false) {
+      return job;
+    }
+
+    changed = true;
+    const nextJob = buildStaleActiveJobPatch(job, inspection, timestamp);
+    reconciled.push({
+      id: job.id,
+      previousStatus: job.status,
+      pid: inspection.pid,
+      reason: inspection.reason,
+      completedAt: timestamp
+    });
+    appendStaleJobLog(
+      job,
+      `Detected stale ${job.status} job (${staleReasonDetail(inspection)}). Marked as failed automatically.`
+    );
+    persistJobFilePatch(cwd, job.id, nextJob);
+    return nextJob;
+  });
+
+  if (changed) {
+    saveState(cwd, {
+      ...state,
+      jobs
+    });
+  }
+
+  return {
+    changed,
+    reconciled,
+    jobs
+  };
 }
 
 export function saveState(cwd, state) {

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -545,6 +545,9 @@ rl.on("line", (line) => {
 	          turnId: message.params.turnId
 	        };
 	        saveState(state);
+	        if (BEHAVIOR === "interrupt-hangs") {
+	          break;
+	        }
 	        const pending = interruptibleTurns.get(message.params.turnId);
 	        if (pending) {
 	          clearTimeout(pending.timer);

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -1,7 +1,36 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+import { inspectProcess, normalizePid, terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+
+test("normalizePid rejects missing and invalid pid values", () => {
+  assert.equal(normalizePid(null), null);
+  assert.equal(normalizePid(""), null);
+  assert.equal(normalizePid(-1), null);
+  assert.equal(normalizePid("123.9"), 123);
+});
+
+test("inspectProcess reports missing and dead pids deterministically", () => {
+  assert.deepEqual(inspectProcess(null), {
+    pid: null,
+    live: false,
+    reason: "missing_pid",
+    detail: "Job has no valid pid."
+  });
+
+  const dead = inspectProcess(1234, {
+    killImpl() {
+      const error = new Error("no such process");
+      error.code = "ESRCH";
+      throw error;
+    }
+  });
+
+  assert.equal(dead.pid, 1234);
+  assert.equal(dead.live, false);
+  assert.equal(dead.reason, "dead_pid");
+  assert.match(dead.detail, /not running/);
+});
 
 test("terminateProcessTree uses taskkill on Windows", () => {
   let captured = null;

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -977,6 +977,7 @@ test("status shows phases, hints, and the latest finished job", () => {
             phase: "reviewing",
             threadId: "thr_1",
             summary: "Review working tree diff",
+            pid: process.pid,
             logFile,
             createdAt: "2026-03-18T15:30:00.000Z",
             updatedAt: "2026-03-18T15:30:03.000Z"
@@ -1053,6 +1054,7 @@ test("status without a job id only shows jobs from the current Claude session", 
             sessionId: "sess-current",
             threadId: "thr_current",
             summary: "Current session review",
+            pid: process.pid,
             logFile: currentLog,
             createdAt: "2026-03-18T15:30:00.000Z",
             updatedAt: "2026-03-18T15:30:00.000Z"
@@ -1120,6 +1122,7 @@ test("status preserves adversarial review kind labels", () => {
             phase: "reviewing",
             threadId: "thr_adv_live",
             summary: "Adversarial review current changes",
+            pid: process.pid,
             logFile,
             createdAt: "2026-03-18T15:30:00.000Z",
             updatedAt: "2026-03-18T15:30:00.000Z"
@@ -1192,6 +1195,7 @@ test("status --wait times out cleanly when a job is still active", () => {
             title: "Codex Task",
             jobClass: "task",
             summary: "Investigate flaky test",
+            pid: process.pid,
             logFile,
             createdAt: "2026-03-18T15:30:00.000Z",
             startedAt: "2026-03-18T15:30:01.000Z",
@@ -1496,6 +1500,224 @@ test("cancel stops an active background job and marks it cancelled", async (t) =
   const stored = JSON.parse(fs.readFileSync(jobFile, "utf8"));
   assert.equal(stored.status, "cancelled");
   assert.match(fs.readFileSync(logFile, "utf8"), /Cancelled by user/);
+});
+
+test("cancel returns deterministic JSON for a missing-pid active job without starting codex", () => {
+  const workspace = makeTempDir();
+  const binDir = makeTempDir();
+  const fakeStatePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir, "interrupt-hangs");
+
+  const stateDir = resolveStateDir(workspace);
+  const jobsDir = path.join(stateDir, "jobs");
+  fs.mkdirSync(jobsDir, { recursive: true });
+
+  const logFile = path.join(jobsDir, "task-missing-pid.log");
+  const jobFile = path.join(jobsDir, "task-missing-pid.json");
+  fs.writeFileSync(logFile, "", "utf8");
+  fs.writeFileSync(
+    jobFile,
+    JSON.stringify(
+      {
+        id: "task-missing-pid",
+        status: "running",
+        title: "Codex Task",
+        threadId: "thr_missing",
+        turnId: "turn_missing",
+        logFile
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+  fs.writeFileSync(
+    path.join(stateDir, "state.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        config: { stopReviewGate: false },
+        jobs: [
+          {
+            id: "task-missing-pid",
+            status: "running",
+            title: "Codex Task",
+            jobClass: "task",
+            threadId: "thr_missing",
+            turnId: "turn_missing",
+            logFile,
+            createdAt: "2026-03-18T15:30:00.000Z",
+            updatedAt: "2026-03-18T15:30:02.000Z"
+          }
+        ]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  const cancel = run("node", [SCRIPT, "cancel", "task-missing-pid", "--json"], {
+    cwd: workspace,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(cancel.status, 0, cancel.stderr);
+  const payload = JSON.parse(cancel.stdout);
+  assert.equal(payload.status, "cancelled");
+  assert.equal(payload.previousStatus, "running");
+  assert.equal(payload.pid, null);
+  assert.equal(payload.staleReconciliationReason, "missing_pid");
+  assert.equal(payload.interrupt.attempted, false);
+  assert.equal(payload.termination.attempted, false);
+  assert.equal(fs.existsSync(fakeStatePath), false);
+
+  const state = JSON.parse(fs.readFileSync(path.join(stateDir, "state.json"), "utf8"));
+  assert.equal(state.jobs[0].status, "cancelled");
+  assert.equal(state.jobs[0].pid, null);
+
+  const stored = JSON.parse(fs.readFileSync(jobFile, "utf8"));
+  assert.equal(stored.status, "cancelled");
+  assert.equal(stored.cancelledAt, payload.cancelledAt);
+});
+
+test("cancel returns deterministic JSON for a dead-pid active job without app-server interrupt", () => {
+  const workspace = makeTempDir();
+  const binDir = makeTempDir();
+  const fakeStatePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir, "interrupt-hangs");
+
+  const stateDir = resolveStateDir(workspace);
+  const jobsDir = path.join(stateDir, "jobs");
+  fs.mkdirSync(jobsDir, { recursive: true });
+
+  const logFile = path.join(jobsDir, "task-dead-pid.log");
+  fs.writeFileSync(logFile, "", "utf8");
+  fs.writeFileSync(
+    path.join(stateDir, "state.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        config: { stopReviewGate: false },
+        jobs: [
+          {
+            id: "task-dead-pid",
+            status: "running",
+            title: "Codex Task",
+            jobClass: "task",
+            pid: 999999,
+            threadId: "thr_dead",
+            turnId: "turn_dead",
+            logFile,
+            createdAt: "2026-03-18T15:30:00.000Z",
+            updatedAt: "2026-03-18T15:30:02.000Z"
+          }
+        ]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  const cancel = run("node", [SCRIPT, "cancel", "task-dead-pid", "--json"], {
+    cwd: workspace,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(cancel.status, 0, cancel.stderr);
+  const payload = JSON.parse(cancel.stdout);
+  assert.equal(payload.status, "cancelled");
+  assert.equal(payload.pid, 999999);
+  assert.equal(payload.staleReconciliationReason, "dead_pid");
+  assert.equal(payload.interrupt.attempted, false);
+  assert.equal(payload.termination.attempted, true);
+  assert.equal(payload.termination.delivered, false);
+  assert.equal(fs.existsSync(fakeStatePath), false);
+});
+
+test("cancel bounds a live job app-server interrupt and still terminates the process", async (t) => {
+  const workspace = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "interrupt-hangs");
+
+  const stateDir = resolveStateDir(workspace);
+  const jobsDir = path.join(stateDir, "jobs");
+  fs.mkdirSync(jobsDir, { recursive: true });
+
+  const sleeper = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+    cwd: workspace,
+    detached: true,
+    stdio: "ignore"
+  });
+  sleeper.unref();
+
+  t.after(() => {
+    try {
+      process.kill(-sleeper.pid, "SIGTERM");
+    } catch {
+      try {
+        process.kill(sleeper.pid, "SIGTERM");
+      } catch {
+        // Ignore missing process.
+      }
+    }
+  });
+
+  const logFile = path.join(jobsDir, "task-timeout.log");
+  fs.writeFileSync(logFile, "", "utf8");
+  fs.writeFileSync(
+    path.join(stateDir, "state.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        config: { stopReviewGate: false },
+        jobs: [
+          {
+            id: "task-timeout",
+            status: "running",
+            title: "Codex Task",
+            jobClass: "task",
+            pid: sleeper.pid,
+            threadId: "thr_timeout",
+            turnId: "turn_timeout",
+            logFile,
+            createdAt: "2026-03-18T15:30:00.000Z",
+            updatedAt: "2026-03-18T15:30:02.000Z"
+          }
+        ]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  const cancel = run("node", [SCRIPT, "cancel", "task-timeout", "--json"], {
+    cwd: workspace,
+    env: {
+      ...buildEnv(binDir),
+      CODEX_COMPANION_CANCEL_INTERRUPT_TIMEOUT_MS: "50"
+    }
+  });
+
+  assert.equal(cancel.status, 0, cancel.stderr);
+  const payload = JSON.parse(cancel.stdout);
+  assert.equal(payload.status, "cancelled");
+  assert.equal(payload.interrupt.attempted, true);
+  assert.equal(payload.interrupt.interrupted, false);
+  assert.equal(payload.interrupt.timeoutMs, 50);
+  assert.match(payload.interrupt.detail, /Timed out after 50ms/);
+  assert.equal(payload.termination.attempted, true);
+
+  await waitFor(() => {
+    try {
+      process.kill(sleeper.pid, 0);
+      return false;
+    } catch (error) {
+      return error?.code === "ESRCH";
+    }
+  });
 });
 
 test("cancel without a job id ignores active jobs from other Claude sessions", () => {

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -5,7 +5,15 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { makeTempDir } from "./helpers.mjs";
-import { resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState } from "../plugins/codex/scripts/lib/state.mjs";
+import {
+  reconcileActiveJobs,
+  resolveJobFile,
+  resolveJobLogFile,
+  resolveStateDir,
+  resolveStateFile,
+  saveState,
+  writeJobFile
+} from "../plugins/codex/scripts/lib/state.mjs";
 
 test("resolveStateDir uses a temp-backed per-workspace directory", () => {
   const workspace = makeTempDir();
@@ -102,4 +110,77 @@ test("saveState prunes dropped job artifacts when indexed jobs exceed the cap", 
       .flatMap((jobId) => [`${jobId}.json`, `${jobId}.log`])
       .sort()
   );
+});
+
+test("reconcileActiveJobs marks missing-pid running jobs failed and persists diagnostics", () => {
+  const workspace = makeTempDir();
+  const jobId = "task-stale-missing-pid";
+  const logFile = resolveJobLogFile(workspace, jobId);
+  const job = {
+    id: jobId,
+    status: "running",
+    phase: "running",
+    title: "Codex Task",
+    logFile,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z"
+  };
+  fs.writeFileSync(logFile, "[2026-01-01T00:00:00.000Z] Starting Codex Task.\n", "utf8");
+  saveState(workspace, {
+    version: 1,
+    config: { stopReviewGate: false },
+    jobs: [job]
+  });
+  writeJobFile(workspace, jobId, job);
+
+  const result = reconcileActiveJobs(workspace);
+
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.reconciled.map((entry) => entry.reason), ["missing_pid"]);
+  assert.equal(result.jobs[0].status, "failed");
+  assert.equal(result.jobs[0].previousStatus, "running");
+  assert.equal(result.jobs[0].pid, null);
+  assert.equal(result.jobs[0].staleReconciliationReason, "missing_pid");
+  assert.match(result.jobs[0].errorMessage, /auto-reconciled as failed/);
+
+  const persistedState = JSON.parse(fs.readFileSync(resolveStateFile(workspace), "utf8"));
+  assert.equal(persistedState.jobs[0].status, "failed");
+  assert.equal(persistedState.jobs[0].staleReconciliationReason, "missing_pid");
+
+  const persistedJob = JSON.parse(fs.readFileSync(resolveJobFile(workspace, jobId), "utf8"));
+  assert.equal(persistedJob.status, "failed");
+  assert.equal(persistedJob.previousStatus, "running");
+  assert.match(fs.readFileSync(logFile, "utf8"), /Detected stale running job/);
+});
+
+test("reconcileActiveJobs marks dead-pid queued jobs failed", () => {
+  const workspace = makeTempDir();
+  const jobId = "task-stale-dead-pid";
+  const job = {
+    id: jobId,
+    status: "queued",
+    phase: "queued",
+    title: "Codex Task",
+    pid: 424242,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z"
+  };
+  saveState(workspace, {
+    version: 1,
+    config: { stopReviewGate: false },
+    jobs: [job]
+  });
+
+  const result = reconcileActiveJobs(workspace, {
+    killImpl() {
+      const error = new Error("no such process");
+      error.code = "ESRCH";
+      throw error;
+    }
+  });
+
+  assert.equal(result.changed, true);
+  assert.equal(result.jobs[0].status, "failed");
+  assert.equal(result.jobs[0].previousStatus, "queued");
+  assert.equal(result.jobs[0].staleReconciliationReason, "dead_pid");
 });


### PR DESCRIPTION
## Failure Signal

`codex-companion status --all --json` can keep stale `queued` / `running` jobs visible forever when their tracked pid is missing or dead, and `codex-companion cancel <job-id> --json` can hang or fail to emit deterministic cleanup diagnostics when the job process is already gone or app-server interrupt does not return.

## Root Cause Hypothesis

Active job state was rendered directly from `state.json` without validating whether the tracked process was still live. The cancel path also always attempted app-server interrupt for live-looking jobs and did not bound the interrupt request or serialize process cleanup outcomes in the JSON payload.

## Reproduction And Guard

This PR adds tests for:

- missing-pid running jobs being reconciled as failed and persisted to `state.json` and the per-job file
- dead-pid queued jobs being reconciled as failed
- cancel of missing-pid active jobs returning JSON without starting Codex
- cancel of dead-pid active jobs returning JSON without app-server interrupt
- cancel of live jobs bounding a hanging app-server interrupt while still terminating the process

## Fix Plan

- Add process pid normalization and liveness inspection helpers.
- Reconcile stale active jobs before status snapshots so dead jobs do not remain under `running`.
- Keep cancel resolution independent from status reconciliation so `cancel <job-id>` can still clean up stale active records deterministically.
- Skip interrupt for missing/dead pid jobs; bound interrupt for live jobs.
- Persist cancellation and stale reconciliation diagnostics while keeping existing `status: "cancelled"`, `turnInterruptAttempted`, and `turnInterrupted` fields.
- Add app-server initialize/request timeout cleanup so timed-out interrupt attempts do not leave child handles keeping the command alive.

## Verification Plan

- `npm test` passes locally: 93 tests, 0 failures.

## Out of Scope

- Runner behavior outside this companion plugin.
- Changing the `@openai/codex` CLI package.
- Changing existing command names or removing existing JSON fields.
