### PR TITLE
fix: widen /codex:review wait threshold to ~5 files / 200 lines

### DIFF
--- a/plugins/codex/commands/review.md
+++ b/plugins/codex/commands/review.md
@@ -24,7 +24,7 @@ Execution mode rules:
   - For base-branch review, use `git diff --shortstat <base>...HEAD`.
   - Treat untracked files or directories as reviewable work even when `git diff --shortstat` is empty.
   - Only conclude there is nothing to review when the relevant working-tree status is empty or the explicit branch diff is empty.
-  - Recommend waiting only when the review is clearly tiny, roughly 1-2 files total and no sign of a broader directory-sized change.
+  - Recommend waiting when the review is small, roughly up to 5 files or 200 lines of diff, with no sign of a broader directory-sized change. Codex finishes within Claude's prompt cache window (5 minutes) for diffs of this size, so wait in the foreground and the result feeds the next step.
   - In every other case, including unclear size, recommend background.
   - When in doubt, run the review instead of declaring that there is nothing to review.
 - Then use `AskUserQuestion` exactly once with two options, putting the recommended option first and suffixing its label with `(Recommended)`:

--- a/plugins/codex/commands/review.md
+++ b/plugins/codex/commands/review.md
@@ -24,7 +24,7 @@ Execution mode rules:
   - For base-branch review, use `git diff --shortstat <base>...HEAD`.
   - Treat untracked files or directories as reviewable work even when `git diff --shortstat` is empty.
   - Only conclude there is nothing to review when the relevant working-tree status is empty or the explicit branch diff is empty.
-  - Recommend waiting when the review is small, roughly up to 5 files or 200 lines of diff, with no sign of a broader directory-sized change. Codex finishes within Claude's prompt cache window (5 minutes) for diffs of this size, so wait in the foreground and the result feeds the next step.
+  - Recommend waiting when the review is small, roughly up to 5 files or about 200 insertions+deletions as reported by `git diff --shortstat`, with no sign of a broader directory-sized change. Codex finishes within Claude's prompt cache window (5 minutes) for changes of this size, so wait in the foreground and the result feeds the next step.
   - In every other case, including unclear size, recommend background.
   - When in doubt, run the review instead of declaring that there is nothing to review.
 - Then use `AskUserQuestion` exactly once with two options, putting the recommended option first and suffixing its label with `(Recommended)`:


### PR DESCRIPTION
## Summary

Widen the wait/background threshold in `/codex:review` from "1-2 files" to "up to 5 files or 200 lines of diff."

## Motivation

The current threshold trips on most real PRs. Even a 3-file fix asks "wait or background?", and the answer is "wait." Codex finishes inside the prompt-cache window.

Concrete case: a 3-file / 43-line wp-calypso review today hit the prompt. Codex finished in about 2 minutes. The 5-minute cache window was nowhere near expiring. The dispatcher prompt was pure round-trip cost.

5 files / 200 lines covers the small-PR case without losing the background recommendation for refactors, where the cache miss is already priced in.

## Test plan

- [ ] `/codex:review` on a 3-file / 50-line diff recommends "Wait for results"
- [ ] `/codex:review` on a 10-file / 500-line diff recommends "Run in background"
- [ ] `--wait` / `--background` flags still bypass the dispatcher