### PR TITLE
[codex] AET-416 align adversarial review disposition contract

### DIFF
--- a/plugins/codex/prompts/adversarial-review.md
+++ b/plugins/codex/prompts/adversarial-review.md
@@ -58,7 +58,7 @@ Every finding must include:
 - a concrete recommendation
 - `blocker_class`: one of `runtime_or_behavioral_regression`, `trust_or_safety`, `contract_or_evidence`, `architecture_or_scope`
 - `merge_impact`: one of `merge_blocker`, `follow_up_debt`, `non_blocking_polish`
-- `follow_up_ticket` when `merge_impact` is `follow_up_debt`, formatted as `AET-<number>`
+- `follow_up_ticket`: formatted as `AET-<number>` when `merge_impact` is `follow_up_debt`; otherwise use an empty string
 Write the summary like a terse ship/no-ship assessment, not a neutral recap.
 </structured_output_contract>
 

--- a/plugins/codex/prompts/adversarial-review.md
+++ b/plugins/codex/prompts/adversarial-review.md
@@ -50,11 +50,15 @@ Return only valid JSON matching the provided schema.
 Keep the output compact and specific.
 Use `needs-attention` if there is any material risk worth blocking on.
 Use `approve` only if you cannot support any substantive adversarial finding from the provided context.
+Use `approve` only when `findings` is empty.
 Every finding must include:
 - the affected file
 - `line_start` and `line_end`
 - a confidence score from 0 to 1
 - a concrete recommendation
+- `blocker_class`: one of `runtime_or_behavioral_regression`, `trust_or_safety`, `contract_or_evidence`, `architecture_or_scope`
+- `merge_impact`: one of `merge_blocker`, `follow_up_debt`, `non_blocking_polish`
+- `follow_up_ticket` when `merge_impact` is `follow_up_debt`, formatted as `AET-<number>`
 Write the summary like a terse ship/no-ship assessment, not a neutral recap.
 </structured_output_contract>
 
@@ -77,6 +81,7 @@ Before finalizing, check that each finding is:
 - tied to a concrete code location
 - plausible under a real failure scenario
 - actionable for an engineer fixing the issue
+- classified with the required `blocker_class` and `merge_impact`
 </final_check>
 
 <repository_context>

--- a/plugins/codex/schemas/review-output.schema.json
+++ b/plugins/codex/schemas/review-output.schema.json
@@ -35,7 +35,8 @@
           "confidence",
           "recommendation",
           "blocker_class",
-          "merge_impact"
+          "merge_impact",
+          "follow_up_ticket"
         ],
         "properties": {
           "severity": {
@@ -93,8 +94,7 @@
             ]
           },
           "follow_up_ticket": {
-            "type": "string",
-            "pattern": "^AET-[1-9][0-9]*$"
+            "type": "string"
           }
         }
       }

--- a/plugins/codex/schemas/review-output.schema.json
+++ b/plugins/codex/schemas/review-output.schema.json
@@ -23,154 +23,95 @@
     "findings": {
       "type": "array",
       "items": {
-        "anyOf": [
-          {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "severity",
-              "title",
-              "body",
-              "file",
-              "line_start",
-              "line_end",
-              "confidence",
-              "recommendation",
-              "blocker_class",
-              "merge_impact"
-            ],
-            "properties": {
-              "severity": {
-                "type": "string",
-                "enum": [
-                  "critical",
-                  "high",
-                  "medium",
-                  "low"
-                ]
-              },
-              "title": {
-                "type": "string",
-                "minLength": 1
-              },
-              "body": {
-                "type": "string",
-                "minLength": 1
-              },
-              "file": {
-                "type": "string",
-                "minLength": 1
-              },
-              "line_start": {
-                "type": "integer",
-                "minimum": 1
-              },
-              "line_end": {
-                "type": "integer",
-                "minimum": 1
-              },
-              "confidence": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 1
-              },
-              "recommendation": {
-                "type": "string"
-              },
-              "blocker_class": {
-                "type": "string",
-                "enum": [
-                  "runtime_or_behavioral_regression",
-                  "trust_or_safety",
-                  "contract_or_evidence",
-                  "architecture_or_scope"
-                ]
-              },
-              "merge_impact": {
-                "type": "string",
-                "enum": [
-                  "merge_blocker",
-                  "non_blocking_polish"
-                ]
-              }
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "severity",
+          "title",
+          "body",
+          "file",
+          "line_start",
+          "line_end",
+          "confidence",
+          "recommendation",
+          "blocker_class",
+          "merge_impact"
+        ],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": [
+              "critical",
+              "high",
+              "medium",
+              "low"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1
+          },
+          "file": {
+            "type": "string",
+            "minLength": 1
+          },
+          "line_start": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "line_end": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "recommendation": {
+            "type": "string"
+          },
+          "blocker_class": {
+            "type": "string",
+            "enum": [
+              "runtime_or_behavioral_regression",
+              "trust_or_safety",
+              "contract_or_evidence",
+              "architecture_or_scope"
+            ]
+          },
+          "merge_impact": {
+            "type": "string",
+            "enum": [
+              "merge_blocker",
+              "follow_up_debt",
+              "non_blocking_polish"
+            ]
+          },
+          "follow_up_ticket": {
+            "type": "string",
+            "pattern": "^AET-[1-9][0-9]*$"
+          }
+        },
+        "if": {
+          "properties": {
+            "merge_impact": {
+              "const": "follow_up_debt"
             }
           },
-          {
-            "type": "object",
-            "additionalProperties": false,
-            "required": [
-              "severity",
-              "title",
-              "body",
-              "file",
-              "line_start",
-              "line_end",
-              "confidence",
-              "recommendation",
-              "blocker_class",
-              "merge_impact",
-              "follow_up_ticket"
-            ],
-            "properties": {
-              "severity": {
-                "type": "string",
-                "enum": [
-                  "critical",
-                  "high",
-                  "medium",
-                  "low"
-                ]
-              },
-              "title": {
-                "type": "string",
-                "minLength": 1
-              },
-              "body": {
-                "type": "string",
-                "minLength": 1
-              },
-              "file": {
-                "type": "string",
-                "minLength": 1
-              },
-              "line_start": {
-                "type": "integer",
-                "minimum": 1
-              },
-              "line_end": {
-                "type": "integer",
-                "minimum": 1
-              },
-              "confidence": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 1
-              },
-              "recommendation": {
-                "type": "string"
-              },
-              "blocker_class": {
-                "type": "string",
-                "enum": [
-                  "runtime_or_behavioral_regression",
-                  "trust_or_safety",
-                  "contract_or_evidence",
-                  "architecture_or_scope"
-                ]
-              },
-              "merge_impact": {
-                "type": "string",
-                "enum": [
-                  "follow_up_debt"
-                ]
-              },
-              "follow_up_ticket": {
-                "type": "string",
-                "pattern": "^AET-[1-9][0-9]*$"
-              }
-            }
-          }
-        ]
+          "required": [
+            "merge_impact"
+          ]
+        },
+        "then": {
+          "required": [
+            "follow_up_ticket"
+          ]
+        }
       }
     },
     "next_steps": {

--- a/plugins/codex/schemas/review-output.schema.json
+++ b/plugins/codex/schemas/review-output.schema.json
@@ -96,21 +96,6 @@
             "type": "string",
             "pattern": "^AET-[1-9][0-9]*$"
           }
-        },
-        "if": {
-          "properties": {
-            "merge_impact": {
-              "const": "follow_up_debt"
-            }
-          },
-          "required": [
-            "merge_impact"
-          ]
-        },
-        "then": {
-          "required": [
-            "follow_up_ticket"
-          ]
         }
       }
     },

--- a/plugins/codex/schemas/review-output.schema.json
+++ b/plugins/codex/schemas/review-output.schema.json
@@ -23,96 +23,151 @@
     "findings": {
       "type": "array",
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "severity",
-          "title",
-          "body",
-          "file",
-          "line_start",
-          "line_end",
-          "confidence",
-          "recommendation",
-          "blocker_class",
-          "merge_impact"
-        ],
-        "properties": {
-          "severity": {
-            "type": "string",
-            "enum": [
-              "critical",
-              "high",
-              "medium",
-              "low"
-            ]
-          },
-          "title": {
-            "type": "string",
-            "minLength": 1
-          },
-          "body": {
-            "type": "string",
-            "minLength": 1
-          },
-          "file": {
-            "type": "string",
-            "minLength": 1
-          },
-          "line_start": {
-            "type": "integer",
-            "minimum": 1
-          },
-          "line_end": {
-            "type": "integer",
-            "minimum": 1
-          },
-          "confidence": {
-            "type": "number",
-            "minimum": 0,
-            "maximum": 1
-          },
-          "recommendation": {
-            "type": "string"
-          },
-          "blocker_class": {
-            "type": "string",
-            "enum": [
-              "runtime_or_behavioral_regression",
-              "trust_or_safety",
-              "contract_or_evidence",
-              "architecture_or_scope"
-            ]
-          },
-          "merge_impact": {
-            "type": "string",
-            "enum": [
-              "merge_blocker",
-              "follow_up_debt",
-              "non_blocking_polish"
-            ]
-          },
-          "follow_up_ticket": {
-            "type": "string",
-            "pattern": "^AET-[1-9][0-9]*$"
-          }
-        },
-        "allOf": [
+        "anyOf": [
           {
-            "if": {
-              "properties": {
-                "merge_impact": {
-                  "const": "follow_up_debt"
-                }
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "severity",
+              "title",
+              "body",
+              "file",
+              "line_start",
+              "line_end",
+              "confidence",
+              "recommendation",
+              "blocker_class",
+              "merge_impact"
+            ],
+            "properties": {
+              "severity": {
+                "type": "string",
+                "enum": [
+                  "critical",
+                  "high",
+                  "medium",
+                  "low"
+                ]
               },
-              "required": [
-                "merge_impact"
-              ]
-            },
-            "then": {
-              "required": [
-                "follow_up_ticket"
-              ]
+              "title": {
+                "type": "string",
+                "minLength": 1
+              },
+              "body": {
+                "type": "string",
+                "minLength": 1
+              },
+              "file": {
+                "type": "string",
+                "minLength": 1
+              },
+              "line_start": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "line_end": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "confidence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "recommendation": {
+                "type": "string"
+              },
+              "blocker_class": {
+                "type": "string",
+                "enum": [
+                  "runtime_or_behavioral_regression",
+                  "trust_or_safety",
+                  "contract_or_evidence",
+                  "architecture_or_scope"
+                ]
+              },
+              "merge_impact": {
+                "type": "string",
+                "enum": [
+                  "merge_blocker",
+                  "non_blocking_polish"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "severity",
+              "title",
+              "body",
+              "file",
+              "line_start",
+              "line_end",
+              "confidence",
+              "recommendation",
+              "blocker_class",
+              "merge_impact",
+              "follow_up_ticket"
+            ],
+            "properties": {
+              "severity": {
+                "type": "string",
+                "enum": [
+                  "critical",
+                  "high",
+                  "medium",
+                  "low"
+                ]
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1
+              },
+              "body": {
+                "type": "string",
+                "minLength": 1
+              },
+              "file": {
+                "type": "string",
+                "minLength": 1
+              },
+              "line_start": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "line_end": {
+                "type": "integer",
+                "minimum": 1
+              },
+              "confidence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "recommendation": {
+                "type": "string"
+              },
+              "blocker_class": {
+                "type": "string",
+                "enum": [
+                  "runtime_or_behavioral_regression",
+                  "trust_or_safety",
+                  "contract_or_evidence",
+                  "architecture_or_scope"
+                ]
+              },
+              "merge_impact": {
+                "type": "string",
+                "enum": [
+                  "follow_up_debt"
+                ]
+              },
+              "follow_up_ticket": {
+                "type": "string",
+                "pattern": "^AET-[1-9][0-9]*$"
+              }
             }
           }
         ]

--- a/plugins/codex/schemas/review-output.schema.json
+++ b/plugins/codex/schemas/review-output.schema.json
@@ -33,7 +33,9 @@
           "line_start",
           "line_end",
           "confidence",
-          "recommendation"
+          "recommendation",
+          "blocker_class",
+          "merge_impact"
         ],
         "properties": {
           "severity": {
@@ -72,8 +74,48 @@
           },
           "recommendation": {
             "type": "string"
+          },
+          "blocker_class": {
+            "type": "string",
+            "enum": [
+              "runtime_or_behavioral_regression",
+              "trust_or_safety",
+              "contract_or_evidence",
+              "architecture_or_scope"
+            ]
+          },
+          "merge_impact": {
+            "type": "string",
+            "enum": [
+              "merge_blocker",
+              "follow_up_debt",
+              "non_blocking_polish"
+            ]
+          },
+          "follow_up_ticket": {
+            "type": "string",
+            "pattern": "^AET-[1-9][0-9]*$"
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "merge_impact": {
+                  "const": "follow_up_debt"
+                }
+              },
+              "required": [
+                "merge_impact"
+              ]
+            },
+            "then": {
+              "required": [
+                "follow_up_ticket"
+              ]
+            }
+          }
+        ]
       }
     },
     "next_steps": {

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -55,7 +55,10 @@ function normalizeReviewFinding(finding, index) {
     file: typeof source.file === "string" && source.file.trim() ? source.file.trim() : "unknown",
     line_start: lineStart,
     line_end: lineEnd,
-    recommendation: typeof source.recommendation === "string" ? source.recommendation.trim() : ""
+    recommendation: typeof source.recommendation === "string" ? source.recommendation.trim() : "",
+    blocker_class: typeof source.blocker_class === "string" ? source.blocker_class.trim() : "",
+    merge_impact: typeof source.merge_impact === "string" ? source.merge_impact.trim() : "",
+    follow_up_ticket: typeof source.follow_up_ticket === "string" ? source.follow_up_ticket.trim() : ""
   };
 }
 
@@ -267,6 +270,15 @@ export function renderReviewResult(parsedResult, meta) {
       const lineSuffix = formatLineRange(finding);
       lines.push(`- [${finding.severity}] ${finding.title} (${finding.file}${lineSuffix})`);
       lines.push(`  ${finding.body}`);
+      if (finding.blocker_class) {
+        lines.push(`  Blocker class: ${finding.blocker_class}`);
+      }
+      if (finding.merge_impact) {
+        lines.push(`  Merge impact: ${finding.merge_impact}`);
+      }
+      if (finding.follow_up_ticket) {
+        lines.push(`  Follow-up ticket: ${finding.follow_up_ticket}`);
+      }
       if (finding.recommendation) {
         lines.push(`  Recommendation: ${finding.recommendation}`);
       }

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -197,7 +197,10 @@ function structuredReviewPayload(prompt) {
           line_start: 4,
           line_end: 6,
           confidence: 0.87,
-          recommendation: "Handle empty collections before indexing."
+          recommendation: "Handle empty collections before indexing.",
+          blocker_class: "contract_or_evidence",
+          merge_impact: "follow_up_debt",
+          follow_up_ticket: "AET-413"
         }
       ],
       next_steps: ["Add an empty-state test."]

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -57,3 +57,40 @@ test("renderStoredJobResult prefers rendered output for structured review jobs",
   assert.match(output, /Codex session ID: thr_123/);
   assert.match(output, /Resume in Codex: codex resume thr_123/);
 });
+
+test("renderReviewResult includes adversarial disposition metadata when present", () => {
+  const output = renderReviewResult(
+    {
+      parsed: {
+        verdict: "needs-attention",
+        summary: "One issue needs follow-up.",
+        findings: [
+          {
+            severity: "high",
+            title: "Missing empty-state guard",
+            body: "The change assumes data is always present.",
+            file: "src/app.js",
+            line_start: 4,
+            line_end: 6,
+            confidence: 0.87,
+            recommendation: "Handle empty collections before indexing.",
+            blocker_class: "contract_or_evidence",
+            merge_impact: "follow_up_debt",
+            follow_up_ticket: "AET-413"
+          }
+        ],
+        next_steps: ["Add an empty-state test."]
+      },
+      rawOutput: "",
+      parseError: null
+    },
+    {
+      reviewLabel: "Adversarial Review",
+      targetLabel: "working tree diff"
+    }
+  );
+
+  assert.match(output, /Blocker class: contract_or_evidence/);
+  assert.match(output, /Merge impact: follow_up_debt/);
+  assert.match(output, /Follow-up ticket: AET-413/);
+});

--- a/tests/review-contract.test.mjs
+++ b/tests/review-contract.test.mjs
@@ -1,0 +1,162 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const PLUGIN_ROOT = path.join(ROOT, "plugins", "codex");
+const REVIEW_SCHEMA = JSON.parse(
+  fs.readFileSync(path.join(PLUGIN_ROOT, "schemas", "review-output.schema.json"), "utf8")
+);
+const ADVERSARIAL_PROMPT = fs.readFileSync(
+  path.join(PLUGIN_ROOT, "prompts", "adversarial-review.md"),
+  "utf8"
+);
+
+const VALID_BLOCKER_CLASSES = new Set([
+  "runtime_or_behavioral_regression",
+  "trust_or_safety",
+  "contract_or_evidence",
+  "architecture_or_scope"
+]);
+const VALID_MERGE_IMPACTS = new Set([
+  "merge_blocker",
+  "follow_up_debt",
+  "non_blocking_polish"
+]);
+const FOLLOW_UP_TICKET_PATTERN = /^AET-[1-9][0-9]*$/;
+const ALLOWED_FINDING_KEYS = new Set([
+  "severity",
+  "title",
+  "body",
+  "file",
+  "line_start",
+  "line_end",
+  "confidence",
+  "recommendation",
+  "blocker_class",
+  "merge_impact",
+  "follow_up_ticket"
+]);
+
+function validateFinding(finding) {
+  if (!finding || typeof finding !== "object" || Array.isArray(finding)) {
+    return "finding must be an object";
+  }
+
+  for (const key of Object.keys(finding)) {
+    if (!ALLOWED_FINDING_KEYS.has(key)) {
+      return `unexpected key: ${key}`;
+    }
+  }
+
+  if (!VALID_BLOCKER_CLASSES.has(finding.blocker_class)) {
+    return "missing or invalid blocker_class";
+  }
+  if (!VALID_MERGE_IMPACTS.has(finding.merge_impact)) {
+    return "missing or invalid merge_impact";
+  }
+  if (finding.merge_impact === "follow_up_debt" && !FOLLOW_UP_TICKET_PATTERN.test(finding.follow_up_ticket ?? "")) {
+    return "follow_up_ticket required for follow_up_debt";
+  }
+
+  return null;
+}
+
+test("review schema keeps verdict stable while requiring disposition metadata on findings", () => {
+  assert.deepEqual(REVIEW_SCHEMA.properties.verdict.enum, ["approve", "needs-attention"]);
+  const findingSchema = REVIEW_SCHEMA.properties.findings.items;
+  assert.equal(findingSchema.additionalProperties, false);
+  assert.deepEqual(
+    findingSchema.required.slice(-2),
+    ["blocker_class", "merge_impact"]
+  );
+  assert.deepEqual(findingSchema.properties.blocker_class.enum, [
+    "runtime_or_behavioral_regression",
+    "trust_or_safety",
+    "contract_or_evidence",
+    "architecture_or_scope"
+  ]);
+  assert.deepEqual(findingSchema.properties.merge_impact.enum, [
+    "merge_blocker",
+    "follow_up_debt",
+    "non_blocking_polish"
+  ]);
+  assert.equal(findingSchema.properties.follow_up_ticket.pattern, "^AET-[1-9][0-9]*$");
+});
+
+test("enriched needs-attention finding with follow_up_ticket satisfies the producer contract", () => {
+  const finding = {
+    severity: "high",
+    title: "Missing empty-state guard",
+    body: "The change assumes data is always present.",
+    file: "src/app.js",
+    line_start: 4,
+    line_end: 6,
+    confidence: 0.87,
+    recommendation: "Handle empty collections before indexing.",
+    blocker_class: "contract_or_evidence",
+    merge_impact: "follow_up_debt",
+    follow_up_ticket: "AET-413"
+  };
+
+  assert.equal(validateFinding(finding), null);
+});
+
+test("producer contract rejects findings without blocker_class", () => {
+  const finding = {
+    severity: "high",
+    title: "Missing empty-state guard",
+    body: "The change assumes data is always present.",
+    file: "src/app.js",
+    line_start: 4,
+    line_end: 6,
+    confidence: 0.87,
+    recommendation: "Handle empty collections before indexing.",
+    merge_impact: "follow_up_debt",
+    follow_up_ticket: "AET-413"
+  };
+
+  assert.equal(validateFinding(finding), "missing or invalid blocker_class");
+});
+
+test("producer contract rejects findings without merge_impact", () => {
+  const finding = {
+    severity: "high",
+    title: "Missing empty-state guard",
+    body: "The change assumes data is always present.",
+    file: "src/app.js",
+    line_start: 4,
+    line_end: 6,
+    confidence: 0.87,
+    recommendation: "Handle empty collections before indexing.",
+    blocker_class: "contract_or_evidence"
+  };
+
+  assert.equal(validateFinding(finding), "missing or invalid merge_impact");
+});
+
+test("producer contract rejects follow_up_debt without follow_up_ticket", () => {
+  const finding = {
+    severity: "high",
+    title: "Missing empty-state guard",
+    body: "The change assumes data is always present.",
+    file: "src/app.js",
+    line_start: 4,
+    line_end: 6,
+    confidence: 0.87,
+    recommendation: "Handle empty collections before indexing.",
+    blocker_class: "contract_or_evidence",
+    merge_impact: "follow_up_debt"
+  };
+
+  assert.equal(validateFinding(finding), "follow_up_ticket required for follow_up_debt");
+});
+
+test("adversarial prompt instructs Codex to emit the disposition contract fields", () => {
+  assert.match(ADVERSARIAL_PROMPT, /Use `approve` only when `findings` is empty\./);
+  assert.match(ADVERSARIAL_PROMPT, /`blocker_class`/);
+  assert.match(ADVERSARIAL_PROMPT, /`merge_impact`/);
+  assert.match(ADVERSARIAL_PROMPT, /`follow_up_ticket` when `merge_impact` is `follow_up_debt`/);
+});

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -250,6 +250,9 @@ test("adversarial review renders structured findings over app-server turn/start"
 
   assert.equal(result.status, 0);
   assert.match(result.stdout, /Missing empty-state guard/);
+  assert.match(result.stdout, /Blocker class: contract_or_evidence/);
+  assert.match(result.stdout, /Merge impact: follow_up_debt/);
+  assert.match(result.stdout, /Follow-up ticket: AET-413/);
 });
 
 test("adversarial review accepts the same base-branch targeting as review", () => {


### PR DESCRIPTION
## Summary
- add Aetherion disposition fields to the adversarial review-output schema
- teach the adversarial-review prompt to require blocker and merge-impact classification
- surface the new disposition metadata in rendered review output and cover it with tests

## Why
Aetherion's wrapper needs machine-readable blocker vs debt semantics. This keeps the producer contract explicit instead of forcing the wrapper to infer meaning from prose or severity.

## Validation
- `npm test`
- `git diff --check`
