### PR TITLE
fix: drop non-JSONL garbage on codex app-server stdout

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -14,6 +14,7 @@ import { spawn } from "node:child_process";
 import readline from "node:readline";
 import { parseBrokerEndpoint } from "./broker-endpoint.mjs";
 import { ensureBrokerSession, loadBrokerSession } from "./broker-lifecycle.mjs";
+import { cleanProtocolLine } from "./jsonl.mjs";
 import { terminateProcessTree } from "./process.mjs";
 
 const PLUGIN_MANIFEST_URL = new URL("../../.claude-plugin/plugin.json", import.meta.url);
@@ -114,16 +115,20 @@ class AppServerClientBase {
     }
   }
 
-  handleLine(line) {
-    if (!line.trim()) {
+  handleLine(rawLine) {
+    const candidate = cleanProtocolLine(rawLine);
+    if (candidate === null) {
+      // Empty line, terminal noise (issue #23), or localized OS messages
+      // (e.g. CP-950 mojibaked taskkill SUCCESS on Windows zh-TW). Drop
+      // it instead of tearing the connection down — see lib/jsonl.mjs.
       return;
     }
 
     let message;
     try {
-      message = JSON.parse(line);
+      message = JSON.parse(candidate);
     } catch (error) {
-      this.handleExit(createProtocolError(`Failed to parse codex app-server JSONL: ${error.message}`, { line }));
+      this.handleExit(createProtocolError(`Failed to parse codex app-server JSONL: ${error.message}`, { line: rawLine }));
       return;
     }
 

--- a/plugins/codex/scripts/lib/jsonl.mjs
+++ b/plugins/codex/scripts/lib/jsonl.mjs
@@ -1,0 +1,60 @@
+/**
+ * Helpers for reading the Codex app-server JSONL protocol.
+ *
+ * The codex CLI's app-server occasionally emits non-JSON bytes onto stdout
+ * that have nothing to do with the protocol. Two known sources:
+ *
+ *   1. Terminal/shell init noise — e.g. zsh writes the bracketed-paste
+ *      marker `\x1b[?2004h` when a subprocess inherits the parent's TTY
+ *      (issue #23).
+ *
+ *   2. Localized OS messages on Windows non-English locales. On zh-TW
+ *      (CP-950 / Big5), when codex.exe runs `taskkill /T /F` to clean up
+ *      a failed MCP child and inadvertently routes taskkill's stdout to
+ *      its own stdout, we see the bytes `A6 A8 A5 5C 3A 20 50 49 44 ...`
+ *      ("成功: PID 為 xxxx ...") which decode under UTF-8 as
+ *      `���\\: PID ...`.
+ *
+ * Both cases historically tore the broker connection down with
+ * `Failed to parse codex app-server JSONL: Unexpected token …`. The
+ * client never recovers because `handleExit` rejects every in-flight
+ * request before any subsequent valid record arrives.
+ *
+ * `cleanProtocolLine` is the conservative guard:
+ *
+ *   - Strip CSI / OSC ANSI escape sequences from the raw line.
+ *   - Trim whitespace.
+ *   - Require the first remaining character to be `{` or `[`. JSONL
+ *     records cannot start with anything else, so any other prefix is
+ *     definitively garbage and is dropped.
+ *
+ * Lines that pass these checks are still parsed with `JSON.parse`; if
+ * that fails the caller surfaces a real protocol error as before.
+ */
+
+// CSI:  ESC [ … final-byte                  (e.g. \x1b[?2004h, \x1b[31m)
+// OSC:  ESC ] … (BEL | ESC \)               (e.g. window-title sets)
+// eslint-disable-next-line no-control-regex
+const ANSI_ESCAPE_RE = /\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
+
+/**
+ * Returns a JSON-shaped candidate string for the given raw line, or
+ * `null` if the line should be skipped because it cannot be valid JSONL.
+ *
+ * @param {string} rawLine
+ * @returns {string | null}
+ */
+export function cleanProtocolLine(rawLine) {
+  if (typeof rawLine !== "string") {
+    return null;
+  }
+  const cleaned = rawLine.replace(ANSI_ESCAPE_RE, "").trim();
+  if (!cleaned) {
+    return null;
+  }
+  const firstChar = cleaned.charCodeAt(0);
+  if (firstChar !== 0x7B /* { */ && firstChar !== 0x5B /* [ */) {
+    return null;
+  }
+  return cleaned;
+}

--- a/plugins/codex/scripts/lib/jsonl.mjs
+++ b/plugins/codex/scripts/lib/jsonl.mjs
@@ -32,16 +32,25 @@
  * that fails the caller surfaces a real protocol error as before.
  */
 
-// CSI:  ESC [ … final-byte                  (e.g. \x1b[?2004h, \x1b[31m)
-// OSC:  ESC ] … (BEL | ESC \)               (e.g. window-title sets)
+// CSI: ESC [ <params> <intermediates> <final>
+//      params       = 0x30..0x3F (digits, ?, etc.)
+//      intermediates= 0x20..0x2F (space, !, ", $, %, &, ', (, ), *, +, ,, -, ., /)
+//      final        = 0x40..0x7E (any byte in @, A..Z, [, \, ], ^, _, `, a..z, {, |, }, ~)
+// This grammar matches the original ECMA-48 spec and covers cases like
+// bracketed-paste *content* markers `\x1b[200~` / `\x1b[201~` (final
+// byte `~`) which a letter-only `[a-zA-Z]` final misses.
+// OSC: ESC ] <text> (BEL | ESC \)            e.g. window-title sets
 // eslint-disable-next-line no-control-regex
-const ANSI_ESCAPE_RE = /\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
+const ANSI_ESCAPE_RE = /\x1b\[[\x30-\x3F]*[\x20-\x2F]*[\x40-\x7E]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
 
 /**
  * Returns a JSON-shaped candidate string for the given raw line, or
  * `null` if the line should be skipped because it cannot be valid JSONL.
  *
- * @param {string} rawLine
+ * Accepts arbitrary input — non-string values short-circuit to `null` so
+ * callers don't have to type-check before invoking.
+ *
+ * @param {unknown} rawLine
  * @returns {string | null}
  */
 export function cleanProtocolLine(rawLine) {

--- a/tests/jsonl.test.mjs
+++ b/tests/jsonl.test.mjs
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { cleanProtocolLine } from "../plugins/codex/scripts/lib/jsonl.mjs";
+
+test("cleanProtocolLine returns null for empty / whitespace lines", () => {
+  assert.equal(cleanProtocolLine(""), null);
+  assert.equal(cleanProtocolLine("   "), null);
+  assert.equal(cleanProtocolLine("\t\r\n"), null);
+});
+
+test("cleanProtocolLine returns null for non-string input", () => {
+  assert.equal(cleanProtocolLine(undefined), null);
+  assert.equal(cleanProtocolLine(null), null);
+  assert.equal(cleanProtocolLine(42), null);
+});
+
+test("cleanProtocolLine passes through plain JSON object lines unchanged", () => {
+  assert.equal(cleanProtocolLine('{"id":1,"result":{}}'), '{"id":1,"result":{}}');
+  assert.equal(cleanProtocolLine('  {"a":1}  '), '{"a":1}');
+});
+
+test("cleanProtocolLine passes through plain JSON array lines unchanged", () => {
+  assert.equal(cleanProtocolLine('[1,2,3]'), '[1,2,3]');
+});
+
+test("cleanProtocolLine strips bracketed-paste-mode ANSI prefix (issue #23)", () => {
+  assert.equal(
+    cleanProtocolLine('\x1b[?2004h{"id":1}'),
+    '{"id":1}'
+  );
+  assert.equal(
+    cleanProtocolLine('{"id":1}\x1b[?2004l'),
+    '{"id":1}'
+  );
+});
+
+test("cleanProtocolLine strips OSC window-title sequences", () => {
+  assert.equal(
+    cleanProtocolLine('\x1b]0;some title\x07{"id":1}'),
+    '{"id":1}'
+  );
+});
+
+test("cleanProtocolLine strips SGR color codes", () => {
+  assert.equal(
+    cleanProtocolLine('\x1b[1;31m{"id":1}\x1b[0m'),
+    '{"id":1}'
+  );
+});
+
+test("cleanProtocolLine drops CP-950 mojibake of Windows taskkill SUCCESS", () => {
+  // Raw bytes from `taskkill /T /F` on a zh-TW (Big5 / CP-950) Windows
+  // system: `成功: PID 為 1234 (PID 為 5678 的子處理程序) 的處理程序已終止。`
+  // When read off codex.exe's stdout pipe under Node's UTF-8 decoder, the
+  // invalid CP-950 high bytes become U+FFFD replacement characters.
+  const mojibake = "���\\: PID �� 1234 (PID �� 5678 ���l�B�z�{��)";
+  assert.equal(cleanProtocolLine(mojibake), null);
+});
+
+test("cleanProtocolLine drops the literal U+FFFD prefix that triggered the original bug", () => {
+  // This is the smallest reproducer of the production failure: the parser
+  // saw `Unexpected token '�', "���\: PID "...` and tore the connection
+  // down. After this guard the line is silently skipped.
+  assert.equal(cleanProtocolLine("���\\: PID 1234"), null);
+});
+
+test("cleanProtocolLine drops other non-JSON garbage (shell prompts, plain text)", () => {
+  assert.equal(cleanProtocolLine("PS C:\\> "), null);
+  assert.equal(cleanProtocolLine("user@host:~$ "), null);
+  assert.equal(cleanProtocolLine("warning: something happened"), null);
+  // Note: anything whose first non-whitespace character is `[` (e.g. an
+  // ANSI-stripped bracket-log timestamp like `[2026-05-09T...]`) is NOT
+  // dropped by this guard — it looks like a JSON array. Such lines still
+  // reach JSON.parse and surface as a real protocol error, which is the
+  // desired behaviour: the guard only drops lines that cannot possibly
+  // be JSONL.
+});
+
+test("cleanProtocolLine forwards a malformed but JSON-shaped line for the parser to reject", () => {
+  // Lines that DO start with `{` or `[` are returned even if they are not
+  // strictly valid JSON. The caller will then surface a real protocol
+  // error via JSON.parse. This is the desired behaviour: the guard only
+  // drops lines that cannot possibly be JSONL.
+  assert.equal(cleanProtocolLine('{"id":1,'), '{"id":1,');
+  assert.equal(cleanProtocolLine('[1,2,'), '[1,2,');
+});

--- a/tests/jsonl.test.mjs
+++ b/tests/jsonl.test.mjs
@@ -35,6 +35,20 @@ test("cleanProtocolLine strips bracketed-paste-mode ANSI prefix (issue #23)", ()
   );
 });
 
+test("cleanProtocolLine strips CSI sequences whose final byte is not a letter", () => {
+  // Bracketed-paste content markers use `~` as the final byte. A
+  // letter-only CSI final pattern (`[a-zA-Z]`) misses them and the
+  // surrounding JSON would be incorrectly dropped by the first-char
+  // guard. ECMA-48's CSI grammar allows any final byte in 0x40..0x7E.
+  assert.equal(
+    cleanProtocolLine('\x1b[200~{"id":1}\x1b[201~'),
+    '{"id":1}'
+  );
+  // Other non-letter finals at the boundaries of the 0x40..0x7E range.
+  assert.equal(cleanProtocolLine('\x1b[@{"id":1}'), '{"id":1}'); // 0x40
+  assert.equal(cleanProtocolLine('\x1b[`{"id":1}'), '{"id":1}'); // 0x60
+});
+
 test("cleanProtocolLine strips OSC window-title sequences", () => {
   assert.equal(
     cleanProtocolLine('\x1b]0;some title\x07{"id":1}'),


### PR DESCRIPTION
## Summary

- Adds `lib/jsonl.mjs#cleanProtocolLine(rawLine)`: strips ANSI/OSC escape sequences, trims whitespace, and returns the cleaned line **only if** it starts with a JSON delimiter (`{` or `[`). Otherwise returns `null`.
- Rewires `lib/app-server.mjs` `handleLine()` to skip on `null` instead of treating non-JSON lines as protocol violations that tear the connection down.
- Adds `tests/jsonl.test.mjs` (11 cases) covering bracketed-paste prefix, OSC window-title, SGR colours, the exact CP-950 mojibake from #310, plain JSON passthrough, malformed-but-JSON-shaped fall-through to the parser, and non-string input.

## Problem

`handleLine()` calls `JSON.parse()` on every line read from the codex app-server stdout pipe and, on failure, calls `handleExit()` — rejecting every in-flight request and closing the connection. In practice the codex CLI occasionally emits bytes onto stdout that have nothing to do with the protocol. Two known sources:

1. **Terminal / shell init noise** (issue #23). zsh writes the bracketed-paste marker `\x1b[?2004h` when a subprocess inherits the parent's TTY. The user-visible error:
   ```
   Failed to parse codex app-server JSONL: Unexpected token '', "[?2004h" is not valid JSON
   ```
2. **Localized OS messages on Windows non-English locales** (issue #310 ⇄ root cause filed upstream as [openai/codex#21957](https://github.com/openai/codex/issues/21957)). On zh-TW (CP-950 / Big5), when `codex.exe` runs `taskkill /T /F` to clean up a failed MCP child and inadvertently routes taskkill's stdout to its own stdout, the JSONL stream receives:
   ```
   raw   : a6 a8 a5 5c 3a 20 50 49 44 20 ac b0 20 31 32 33 34 ...
   cp950 : 成功: PID 為 1234 ...
   utf-8 : ���\: PID �� 1234 ...
   ```
   which is the exact `Unexpected token '�', "���\: PID "...` reported in #310.

Both bug classes share the same correct fix at the plugin layer: **lines that cannot possibly be JSONL records should be dropped, not treated as protocol violations**. A JSONL record always begins with `{` or `[`. Any line whose first non-whitespace, post-strip-ANSI character is something else is definitively garbage from outside the protocol.

## Why this approach over the existing PRs (#24, #97, #171)

[#171][p171] (the most recent of three open PRs) introduces a `stripAnsi()` helper and applies it before `JSON.parse()`. That correctly fixes #23 — but does not fix #310, because the leaked bytes are not ANSI escapes. They are localized OS text. After `stripAnsi()` the line is still not JSON, the parser still throws, the connection still dies.

The `cleanProtocolLine()` guard in this PR is a strict superset:
- It still strips ANSI/OSC sequences (so #23 is covered identically to #171).
- It additionally drops anything whose post-strip first character is not `{` or `[` (so #310 is covered).

If maintainers prefer to land #171 first I'm happy to rebase this onto it (the regex code can move to `lib/strings.mjs#stripAnsi` and `cleanProtocolLine` becomes a one-liner that imports it). Either order works; the unit tests stay the same.

## What this PR explicitly does NOT do

- It does **not** patch the broker side (`app-server-broker.mjs`'s socket data handler). That handler reads JSONRPC requests *from the companion*, which sends well-formed JSON; there is no observed corruption source on that path. #171 does patch it for symmetry — happy to add the same here if you'd like.
- It does **not** fix the upstream stdio leak in `codex.exe`. That is filed as [openai/codex#21957](https://github.com/openai/codex/issues/21957) and is out of scope for this repo. This PR is defense-in-depth for any embedder of `codex app-server`.

## Test plan

- [x] `node --test tests/jsonl.test.mjs` — 11/11 pass.
- [x] `node --test tests/*.test.mjs` — all failures present on this branch (`state.test.mjs`, `runtime.test.mjs`, `process.test.mjs` — all Windows-only `os.tmpdir()` / MSYS path translation issues) reproduce against `main` from the same checkout, i.e. no regressions introduced by this PR.
- [x] End-to-end: stop-time review gate fired during a Claude Code session running on Windows zh-TW reliably reproduced the original failure pre-patch; with this patch applied to the plugin cache, three back-to-back `codex-companion.mjs task` invocations (each preceded by killing the broker to force the leaky direct-spawn path) now all return `{"status":0,...}`.
- [ ] Manual: `/codex:review` from a zsh-default Claude Code session (issue #23 case) — I do not have a zsh box handy; logically equivalent to PR #171's verification.

## Closes / refs

- Closes #310
- Refs #23 (also addressed by this PR — happy to mark Closes if you'd prefer to consolidate)
- Refs #24, #97, #171 (alternative approaches to the same shape of bug)
- Refs root-cause issue: [openai/codex#21957](https://github.com/openai/codex/issues/21957)

[p171]: https://github.com/openai/codex-plugin-cc/pull/171
