### PR TITLE
fix(codex-rescue): append </dev/null to codex-companion task invocation

### DIFF
--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -19,7 +19,8 @@ Selection guidance:
 
 Forwarding rules:
 
-- Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ...`.
+- Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ... </dev/null`.
+- Always append `</dev/null` to the Bash invocation. Without it the codex-companion node process can hang reading from stdin (Codex skill execution often hangs in Claude Code with "Reading additional input from stdin..." errors when stdin is left attached to the parent shell).
 - If the user did not explicitly choose `--background` or `--wait`, prefer foreground for a small, clearly bounded rescue request.
 - If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution.
 - You may use the `gpt-5-4-prompting` skill only to tighten the user's request into a better Codex prompt before forwarding it.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -9,7 +9,9 @@ user-invocable: false
 Use this skill only inside the `codex:codex-rescue` subagent.
 
 Primary helper:
-- `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task "<raw arguments>"`
+- `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task "<raw arguments>" </dev/null`
+
+The `</dev/null` redirect is mandatory. Without it the codex-companion node process can hang reading from stdin (Codex skill execution often hangs in Claude Code with "Reading additional input from stdin..." errors when stdin is left attached to the parent shell).
 
 Execution rules:
 - The rescue subagent is a forwarder, not an orchestrator. Its only job is to invoke `task` once and return that stdout unchanged.


### PR DESCRIPTION
## Summary

Append `</dev/null` to the `node codex-companion.mjs task ...` Bash invocation documented in:
- `plugins/codex/agents/codex-rescue.md`
- `plugins/codex/skills/codex-cli-runtime/SKILL.md`

Without this stdin redirect, the node process can hang when stdin is left attached to the parent shell. In Claude Code this surfaces as `Reading additional input from stdin...` errors that block long-running Codex dispatches at indeterminate points (post-fixture, post-commit, etc.) — the wrapper reports "completed" but the underlying node process never returns to terminal state.

## Reproducer

Two consecutive Codex dispatches in a downstream repo (2026-04-27) where Codex:
- Correctly wrote all expected files
- Ran regression tests to PASS (verified via `codex-companion.mjs status` `progressPreview`)
- Then hung 30+ minutes before the would-be `git commit`/`git push` step

External `codex-companion.mjs status --json` confirmed the job was still listed as `"status": "running"` with the node process alive. Killing the process unblocked the hang and the partial work was visible on disk. Appending `</dev/null` to the invocation in the local plugin cache prevented the hang on subsequent dispatches.

## Diff

```diff
--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -19,7 +19,8 @@
 
 Forwarding rules:
 
-- Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ...`.
+- Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ... </dev/null`.
+- Always append `</dev/null` to the Bash invocation. Without it the codex-companion node process can hang reading from stdin (Codex skill execution often hangs in Claude Code with "Reading additional input from stdin..." errors when stdin is left attached to the parent shell).

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -9,7 +9,9 @@
 Use this skill only inside the \`codex:codex-rescue\` subagent.
 
 Primary helper:
-- \`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task "<raw arguments>"\`
+- \`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task "<raw arguments>" </dev/null\`
+
+The \`</dev/null\` redirect is mandatory. Without it the codex-companion node process can hang reading from stdin (Codex skill execution often hangs in Claude Code with "Reading additional input from stdin..." errors when stdin is left attached to the parent shell).
```

## Why this is safe

- The `node codex-companion.mjs task` invocation is a forwarder — it does not itself read from stdin meaningfully. The node child processes Codex spawns also do not depend on the parent's stdin being attached.
- The `</dev/null` redirect only affects the spawned process's stdin (any read returns EOF immediately). It does not affect arguments, env vars, output, or the parent shell.
- Standard pattern for non-interactive shell-spawned node processes.

## Test plan

- [ ] Existing dispatch behavior unchanged when stdin is already detached (no regression)
- [ ] Long-running dispatches no longer hang post-fixture / post-commit when invoked from Claude Code
- [ ] Background mode (`--background`) and foreground mode both unaffected by the redirect

The patch is minimal — two file edits, 5 lines added — and includes a short inline rationale so a future cleanup pass doesn't strip the redirect without context.