### PR TITLE
Fix broker shutdown hang on unresponsive socket

### DIFF
--- a/plugins/codex/scripts/lib/broker-lifecycle.mjs
+++ b/plugins/codex/scripts/lib/broker-lifecycle.mjs
@@ -40,19 +40,28 @@ export async function waitForBrokerEndpoint(endpoint, timeoutMs = 2000) {
   return false;
 }
 
-export async function sendBrokerShutdown(endpoint) {
+export async function sendBrokerShutdown(endpoint, timeoutMs = 5000) {
   await new Promise((resolve) => {
     const socket = connectToEndpoint(endpoint);
+    let settled = false;
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      resolve();
+    };
+    const timer = setTimeout(finish, timeoutMs);
+
     socket.setEncoding("utf8");
     socket.on("connect", () => {
       socket.write(`${JSON.stringify({ id: 1, method: "broker/shutdown", params: {} })}\n`);
     });
-    socket.on("data", () => {
-      socket.end();
-      resolve();
-    });
-    socket.on("error", resolve);
-    socket.on("close", resolve);
+    socket.on("data", finish);
+    socket.on("error", finish);
+    socket.on("close", finish);
   });
 }
 

--- a/tests/broker-lifecycle.test.mjs
+++ b/tests/broker-lifecycle.test.mjs
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { sendBrokerShutdown } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { makeTempDir } from "./helpers.mjs";
+
+test("sendBrokerShutdown resolves when the broker accepts the socket but never replies", async () => {
+  const socketPath = path.join(makeTempDir(), "broker.sock");
+  let receivedShutdown = false;
+
+  const server = net.createServer((socket) => {
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      if (String(chunk).includes("broker/shutdown")) {
+        receivedShutdown = true;
+      }
+      // Deliberately keep the socket open without responding.
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+
+  try {
+    const startedAt = Date.now();
+    await sendBrokerShutdown(`unix:${socketPath}`, 50);
+    assert.equal(receivedShutdown, true);
+    assert.ok(Date.now() - startedAt < 1000);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    if (fs.existsSync(socketPath)) {
+      fs.unlinkSync(socketPath);
+    }
+  }
+});

--- a/tests/broker-lifecycle.test.mjs
+++ b/tests/broker-lifecycle.test.mjs
@@ -4,18 +4,23 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { createBrokerEndpoint, parseBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-endpoint.mjs";
 import { sendBrokerShutdown } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
 import { makeTempDir } from "./helpers.mjs";
 
 test("sendBrokerShutdown resolves when the broker accepts the socket but never replies", async () => {
-  const socketPath = path.join(makeTempDir(), "broker.sock");
-  let receivedShutdown = false;
+  const endpoint = createBrokerEndpoint(makeTempDir(), process.platform);
+  const { path: socketPath } = parseBrokerEndpoint(endpoint);
+  let resolveShutdownReceived;
+  const shutdownReceived = new Promise((resolve) => {
+    resolveShutdownReceived = resolve;
+  });
 
   const server = net.createServer((socket) => {
     socket.setEncoding("utf8");
     socket.on("data", (chunk) => {
       if (String(chunk).includes("broker/shutdown")) {
-        receivedShutdown = true;
+        resolveShutdownReceived();
       }
       // Deliberately keep the socket open without responding.
     });
@@ -28,8 +33,7 @@ test("sendBrokerShutdown resolves when the broker accepts the socket but never r
 
   try {
     const startedAt = Date.now();
-    await sendBrokerShutdown(`unix:${socketPath}`, 50);
-    assert.equal(receivedShutdown, true);
+    await Promise.all([sendBrokerShutdown(endpoint, 500), shutdownReceived]);
     assert.ok(Date.now() - startedAt < 1000);
   } finally {
     await new Promise((resolve) => server.close(resolve));


### PR DESCRIPTION
## Summary

Fixes a SessionEnd hang where `sendBrokerShutdown` could wait indefinitely if the broker accepted the shutdown socket connection but never replied, errored, or closed.

This adds a bounded timeout to the shutdown RPC and uses a single guarded cleanup path for `data`, `error`, `close`, and timeout.

## Changes

- Add `timeoutMs = 5000` to `sendBrokerShutdown`
- Resolve shutdown on timeout instead of waiting forever
- Destroy the socket during cleanup
- Add a regression test for a broker that accepts `broker/shutdown` but never responds

## Testing

```bash
node --test tests/broker-lifecycle.test.mjs
npm test
```

Full suite passed locally: 87 passed, 0 failed.

Fixes #288 .