### PR TITLE
feat: add /codex:attach command for live log streaming

### DIFF
--- a/plugins/codex/commands/attach.md
+++ b/plugins/codex/commands/attach.md
@@ -1,0 +1,13 @@
+---
+description: Attach to a running Codex job and stream its live log output until it completes
+argument-hint: '[job-id] [--poll-interval-ms <ms>]'
+disable-model-invocation: true
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" attach "$ARGUMENTS"`
+
+Present the command output verbatim to the user. Do not summarize or condense it.
+
+If no active job is found, tell the user to start one with `/codex:rescue`.
+If a job ID was not specified, the command automatically attaches to the most recent active job.

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -28,6 +28,7 @@ import {
   generateJobId,
   getConfig,
   listJobs,
+  resolveJobLogFile,
   setConfig,
   upsertJob,
   writeJobFile
@@ -837,6 +838,62 @@ async function handleTaskWorker(argv) {
   );
 }
 
+async function handleAttach(argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["cwd", "poll-interval-ms"],
+    booleanOptions: []
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+  const pollIntervalMs = Math.max(200, Number(options["poll-interval-ms"]) || 500);
+  const reference = positionals[0] ?? "";
+
+  let job;
+  if (reference) {
+    const snapshot = buildSingleJobSnapshot(cwd, reference);
+    job = snapshot.job;
+  } else {
+    const jobs = sortJobsNewestFirst(listJobs(workspaceRoot));
+    job = jobs.find((j) => isActiveJobStatus(j.status)) ?? jobs[0] ?? null;
+  }
+
+  if (!job) {
+    process.stdout.write("No Codex job found. Start one with /codex:rescue.\n");
+    return;
+  }
+
+  const logFile = job.logFile ?? resolveJobLogFile(workspaceRoot, job.id);
+  process.stdout.write(`[attach] Job ${job.id} · status: ${job.status}\n`);
+  if (job.title) process.stdout.write(`[attach] Task: ${job.title}\n`);
+  process.stdout.write(`[attach] Log: ${logFile}\n---\n`);
+
+  let offset = 0;
+
+  function flushNewLogContent() {
+    if (!fs.existsSync(logFile)) return;
+    const content = fs.readFileSync(logFile, "utf8");
+    if (content.length > offset) {
+      process.stdout.write(content.slice(offset));
+      offset = content.length;
+    }
+  }
+
+  flushNewLogContent();
+
+  while (true) {
+    await sleep(pollIntervalMs);
+    flushNewLogContent();
+
+    const currentJob = listJobs(workspaceRoot).find((j) => j.id === job.id);
+    if (!currentJob || !isActiveJobStatus(currentJob.status)) {
+      flushNewLogContent();
+      process.stdout.write(`\n--- Job ${job.id} ${currentJob?.status ?? "gone"} ---\n`);
+      break;
+    }
+  }
+}
+
 async function handleStatus(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["cwd", "timeout-ms", "poll-interval-ms"],
@@ -1014,6 +1071,9 @@ async function main() {
       break;
     case "cancel":
       await handleCancel(argv);
+      break;
+    case "attach":
+      await handleAttach(argv);
       break;
     default:
       throw new Error(`Unknown subcommand: ${subcommand}`);


### PR DESCRIPTION
## Problem

Background Codex jobs (`/codex:rescue --background`) are a black box. Once fired, there's no way to observe what Codex is doing until the job completes. The only options are polling `/codex:status` (which shows a one-line phase summary) or waiting for `/codex:result` (which shows the final output only).

Meanwhile, the background worker already writes every event — thread start, turn start, command executions, assistant messages, completion — to a structured log file on disk. That data just goes unobserved.

## Solution

Add `/codex:attach [job-id]` — a new command that tails the job's log file in real time and exits cleanly when the job reaches a terminal status.

```
/codex:attach                    # attaches to the most recent active job
/codex:attach task-abc123        # attaches to a specific job by ID
/codex:attach task-abc123 --poll-interval-ms 250   # faster polling
```

**Example output:**
```
[attach] Job task-moozar3f-3ly2x1 · status: running
[attach] Task: Security audit of freudche-be/ and freudche-cortex/
[attach] Log: ~/.claude/plugins/data/.../jobs/task-moozar3f-3ly2x1.log
---
[2026-05-03T00:12:01Z] Starting Codex Task.
[2026-05-03T00:12:01Z] Queued for background execution.
[2026-05-03T00:12:02Z] Starting Codex task thread.
[2026-05-03T00:12:04Z] Turn started (019dead8-...).
[2026-05-03T00:12:04Z] Running command: rg -n "api_key|secret" freudche-be/
...

--- Job task-moozar3f-3ly2x1 completed ---
```

## Implementation

**`plugins/codex/scripts/codex-companion.mjs`** — new `handleAttach()` function + `attach` case in the dispatch switch:
- Resolves the job by ID or falls back to the most recent active job via `listJobs()` + `sortJobsNewestFirst()`
- Reads log file path from `job.logFile` (falls back to `resolveJobLogFile()`)
- Polls for new log content every 500ms (configurable via `--poll-interval-ms`)
- Simultaneously polls job state for terminal status (`completed`, `failed`, `cancelled`)
- Final log flush + closing line on exit — no content is missed

**`plugins/codex/commands/attach.md`** — command definition following the same pattern as `status.md` and `cancel.md`.

## What this does NOT change

- No existing commands or behaviours are modified
- No new dependencies
- Background mode, foreground mode, review commands — all untouched
- Works entirely with the existing `state.mjs` / `job-control.mjs` infrastructure

## Context: why not MCP streaming?

We investigated whether `codex mcp-server` streaming notifications could solve this. The Codex MCP server does emit events as MCP notifications during execution, but Claude Code silently drops them (the MCP client does not forward `notifications/progress` or `notifications/message` to the model — tracked in anthropics/claude-code#4157, closed "not planned"). The log file approach is the reliable path and requires no protocol changes on either side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)