### PR TITLE
refactor: rename gpt-5-4-prompting skill to codex-prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Examples:
 /codex:rescue investigate why the tests started failing
 /codex:rescue fix the failing test with the smallest safe patch
 /codex:rescue --resume apply the top fix from the last run
-/codex:rescue --model gpt-5.4-mini --effort medium investigate the flaky integration test
+/codex:rescue --model <your-model> --effort medium investigate the flaky integration test
 /codex:rescue --model spark fix the issue quickly
 /codex:rescue --background investigate the regression
 ```
@@ -255,10 +255,10 @@ The Codex plugin wraps the [Codex app server](https://developers.openai.com/code
 
 ### Common Configurations
 
-If you want to change the default reasoning effort or the default model that gets used by the plugin, you can define that inside your user-level or project-level `config.toml`. For example to always use `gpt-5.4-mini` on `high` for a specific project you can add the following to a `.codex/config.toml` file at the root of the directory you started Claude in:
+If you want to change the default reasoning effort or the default model that gets used by the plugin, you can define that inside your user-level or project-level `config.toml`. For example to always use a specific model on `high` reasoning effort for a project you can add the following to a `.codex/config.toml` file at the root of the directory you started Claude in:
 
 ```toml
-model = "gpt-5.4-mini"
+model = "<your-model>"
 model_reasoning_effort = "high"
 ```
 

--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -5,7 +5,7 @@ model: sonnet
 tools: Bash
 skills:
   - codex-cli-runtime
-  - gpt-5-4-prompting
+  - codex-prompting
 ---
 
 You are a thin forwarding wrapper around the Codex companion task runtime.
@@ -22,14 +22,14 @@ Forwarding rules:
 - Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ...`.
 - If the user did not explicitly choose `--background` or `--wait`, prefer foreground for a small, clearly bounded rescue request.
 - If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution.
-- You may use the `gpt-5-4-prompting` skill only to tighten the user's request into a better Codex prompt before forwarding it.
+- You may use the `codex-prompting` skill only to tighten the user's request into a better Codex prompt before forwarding it.
 - Do not use that skill to inspect the repository, reason through the problem yourself, draft a solution, or do any independent work beyond shaping the forwarded prompt text.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
 - Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`. This subagent only forwards to `task`.
 - Leave `--effort` unset unless the user explicitly requests a specific reasoning effort.
 - Leave model unset by default. Only add `--model` when the user explicitly asks for a specific model.
 - If the user asks for `spark`, map that to `--model gpt-5.3-codex-spark`.
-- If the user asks for a concrete model name such as `gpt-5.4-mini`, pass it through with `--model`.
+- If the user asks for a concrete model name (such as one configured in their `~/.codex/config.toml`), pass it through with `--model`.
 - Treat `--effort <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
 - Default to a write-capable Codex run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
 - Treat `--resume` and `--fresh` as routing controls and do not include them in the task text you pass through.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -16,7 +16,7 @@ Execution rules:
 - Prefer the helper over hand-rolled `git`, direct Codex CLI strings, or any other Bash activity.
 - Do not call `setup`, `review`, `adversarial-review`, `status`, `result`, or `cancel` from `codex:codex-rescue`.
 - Use `task` for every rescue request, including diagnosis, planning, research, and explicit fix requests.
-- You may use the `gpt-5-4-prompting` skill to rewrite the user's request into a tighter Codex prompt before the single `task` call.
+- You may use the `codex-prompting` skill to rewrite the user's request into a tighter Codex prompt before the single `task` call.
 - That prompt drafting is the only Claude-side work allowed. Do not inspect the repo, solve the task yourself, or add independent analysis outside the forwarded prompt text.
 - Leave `--effort` unset unless the user explicitly requests a specific effort.
 - Leave model unset by default. Add `--model` only when the user explicitly asks for one.

--- a/plugins/codex/skills/codex-prompting/SKILL.md
+++ b/plugins/codex/skills/codex-prompting/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: gpt-5-4-prompting
-description: Internal guidance for composing Codex and GPT-5.4 prompts for coding, review, diagnosis, and research tasks inside the Codex Claude Code plugin
+name: codex-prompting
+description: Internal guidance for composing Codex prompts for coding, review, diagnosis, and research tasks inside the Codex Claude Code plugin
 user-invocable: false
 ---
 
-# GPT-5.4 Prompting
+# Codex Prompting
 
-Use this skill when `codex:codex-rescue` needs to ask Codex or another GPT-5.4-based workflow for help.
+Use this skill when `codex:codex-rescue` needs to ask Codex for help.
 
 Prompt Codex like an operator, not a collaborator. Keep prompts compact and block-structured with XML tags. State the task, the output contract, the follow-through defaults, and the small set of extra constraints that matter.
 

--- a/plugins/codex/skills/codex-prompting/references/codex-prompt-antipatterns.md
+++ b/plugins/codex/skills/codex-prompting/references/codex-prompt-antipatterns.md
@@ -1,6 +1,6 @@
 # Codex Prompt Anti-Patterns
 
-Avoid these when prompting Codex or GPT-5.4.
+Avoid these when prompting Codex.
 
 ## Vague task framing
 

--- a/plugins/codex/skills/codex-prompting/references/codex-prompt-recipes.md
+++ b/plugins/codex/skills/codex-prompting/references/codex-prompt-recipes.md
@@ -1,6 +1,6 @@
 # Codex Prompt Recipes
 
-Use these as starting templates for Codex task prompts or other Codex/GPT-5.4 prompt construction.
+Use these as starting templates for Codex task prompts.
 Copy the smallest recipe that fits the task, then trim anything you do not need.
 In `codex:codex-rescue`, run diagnosis and fix-oriented recipes in write mode by default unless the user explicitly asked for read-only behavior.
 
@@ -128,7 +128,7 @@ Prefer primary sources.
 
 ```xml
 <task>
-Diagnose why this existing prompt is underperforming and propose the smallest high-leverage changes to improve it for Codex or GPT-5.4.
+Diagnose why this existing prompt is underperforming and propose the smallest high-leverage changes to improve it for Codex.
 </task>
 
 <structured_output_contract>

--- a/plugins/codex/skills/codex-prompting/references/prompt-blocks.md
+++ b/plugins/codex/skills/codex-prompting/references/prompt-blocks.md
@@ -1,6 +1,6 @@
 # Prompt Blocks
 
-Use these blocks selectively when composing Codex or GPT-5.4 prompts.
+Use these blocks selectively when composing Codex prompts.
 Wrap each block in the XML tag shown in its heading.
 
 ## Core Wrapper

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -134,15 +134,15 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(agent, /Leave `--effort` unset unless the user explicitly requests a specific reasoning effort/i);
   assert.match(agent, /Leave model unset by default/i);
   assert.match(agent, /If the user asks for `spark`, map that to `--model gpt-5\.3-codex-spark`/i);
-  assert.match(agent, /If the user asks for a concrete model name such as `gpt-5\.4-mini`, pass it through with `--model`/i);
+  assert.match(agent, /If the user asks for a concrete model name \(such as one configured in their `~\/\.codex\/config\.toml`\), pass it through with `--model`/i);
   assert.match(agent, /Return the stdout of the `codex-companion` command exactly as-is/i);
   assert.match(agent, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
-  assert.match(agent, /gpt-5-4-prompting/);
+  assert.match(agent, /codex-prompting/);
   assert.match(agent, /only to tighten the user's request into a better Codex prompt/i);
   assert.match(agent, /Do not use that skill to inspect the repository, reason through the problem yourself, draft a solution, or do any independent work/i);
   assert.match(runtimeSkill, /only job is to invoke `task` once and return that stdout unchanged/i);
   assert.match(runtimeSkill, /Do not call `setup`, `review`, `adversarial-review`, `status`, `result`, or `cancel`/i);
-  assert.match(runtimeSkill, /use the `gpt-5-4-prompting` skill to rewrite the user's request into a tighter Codex prompt/i);
+  assert.match(runtimeSkill, /use the `codex-prompting` skill to rewrite the user's request into a tighter Codex prompt/i);
   assert.match(runtimeSkill, /That prompt drafting is the only Claude-side work allowed/i);
   assert.match(runtimeSkill, /Leave `--effort` unset unless the user explicitly requests a specific effort/i);
   assert.match(runtimeSkill, /Leave model unset by default/i);
@@ -154,7 +154,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
   assert.match(readme, /`codex:codex-rescue` subagent/i);
   assert.match(readme, /if you do not pass `--model` or `--effort`, Codex chooses its own defaults/i);
-  assert.match(readme, /--model gpt-5\.4-mini --effort medium/i);
+  assert.match(readme, /--model <your-model> --effort medium/i);
   assert.match(readme, /`spark`, the plugin maps that to `gpt-5\.3-codex-spark`/i);
   assert.match(readme, /continue a previous Codex task/i);
   assert.match(readme, /### `\/codex:setup`/);
@@ -183,8 +183,8 @@ test("result and cancel commands are exposed as deterministic runtime entrypoint
 
 test("internal docs use task terminology for rescue runs", () => {
   const runtimeSkill = read("skills/codex-cli-runtime/SKILL.md");
-  const promptingSkill = read("skills/gpt-5-4-prompting/SKILL.md");
-  const promptRecipes = read("skills/gpt-5-4-prompting/references/codex-prompt-recipes.md");
+  const promptingSkill = read("skills/codex-prompting/SKILL.md");
+  const promptRecipes = read("skills/codex-prompting/references/codex-prompt-recipes.md");
 
   assert.match(runtimeSkill, /codex-companion\.mjs" task "<raw arguments>"/);
   assert.match(runtimeSkill, /Use `task` for every rescue request/i);


### PR DESCRIPTION
## Summary
- Rename the `gpt-5-4-prompting` skill to `codex-prompting` so the label doesn't go stale as GPT iterates. The skill is really about prompting Codex (the runtime), not a specific GPT generation, and Codex already routes to whatever model the user has configured.
- Drop "GPT-5.4" mentions from the skill body and reference files. Update cross-references in `agents/codex-rescue.md` and `skills/codex-cli-runtime/SKILL.md`.
- Replace example `gpt-5.4-mini` strings in the README and the agent's model-passthrough rule with a `<your-model>` placeholder, since the actual model selection flows through `~/.codex/config.toml` and `--model`.
- Update assertions in `tests/commands.test.mjs` to match.

Net-zero diff: 8 files, 21 insertions, 21 deletions. Folder rename detected by git (history preserved).

## Test plan
- [x] `node --test tests/commands.test.mjs` — all 8 assertions pass on the new branch
- [x] No remaining `gpt-5-4` / `GPT-5.4` / `gpt-5.4-mini` strings in user-facing `.md`/`.mjs`/`.json`/`.toml` (verified via grep)
- [x] Pre-existing failures in `runtime.test.mjs` and `state.test.mjs` confirmed unrelated — same 4 failures appear on baseline `main` when this branch's changes are stashed

## Notes
- `tests/fake-codex-fixture.mjs` still has `gpt-5.4` as a mock-server fallback. It's internal test infrastructure (not user-facing, not asserted on); left untouched to keep the diff minimal.
- The skill name has to be static — Claude Code resolves it from frontmatter at load time and can't reflect runtime config dynamically. Making it model-agnostic is the closest practical equivalent to "tied to whatever model the user has configured."