### PR TITLE
fix(stop-review-gate): treat job as inactive when its pid is dead

### DIFF
--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -150,6 +150,36 @@ export function listJobs(cwd) {
   return loadState(cwd).jobs;
 }
 
+/**
+ * Check whether a process with the given pid is currently alive.
+ * Cross-platform: uses `process.kill(pid, 0)` which sends signal 0
+ * (no-op signal) and throws ESRCH if the process is gone. EPERM means
+ * the process exists but we lack permission to signal it (still alive).
+ */
+export function isPidAlive(pid) {
+  if (!pid || typeof pid !== "number") return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return err && err.code === "EPERM";
+  }
+}
+
+/**
+ * A job counts as "active" only if its status says queued/running AND
+ * the recorded pid is still alive. This prevents zombie state from
+ * causing false alarms when the codex process was SIGKILL'd
+ * (e.g., by a cleanup script or an OS reboot) without getting a chance
+ * to write status="completed" to disk.
+ */
+export function isJobActive(job) {
+  if (!job) return false;
+  if (job.status !== "queued" && job.status !== "running") return false;
+  if (!job.pid) return false;
+  return isPidAlive(job.pid);
+}
+
 export function setConfig(cwd, key, value) {
   return updateState(cwd, (state) => {
     state.config = {

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 
 import { getCodexAvailability } from "./lib/codex.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
-import { getConfig, listJobs } from "./lib/state.mjs";
+import { getConfig, isJobActive, listJobs } from "./lib/state.mjs";
 import { sortJobsNewestFirst } from "./lib/job-control.mjs";
 import { SESSION_ID_ENV } from "./lib/tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
@@ -146,7 +146,7 @@ function main() {
   const config = getConfig(workspaceRoot);
 
   const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot), input));
-  const runningJob = jobs.find((job) => job.status === "queued" || job.status === "running");
+  const runningJob = jobs.find(isJobActive);
   const runningTaskNote = runningJob
     ? `Codex task ${runningJob.id} is still running. Check /codex:status and use /codex:cancel ${runningJob.id} if you want to stop it before ending the session.`
     : null;


### PR DESCRIPTION
## Summary

Codex plugin job state (`state.json` / `jobs/task-*.json`) records `status: "running"` while a job is in flight. The dying `codex.exe` is expected to update this field to `"completed"` / `"cancelled"` on exit, but that responsibility cannot be honored if the process is killed by something external (`SIGKILL`, OS reboot, power loss, a cleanup script, or `taskkill /F`).

Result: zombie entries with `status: "running"` accumulate in `state.json`. `stop-review-gate-hook.mjs` reads them, finds a "running" entry, and emits `Codex task task-XYZ is still running.` on every session end — even when no Codex process is actually alive. Users have to either ignore the false alarm or repeatedly invoke `/codex:cancel` against ghost ids that no longer exist.

We hit this in the wild on 2026-05-05: 11 zombie entries with status `"running"` persisted across multiple sessions after a process cleanup; all 11 pids were verified dead via the host OS but the hook continued firing. The root cause is that the hook trusts `status` as a single source of truth without verifying the recorded `pid`.

## Fix

Add two helpers in `plugins/codex/scripts/lib/state.mjs`:

- `isPidAlive(pid)` — cross-platform pid liveness via `process.kill(pid, 0)` (`ESRCH` = dead, `EPERM` = exists but unsignalable / still alive). Both error codes handled correctly.
- `isJobActive(job)` — combines the existing `status === "queued" || "running"` check with `isPidAlive(job.pid)`. Returns `false` when `pid` is missing (older state format) so it fails safe.

Replace the inline filter in `plugins/codex/scripts/stop-review-gate-hook.mjs`:

```diff
-  const runningJob = jobs.find((job) => job.status === "queued" || job.status === "running");
+  const runningJob = jobs.find(isJobActive);
```

Net change: ~30 lines added, 1 line modified.

## Why this scope (read-only)

The patch does **not** mutate `state.json`. Persistent zombie cleanup (rewriting `status: "running"` to `"cancelled"` with a `cancelReason` field) deserves its own PR — it changes mutation semantics that other consumers (e.g., `/codex:status`) depend on. The hook fix alone stops the user-visible noise immediately and is safe to land independently.

## Test plan

Smoke-tested locally on Windows (Node v24, but the helpers use only standard Node APIs):

- [x] `isPidAlive(99999999)` → `false` (dead pid)
- [x] `isPidAlive(process.pid)` → `true` (self)
- [x] `isPidAlive(null)` → `false`
- [x] `isJobActive({status: "running", pid: process.pid})` → `true`
- [x] `isJobActive({status: "running", pid: 99999999})` → `false` (zombie case)
- [x] `isJobActive({status: "completed", pid: process.pid})` → `false` (already done)
- [x] `isJobActive({status: "running", pid: null})` → `false` (older state, fails safe)
- [x] `node --check` on both modified files

End-to-end: injected a fake `{id: "task-FAKE", status: "running", pid: 99999999}` into a real `state.json`, confirmed the hook previously emitted `Codex task task-FAKE is still running.`, applied the patch, confirmed no false alarm, then verified a real long-lived process with a recorded pid is still detected correctly.

## Caveats

- For workspaces where `pid` was never recorded (older format, pre-pid-tracking), the helper falls back to `false` (treat as inactive) rather than trusting status alone. This is the safer default for the false-alarm use case but is technically a behavior change for that legacy slice. If reviewers prefer, we can fall back to the old status-only check when `pid` is missing — happy to adjust.
- Persistent zombies remain in `state.json` until a separate cleanup pass rewrites them. We have a sweeper script in our downstream workspace; we'd be glad to contribute it as a follow-up PR if the maintainers are interested in folding it in.

## Notes for reviewer

This was discovered during a downstream workspace audit (Nippon Medical School research environment). The local mitigation (a PowerShell sweeper run on `SessionStart`) is already in place; this upstream PR is the smaller, safer half of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
