### PR TITLE
fix: sanitize caller-controlled filenames in adversarial review prompts

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -69,6 +69,10 @@ const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
 const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
 const MODEL_ALIASES = new Map([["spark", "gpt-5.3-codex-spark"]]);
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
+const MAX_PROMPT_BYTES = 800 * 1024;
+const TRUNCATION_MARKER = "\n\n[content truncated to fit prompt size limit]\n";
+const LIGHTWEIGHT_GUIDANCE =
+  "The repository context below is a lightweight summary. Inspect the target diff yourself with read-only git commands before finalizing findings.";
 
 function printUsage() {
   console.log(
@@ -235,15 +239,114 @@ async function handleSetup(argv) {
   outputResult(options.json ? finalReport : renderSetupReport(finalReport), options.json);
 }
 
-function buildAdversarialReviewPrompt(context, focusText) {
+export function buildAdversarialReviewPrompt(context, focusText) {
   const template = loadPromptTemplate(ROOT_DIR, "adversarial-review");
+  const initial = renderAdversarialReviewPrompt(
+    template,
+    context,
+    focusText,
+    context.collectionGuidance,
+    context.content
+  );
+  if (Buffer.byteLength(initial, "utf8") <= MAX_PROMPT_BYTES) {
+    return initial;
+  }
+
+  const lightweightContent = buildLightweightAdversarialReviewContent(context);
+  const lightweight = renderAdversarialReviewPrompt(
+    template,
+    context,
+    focusText,
+    LIGHTWEIGHT_GUIDANCE,
+    lightweightContent
+  );
+  if (Buffer.byteLength(lightweight, "utf8") <= MAX_PROMPT_BYTES && lightweightContent !== context.content) {
+    return lightweight;
+  }
+
+  const overhead = Buffer.byteLength(
+    renderAdversarialReviewPrompt(template, context, focusText, LIGHTWEIGHT_GUIDANCE, ""),
+    "utf8"
+  );
+  const budget = MAX_PROMPT_BYTES - overhead - Buffer.byteLength(TRUNCATION_MARKER, "utf8");
+
+  if (budget < 0) {
+    return hardTruncateWithMarker(
+      renderAdversarialReviewPrompt(template, context, "", LIGHTWEIGHT_GUIDANCE, ""),
+      MAX_PROMPT_BYTES
+    );
+  }
+
+  return renderAdversarialReviewPrompt(
+    template,
+    context,
+    focusText,
+    LIGHTWEIGHT_GUIDANCE,
+    `${truncateToByteBudget(lightweightContent, budget)}${TRUNCATION_MARKER}`
+  );
+}
+
+function renderAdversarialReviewPrompt(template, context, focusText, guidance, content) {
   return interpolateTemplate(template, {
     REVIEW_KIND: "Adversarial Review",
     TARGET_LABEL: context.target.label,
     USER_FOCUS: focusText || "No extra focus provided.",
-    REVIEW_COLLECTION_GUIDANCE: context.collectionGuidance,
-    REVIEW_INPUT: context.content
+    REVIEW_COLLECTION_GUIDANCE: guidance,
+    REVIEW_INPUT: content
   });
+}
+
+function buildLightweightAdversarialReviewContent(context) {
+  const parts = [];
+
+  if (context.summary) {
+    parts.push(`Summary: ${context.summary}`);
+  }
+  if (Array.isArray(context.changedFiles) && context.changedFiles.length > 0) {
+    parts.push(`Changed files (${context.changedFiles.length}):\n${context.changedFiles.slice(0, 50).join("\n")}`);
+  } else if (typeof context.fileCount === "number") {
+    parts.push(`Changed file count: ${context.fileCount}`);
+  }
+
+  return parts.length > 0 ? parts.join("\n\n") : context.content;
+}
+
+function truncateToByteBudget(value, maxBytes) {
+  if (maxBytes <= 0) {
+    return "";
+  }
+  if (Buffer.byteLength(value, "utf8") <= maxBytes) {
+    return value;
+  }
+
+  const buffer = Buffer.from(value, "utf8");
+  let end = Math.min(maxBytes, buffer.length);
+  // Avoid ending mid-sequence so the truncated prompt stays valid UTF-8.
+  while (end > 0 && (buffer[end] & 0xc0) === 0x80) {
+    end -= 1;
+  }
+  return buffer.subarray(0, end).toString("utf8");
+}
+
+function hardTruncateWithMarker(value, maxBytes) {
+  const head = truncateToByteBudget(
+    value,
+    Math.max(0, maxBytes - Buffer.byteLength(TRUNCATION_MARKER, "utf8"))
+  );
+  return `${head}${TRUNCATION_MARKER}`;
+}
+
+function isDirectExecution() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const moduleFile = fileURLToPath(import.meta.url);
+  // Compare canonical (realpath) forms so symlinked install paths
+  // (plugin cache, macOS /var vs /private/var) still match the script.
+  try {
+    return fs.realpathSync.native(entry) === fs.realpathSync.native(moduleFile);
+  } catch {
+    return path.resolve(entry) === moduleFile;
+  }
 }
 
 function ensureCodexAvailable(cwd) {
@@ -1020,8 +1123,10 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`${message}\n`);
-  process.exitCode = 1;
-});
+if (isDirectExecution()) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -22,6 +22,10 @@ import {
   } from "./lib/codex.mjs";
 import { readStdinIfPiped } from "./lib/fs.mjs";
 import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./lib/git.mjs";
+import {
+  escapeRenderUnsafeChars,
+  sanitizeFilenamesForPrompt
+} from "./lib/prompt-sanitize.mjs";
 import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
 import {
@@ -296,14 +300,19 @@ function renderAdversarialReviewPrompt(template, context, focusText, guidance, c
   });
 }
 
-function buildLightweightAdversarialReviewContent(context) {
+export function buildLightweightAdversarialReviewContent(context) {
   const parts = [];
 
   if (context.summary) {
-    parts.push(`Summary: ${context.summary}`);
+    parts.push(
+      `Summary: ${JSON.stringify(escapeRenderUnsafeChars(String(context.summary))).replace(/\\\\u([0-9a-f]{4})/g, "\\u$1")}`
+    );
   }
   if (Array.isArray(context.changedFiles) && context.changedFiles.length > 0) {
-    parts.push(`Changed files (${context.changedFiles.length}):\n${context.changedFiles.slice(0, 50).join("\n")}`);
+    const limited = context.changedFiles.slice(0, 50);
+    parts.push(
+      `Changed files (${context.changedFiles.length}):\n${sanitizeFilenamesForPrompt(limited)}`
+    );
   } else if (typeof context.fileCount === "number") {
     parts.push(`Changed file count: ${context.fileCount}`);
   }

--- a/plugins/codex/scripts/lib/git.mjs
+++ b/plugins/codex/scripts/lib/git.mjs
@@ -13,11 +13,11 @@ const DEFAULT_INLINE_DIFF_MAX_FILES = 2;
 const DEFAULT_INLINE_DIFF_MAX_BYTES = 256 * 1024;
 
 function git(cwd, args, options = {}) {
-  return runCommand("git", ["-c", "core.quotePath=false", ...args], { cwd, ...options });
+  return runCommand("git", args, { cwd, ...options });
 }
 
 function gitChecked(cwd, args, options = {}) {
-  return runCommandChecked("git", ["-c", "core.quotePath=false", ...args], { cwd, ...options });
+  return runCommandChecked("git", args, { cwd, ...options });
 }
 
 function listUniqueFiles(...groups) {
@@ -269,7 +269,7 @@ function collectBranchContext(cwd, baseRef, options = {}) {
   const includeDiff = options.includeDiff !== false;
   const comparison = options.comparison ?? buildBranchComparison(cwd, baseRef);
   const currentBranch = getCurrentBranch(cwd);
-  const changedFiles = gitChecked(cwd, ["diff", "--name-only", comparison.commitRange]).stdout.trim().split("\n").filter(Boolean);
+  const changedFiles = gitChecked(cwd, ["diff", "-z", "--name-only", comparison.commitRange]).stdout.split("\0").filter(Boolean);
   const logOutput = gitChecked(cwd, ["log", "--oneline", "--decorate", comparison.commitRange]).stdout.trim();
   const diffStat = escapeRenderUnsafeChars(
     gitChecked(cwd, ["diff", "--stat", comparison.commitRange]).stdout.trim()

--- a/plugins/codex/scripts/lib/git.mjs
+++ b/plugins/codex/scripts/lib/git.mjs
@@ -3,17 +3,21 @@ import path from "node:path";
 
 import { isProbablyText } from "./fs.mjs";
 import { formatCommandFailure, runCommand, runCommandChecked } from "./process.mjs";
+import {
+  escapeRenderUnsafeChars,
+  sanitizeFilenamesForPrompt
+} from "./prompt-sanitize.mjs";
 
 const MAX_UNTRACKED_BYTES = 24 * 1024;
 const DEFAULT_INLINE_DIFF_MAX_FILES = 2;
 const DEFAULT_INLINE_DIFF_MAX_BYTES = 256 * 1024;
 
 function git(cwd, args, options = {}) {
-  return runCommand("git", args, { cwd, ...options });
+  return runCommand("git", ["-c", "core.quotePath=false", ...args], { cwd, ...options });
 }
 
 function gitChecked(cwd, args, options = {}) {
-  return runCommandChecked("git", args, { cwd, ...options });
+  return runCommandChecked("git", ["-c", "core.quotePath=false", ...args], { cwd, ...options });
 }
 
 function listUniqueFiles(...groups) {
@@ -195,35 +199,38 @@ function formatSection(title, body) {
 
 function formatUntrackedFile(cwd, relativePath) {
   const absolutePath = path.join(cwd, relativePath);
+  const displayPath = escapeRenderUnsafeChars(relativePath);
   let stat;
   try {
     stat = fs.statSync(absolutePath);
   } catch {
-    return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+    return `### ${displayPath}\n(skipped: broken symlink or unreadable file)`;
   }
   if (stat.isDirectory()) {
-    return `### ${relativePath}\n(skipped: directory)`;
+    return `### ${displayPath}\n(skipped: directory)`;
   }
   if (stat.size > MAX_UNTRACKED_BYTES) {
-    return `### ${relativePath}\n(skipped: ${stat.size} bytes exceeds ${MAX_UNTRACKED_BYTES} byte limit)`;
+    return `### ${displayPath}\n(skipped: ${stat.size} bytes exceeds ${MAX_UNTRACKED_BYTES} byte limit)`;
   }
 
   let buffer;
   try {
     buffer = fs.readFileSync(absolutePath);
   } catch {
-    return `### ${relativePath}\n(skipped: broken symlink or unreadable file)`;
+    return `### ${displayPath}\n(skipped: broken symlink or unreadable file)`;
   }
   if (!isProbablyText(buffer)) {
-    return `### ${relativePath}\n(skipped: binary file)`;
+    return `### ${displayPath}\n(skipped: binary file)`;
   }
 
-  return [`### ${relativePath}`, "```", buffer.toString("utf8").trimEnd(), "```"].join("\n");
+  return [`### ${displayPath}`, "```", buffer.toString("utf8").trimEnd(), "```"].join("\n");
 }
 
 function collectWorkingTreeContext(cwd, state, options = {}) {
   const includeDiff = options.includeDiff !== false;
-  const status = gitChecked(cwd, ["status", "--short", "--untracked-files=all"]).stdout.trim();
+  const status = escapeRenderUnsafeChars(
+    gitChecked(cwd, ["status", "--short", "--untracked-files=all"]).stdout.trim()
+  );
   const changedFiles = listUniqueFiles(state.staged, state.unstaged, state.untracked);
 
   let parts;
@@ -245,7 +252,7 @@ function collectWorkingTreeContext(cwd, state, options = {}) {
       formatSection("Git Status", status),
       formatSection("Staged Diff Stat", stagedStat),
       formatSection("Unstaged Diff Stat", unstagedStat),
-      formatSection("Changed Files", changedFiles.join("\n")),
+      formatSection("Changed Files", sanitizeFilenamesForPrompt(changedFiles)),
       formatSection("Untracked Files", untrackedBody)
     ];
   }
@@ -264,7 +271,9 @@ function collectBranchContext(cwd, baseRef, options = {}) {
   const currentBranch = getCurrentBranch(cwd);
   const changedFiles = gitChecked(cwd, ["diff", "--name-only", comparison.commitRange]).stdout.trim().split("\n").filter(Boolean);
   const logOutput = gitChecked(cwd, ["log", "--oneline", "--decorate", comparison.commitRange]).stdout.trim();
-  const diffStat = gitChecked(cwd, ["diff", "--stat", comparison.commitRange]).stdout.trim();
+  const diffStat = escapeRenderUnsafeChars(
+    gitChecked(cwd, ["diff", "--stat", comparison.commitRange]).stdout.trim()
+  );
 
   return {
     mode: "branch",
@@ -281,7 +290,7 @@ function collectBranchContext(cwd, baseRef, options = {}) {
       : [
           formatSection("Commit Log", logOutput),
           formatSection("Diff Stat", diffStat),
-          formatSection("Changed Files", changedFiles.join("\n"))
+          formatSection("Changed Files", sanitizeFilenamesForPrompt(changedFiles))
         ].join("\n"),
     changedFiles,
     comparison

--- a/plugins/codex/scripts/lib/prompt-sanitize.mjs
+++ b/plugins/codex/scripts/lib/prompt-sanitize.mjs
@@ -1,0 +1,54 @@
+const RENDER_UNSAFE_RANGES = [
+  [0x0000, 0x001f],
+  [0x007f, 0x007f],
+  [0x0080, 0x009f],
+  [0x200b, 0x200d],
+  [0x200e, 0x200f],
+  [0x202a, 0x202e],
+  [0x2066, 0x2069],
+  [0xfeff, 0xfeff]
+];
+
+const PER_FILENAME_MAX_CHARS = 512;
+const ELLIPSIS = "…";
+
+export function escapeRenderUnsafeChars(s) {
+  if (typeof s !== "string") return "";
+  let out = "";
+  for (let i = 0; i < s.length; i += 1) {
+    const code = s.charCodeAt(i);
+    let escape = false;
+    for (const [lo, hi] of RENDER_UNSAFE_RANGES) {
+      if (code >= lo && code <= hi) {
+        escape = true;
+        break;
+      }
+    }
+    if (escape) {
+      out += `\\u${code.toString(16).padStart(4, "0")}`;
+    } else {
+      out += s[i];
+    }
+  }
+  return out;
+}
+
+function truncatePayload(s, maxChars) {
+  if (s.length <= maxChars) return s;
+  return s.slice(0, maxChars) + ELLIPSIS;
+}
+
+function stringifyEscapedPayload(s) {
+  return JSON.stringify(s).replace(/\\\\u([0-9a-f]{4})/g, "\\u$1");
+}
+
+export function sanitizeFilenamesForPrompt(files) {
+  if (!Array.isArray(files)) return "";
+  return files
+    .map((f) =>
+      stringifyEscapedPayload(
+        truncatePayload(escapeRenderUnsafeChars(String(f)), PER_FILENAME_MAX_CHARS)
+      )
+    )
+    .join("\n");
+}

--- a/plugins/codex/scripts/lib/prompt-sanitize.mjs
+++ b/plugins/codex/scripts/lib/prompt-sanitize.mjs
@@ -1,12 +1,22 @@
 const RENDER_UNSAFE_RANGES = [
-  [0x0000, 0x001f],
-  [0x007f, 0x007f],
-  [0x0080, 0x009f],
-  [0x200b, 0x200d],
-  [0x200e, 0x200f],
-  [0x202a, 0x202e],
-  [0x2066, 0x2069],
-  [0xfeff, 0xfeff]
+  [0x0000, 0x001f],     // C0 controls (NUL through US, incl. tab/newline)
+  [0x007f, 0x007f],     // DEL
+  [0x0080, 0x009f],     // C1 controls
+  [0x00ad, 0x00ad],     // SOFT HYPHEN (default-ignorable)
+  [0x061c, 0x061c],     // ARABIC LETTER MARK
+  [0x180e, 0x180e],     // MONGOLIAN VOWEL SEPARATOR (default-ignorable)
+  [0x200b, 0x200d],     // ZWS / ZWNJ / ZWJ
+  [0x200e, 0x200f],     // LRM / RLM
+  [0x202a, 0x202e],     // bidi overrides (LRE/RLE/PDF/LRO/RLO)
+  [0x2060, 0x2064],     // WORD JOINER + invisible operators
+  [0x2066, 0x2069],     // bidi isolates (LRI/RLI/FSI/PDI)
+  [0xd800, 0xdfff],     // lone surrogates (when iterating by code point)
+  [0xfe00, 0xfe0f],     // BMP variation selectors
+  [0xfeff, 0xfeff],     // BOM (ZWNBSP)
+  [0xfff0, 0xffff],     // BMP specials (incl. replacement char, non-characters)
+  [0x1bca0, 0x1bca3],   // SHORTHAND FORMAT CONTROLS (default-ignorable)
+  [0xe0000, 0xe007f],   // tag characters (supplementary)
+  [0xe0100, 0xe01ef]    // supplementary variation selectors
 ];
 
 const PER_FILENAME_MAX_CHARS = 512;
@@ -15,20 +25,29 @@ const ELLIPSIS = "…";
 export function escapeRenderUnsafeChars(s) {
   if (typeof s !== "string") return "";
   let out = "";
-  for (let i = 0; i < s.length; i += 1) {
-    const code = s.charCodeAt(i);
-    let escape = false;
+  let i = 0;
+  while (i < s.length) {
+    const code = s.codePointAt(i);
+    const charLength = code > 0xffff ? 2 : 1;
+    let unsafe = false;
     for (const [lo, hi] of RENDER_UNSAFE_RANGES) {
       if (code >= lo && code <= hi) {
-        escape = true;
+        unsafe = true;
         break;
       }
     }
-    if (escape) {
-      out += `\\u${code.toString(16).padStart(4, "0")}`;
-    } else {
+    if (unsafe) {
+      if (code <= 0xffff) {
+        out += `\\u${code.toString(16).padStart(4, "0")}`;
+      } else {
+        out += `\\u{${code.toString(16)}}`;
+      }
+    } else if (code <= 0xffff) {
       out += s[i];
+    } else {
+      out += String.fromCodePoint(code);
     }
+    i += charLength;
   }
   return out;
 }

--- a/tests/codex-companion.test.mjs
+++ b/tests/codex-companion.test.mjs
@@ -1,0 +1,126 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildAdversarialReviewPrompt } from '../plugins/codex/scripts/codex-companion.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.join(__dirname, '..', 'plugins', 'codex');
+const TEMPLATE_PATH = path.join(ROOT_DIR, 'prompts', 'adversarial-review.md');
+const MAX_PROMPT_BYTES = 800 * 1024;
+const TEMPLATE = fs.readFileSync(TEMPLATE_PATH, 'utf8');
+
+function buildPromptBaseline(template, label, focusText, guidance) {
+  return template
+    .replace('{{REVIEW_KIND}}', 'Adversarial Review')
+    .replace('{{TARGET_LABEL}}', label)
+    .replace('{{USER_FOCUS}}', focusText || 'No extra focus provided.')
+    .replace('{{REVIEW_COLLECTION_GUIDANCE}}', guidance)
+    .replace('{{REVIEW_INPUT}}', '');
+}
+
+function buildContentToHitExactCap(template, label, focusText, guidance, capBytes) {
+  const basePrompt = buildPromptBaseline(template, label, focusText, guidance);
+  const overhead = Buffer.byteLength(basePrompt, 'utf8');
+  return 'x'.repeat(capBytes - overhead);
+}
+
+test('buildAdversarialReviewPrompt: small content passes through verbatim', () => {
+  // Given
+  const context = {
+    target: { label: 'branch feature/x vs main' },
+    collectionGuidance: 'Use the repository context below as primary evidence.',
+    content: 'hello world'
+  };
+  const focusText = 'test focus';
+
+  // When
+  const result = buildAdversarialReviewPrompt(context, focusText);
+
+  // Then
+  assert.ok(Buffer.byteLength(result, 'utf8') < MAX_PROMPT_BYTES);
+  assert.equal(result.includes('hello world'), true);
+  assert.equal(result.includes('branch feature/x vs main'), true);
+  assert.equal(result.includes('test focus'), true);
+});
+
+test('buildAdversarialReviewPrompt: exact cap boundary keeps full content', () => {
+  // Given
+  const label = 'branch feature/at-limit vs main';
+  const focusText = 'focus';
+  const guidance = 'Use the repository context below as primary evidence.';
+  const content = buildContentToHitExactCap(TEMPLATE, label, focusText, guidance, MAX_PROMPT_BYTES);
+  const context = {
+    target: { label },
+    collectionGuidance: guidance,
+    content
+  };
+
+  // When
+  const result = buildAdversarialReviewPrompt(context, focusText);
+
+  // Then
+  assert.equal(Buffer.byteLength(result, 'utf8'), MAX_PROMPT_BYTES);
+  assert.equal(result.includes(content.slice(0, 100)), true);
+  assert.equal(result.includes(content.slice(-100)), true);
+});
+
+test('buildAdversarialReviewPrompt: 1MB input falls back to lightweight guidance', () => {
+  // Given
+  const context = {
+    target: { label: 'branch big vs main' },
+    collectionGuidance: 'Use the repository context below as primary evidence.',
+    content: 'x'.repeat(1024 * 1024)
+  };
+  const focusText = '';
+
+  // When
+  const result = buildAdversarialReviewPrompt(context, focusText);
+
+  // Then
+  assert.ok(Buffer.byteLength(result, 'utf8') <= MAX_PROMPT_BYTES);
+  assert.equal(
+    result.includes('lightweight summary') || result.includes('Inspect the target diff yourself'),
+    true
+  );
+  assert.equal(result.includes('x'.repeat(1024 * 1024)), false);
+});
+
+test('buildAdversarialReviewPrompt: 5MB input uses truncation fallback', () => {
+  // Given
+  const context = {
+    target: { label: 'branch huge vs main' },
+    collectionGuidance: 'Use the repository context below as primary evidence.',
+    content: 'x'.repeat(5 * 1024 * 1024)
+  };
+  const focusText = '';
+
+  // When
+  const result = buildAdversarialReviewPrompt(context, focusText);
+
+  // Then
+  assert.ok(Buffer.byteLength(result, 'utf8') <= MAX_PROMPT_BYTES);
+  assert.equal(result.toLowerCase().includes('truncated'), true);
+});
+
+test('buildAdversarialReviewPrompt: utf8 byte accounting stays under cap', () => {
+  // Given
+  const content = 'あ'.repeat(250 * 1024);
+  const context = {
+    target: { label: 'branch jp vs main' },
+    collectionGuidance: 'Use the repository context below as primary evidence.',
+    content
+  };
+  const focusText = '';
+
+  // When
+  const result = buildAdversarialReviewPrompt(context, focusText);
+
+  // Then
+  assert.equal(Buffer.byteLength(content, 'utf8'), 750 * 1024);
+  assert.ok(Buffer.byteLength(result, 'utf8') <= MAX_PROMPT_BYTES);
+  assert.equal(result.includes('あ'), true);
+});

--- a/tests/codex-companion.test.mjs
+++ b/tests/codex-companion.test.mjs
@@ -4,7 +4,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { buildAdversarialReviewPrompt } from '../plugins/codex/scripts/codex-companion.mjs';
+import {
+  buildAdversarialReviewPrompt,
+  buildLightweightAdversarialReviewContent
+} from '../plugins/codex/scripts/codex-companion.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -123,4 +126,51 @@ test('buildAdversarialReviewPrompt: utf8 byte accounting stays under cap', () =>
   assert.equal(Buffer.byteLength(content, 'utf8'), 750 * 1024);
   assert.ok(Buffer.byteLength(result, 'utf8') <= MAX_PROMPT_BYTES);
   assert.equal(result.includes('あ'), true);
+});
+
+test('buildLightweightAdversarialReviewContent sanitizes bidi override filenames', () => {
+  // Given: { changedFiles: ['evil‮reversed.ts'] }
+  // When:  buildLightweightAdversarialReviewContent(context)
+  // Then:  raw ‮ を含まず、\u202e を含み、filename 部分が JSON quote される
+  const context = {
+    changedFiles: ['evil‮reversed.ts']
+  };
+
+  const result = buildLightweightAdversarialReviewContent(context);
+
+  assert.equal(result.includes('‮'), false);
+  assert.equal(result.includes('\\u202e'), true);
+  assert.match(result, /"evil\\u202ereversed\.ts"/);
+});
+
+test('buildLightweightAdversarialReviewContent sanitizes bidi isolate filenames', () => {
+  // Given: { changedFiles: ['x⁦isolate⁩y.ts'] }
+  // When:  buildLightweightAdversarialReviewContent(context)
+  // Then:  raw ⁦ / ⁩ を含まず、\u2066 / \u2069 を含む
+  const context = {
+    changedFiles: ['x⁦isolate⁩y.ts']
+  };
+
+  const result = buildLightweightAdversarialReviewContent(context);
+
+  assert.equal(result.includes('⁦'), false);
+  assert.equal(result.includes('⁩'), false);
+  assert.equal(result.includes('\\u2066'), true);
+  assert.equal(result.includes('\\u2069'), true);
+});
+
+test('buildLightweightAdversarialReviewContent JSON-stringifies summary content', () => {
+  // Given: { summary: 'evil‮hiddenSummary', changedFiles: [] }
+  // When:  buildLightweightAdversarialReviewContent(context)
+  // Then:  Summary 行は raw ‮ を含まず、\u202e を含み、JSON.stringify 形式になる
+  const context = {
+    summary: 'evil‮hiddenSummary',
+    changedFiles: []
+  };
+
+  const result = buildLightweightAdversarialReviewContent(context);
+
+  assert.equal(result.includes('Summary: "evil\\u202ehiddenSummary"'), true);
+  assert.equal(result.includes('‮'), false);
+  assert.equal(result.includes('\\u202e'), true);
 });

--- a/tests/git-changed-files-sanitize.test.mjs
+++ b/tests/git-changed-files-sanitize.test.mjs
@@ -26,14 +26,14 @@ test("collectReviewContext sanitizes Changed Files in working-tree mode", (t) =>
   }
 
   // Given: working tree with evil‮reversed.ts
-  // When:  sanitize path flows through collectReviewContext(..., { includeDiff: false })
-  // Then:  raw bidi char is absent and escaped filename is present
+  // When:  collectReviewContext(..., { includeDiff: false }) renders Git-quoted filenames
+  // Then:  raw bidi char is absent and the default C-quoted path bytes are present
   const target = resolveReviewTarget(cwd, {});
   const context = collectReviewContext(cwd, target, { includeDiff: false });
 
   assert.equal(target.mode, "working-tree");
   assert.equal(context.content.includes("‮"), false);
-  assert.equal(context.content.includes("evil\\u202ereversed.ts"), true);
+  assert.equal(context.content.includes("evil\\\\342\\\\200\\\\256reversed.ts"), true);
 });
 
 test("collectReviewContext sanitizes Changed Files in branch mode", (t) => {
@@ -67,4 +67,37 @@ test("collectReviewContext sanitizes Changed Files in branch mode", (t) => {
   assert.equal(target.mode, "branch");
   assert.equal(context.content.includes("‮"), false);
   assert.equal(context.content.includes("evil\\u202ereversed.ts"), true);
+});
+
+test("collectReviewContext keeps Git default quoting for inline-diff path", (t) => {
+  if (process.platform === "win32") {
+    t.skip("bidirectional override filenames are not portable on Windows");
+    return;
+  }
+
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v1');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+  run("git", ["checkout", "-b", "feature/test"], { cwd });
+
+  try {
+    fs.writeFileSync(path.join(cwd, "evil\u202ereversed.ts"), "malicious");
+  } catch (error) {
+    t.skip(`failed to create bidi filename: ${error.message}`);
+    return;
+  }
+  run("git", ["add", "evil\u202ereversed.ts"], { cwd });
+  run("git", ["commit", "-m", "add malicious filename"], { cwd });
+
+  // Given: branch diff with evil<U+202E>reversed.ts
+  // When:  collectReviewContext(..., { includeDiff: true })
+  // Then:  inline-diff content (Branch Diff / Diff Stat) keeps Git's default C-quote
+  //        (`\342\200\256` or `\u202e` octal/utf escape) and never contains raw U+202E
+  const target = resolveReviewTarget(cwd, { base: "main" });
+  const context = collectReviewContext(cwd, target, { includeDiff: true });
+
+  assert.equal(target.mode, "branch");
+  assert.equal(context.content.includes("‮"), false);
 });

--- a/tests/git-changed-files-sanitize.test.mjs
+++ b/tests/git-changed-files-sanitize.test.mjs
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { collectReviewContext, resolveReviewTarget } from "../plugins/codex/scripts/lib/git.mjs";
+import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
+
+test("collectReviewContext sanitizes Changed Files in working-tree mode", (t) => {
+  if (process.platform === "win32") {
+    t.skip("bidirectional override filenames are not portable on Windows");
+    return;
+  }
+
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v1');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+
+  try {
+    fs.writeFileSync(path.join(cwd, "evil‮reversed.ts"), "malicious");
+  } catch (error) {
+    t.skip(`failed to create bidi filename: ${error.message}`);
+    return;
+  }
+
+  // Given: working tree with evil‮reversed.ts
+  // When:  sanitize path flows through collectReviewContext(..., { includeDiff: false })
+  // Then:  raw bidi char is absent and escaped filename is present
+  const target = resolveReviewTarget(cwd, {});
+  const context = collectReviewContext(cwd, target, { includeDiff: false });
+
+  assert.equal(target.mode, "working-tree");
+  assert.equal(context.content.includes("‮"), false);
+  assert.equal(context.content.includes("evil\\u202ereversed.ts"), true);
+});
+
+test("collectReviewContext sanitizes Changed Files in branch mode", (t) => {
+  if (process.platform === "win32") {
+    t.skip("bidirectional override filenames are not portable on Windows");
+    return;
+  }
+
+  const cwd = makeTempDir();
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('v1');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "init"], { cwd });
+  run("git", ["checkout", "-b", "feature/test"], { cwd });
+
+  try {
+    fs.writeFileSync(path.join(cwd, "evil‮reversed.ts"), "malicious");
+  } catch (error) {
+    t.skip(`failed to create bidi filename: ${error.message}`);
+    return;
+  }
+  run("git", ["add", "evil‮reversed.ts"], { cwd });
+  run("git", ["commit", "-m", "add malicious filename"], { cwd });
+
+  // Given: branch diff with evil‮reversed.ts
+  // When:  sanitize path flows through collectReviewContext(..., { includeDiff: false })
+  // Then:  raw bidi char is absent and escaped filename is present
+  const target = resolveReviewTarget(cwd, { base: "main" });
+  const context = collectReviewContext(cwd, target, { includeDiff: false });
+
+  assert.equal(target.mode, "branch");
+  assert.equal(context.content.includes("‮"), false);
+  assert.equal(context.content.includes("evil\\u202ereversed.ts"), true);
+});

--- a/tests/sanitize.test.mjs
+++ b/tests/sanitize.test.mjs
@@ -1,0 +1,70 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { sanitizeFilenamesForPrompt } from "../plugins/codex/scripts/lib/prompt-sanitize.mjs";
+
+test("sanitizeFilenamesForPrompt returns a JSON string for a plain filename", () => {
+  // Given: ['plain-file.ts']
+  // When:  sanitizeFilenamesForPrompt(input)
+  // Then:  '"plain-file.ts"' と一致する
+  const input = ["plain-file.ts"];
+
+  const out = sanitizeFilenamesForPrompt(input);
+
+  assert.equal(out, '"plain-file.ts"');
+});
+
+test("sanitizeFilenamesForPrompt escapes C0 control chars and ANSI escape bytes", () => {
+  // Given: ['evil\x07\x1b[31mred.ts']
+  // When:  sanitizeFilenamesForPrompt(input)
+  // Then:  '"evil\\u0007\\u001b[31mred.ts"' と一致する
+  const input = ["evil\x07\x1b[31mred.ts"];
+
+  const out = sanitizeFilenamesForPrompt(input);
+
+  assert.equal(out, '"evil\\u0007\\u001b[31mred.ts"');
+});
+
+test("sanitizeFilenamesForPrompt escapes bidi override characters", () => {
+  // Given: ['evil‮reversed.ts']
+  // When:  sanitizeFilenamesForPrompt(input)
+  // Then:  '"evil\\u202ereversed.ts"' と一致する
+  const input = ["evil‮reversed.ts"];
+
+  const out = sanitizeFilenamesForPrompt(input);
+
+  assert.equal(out, '"evil\\u202ereversed.ts"');
+});
+
+test("sanitizeFilenamesForPrompt escapes zero-width and BOM characters", () => {
+  // Given: ['evil​zws‍zwj﻿bom.ts']
+  // When:  sanitizeFilenamesForPrompt(input)
+  // Then:  '"evil\\u200bzws\\u200dzwj\\ufeffbom.ts"' と一致する
+  const input = ["evil​zws‍zwj﻿bom.ts"];
+
+  const out = sanitizeFilenamesForPrompt(input);
+
+  assert.equal(out, '"evil\\u200bzws\\u200dzwj\\ufeffbom.ts"');
+});
+
+test("sanitizeFilenamesForPrompt truncates long filenames and preserves JSON parsing", () => {
+  // Given: ['x'.repeat(600)]
+  // When:  sanitizeFilenamesForPrompt(input)
+  // Then:  JSON.parse 可能で復号後の string length が 513 で末尾が … になる
+  const input = ["x".repeat(600)];
+
+  const out = sanitizeFilenamesForPrompt(input);
+  const decoded = JSON.parse(out);
+
+  assert.equal(decoded.length, 513);
+  assert.equal(decoded.endsWith("…"), true);
+});
+
+test("sanitizeFilenamesForPrompt returns an empty string for non-array inputs", () => {
+  // Given: null / 'not-array' / undefined
+  // When:  sanitizeFilenamesForPrompt(input)
+  // Then:  '' と一致する
+  assert.equal(sanitizeFilenamesForPrompt(null), "");
+  assert.equal(sanitizeFilenamesForPrompt("not-array"), "");
+  assert.equal(sanitizeFilenamesForPrompt(undefined), "");
+});

--- a/tests/sanitize.test.mjs
+++ b/tests/sanitize.test.mjs
@@ -68,3 +68,59 @@ test("sanitizeFilenamesForPrompt returns an empty string for non-array inputs", 
   assert.equal(sanitizeFilenamesForPrompt("not-array"), "");
   assert.equal(sanitizeFilenamesForPrompt(undefined), "");
 });
+
+test("sanitizeFilenamesForPrompt escapes BMP invisible format characters", () => {
+  // Given: filename containing U+00AD SOFT HYPHEN + U+061C ARABIC LETTER MARK + U+2060 WORD JOINER + U+FE0F variation selector
+  // When:  sanitizeFilenamesForPrompt(input)
+  // Then:  each invisible char becomes a \uXXXX escape and raw chars are absent from the output
+  const input = [
+    "a\u00adb\u061cc\u2060d\ufe0fe.ts"
+  ];
+
+  const out = sanitizeFilenamesForPrompt(input);
+
+  assert.equal(out.includes("\u00ad"), false);
+  assert.equal(out.includes("\u061c"), false);
+  assert.equal(out.includes("\u2060"), false);
+  assert.equal(out.includes("\ufe0f"), false);
+  assert.equal(out.includes("\\u00ad"), true);
+  assert.equal(out.includes("\\u061c"), true);
+  assert.equal(out.includes("\\u2060"), true);
+  assert.equal(out.includes("\\ufe0f"), true);
+});
+
+test("sanitizeFilenamesForPrompt escapes supplementary plane tag characters", () => {
+  // Given: filename with U+E0001 LANGUAGE TAG (supplementary plane, requires code point iteration)
+  // When:  sanitizeFilenamesForPrompt(input)
+  // Then:  raw U+E0001 is absent and \u{e0001} extended escape literal is present
+  const input = [String.fromCodePoint(0xe0001) + "hidden.ts"];
+
+  const out = sanitizeFilenamesForPrompt(input);
+
+  assert.equal(out.includes(String.fromCodePoint(0xe0001)), false);
+  assert.equal(out.includes("\\u{e0001}"), true);
+});
+
+test("sanitizeFilenamesForPrompt escapes supplementary plane variation selectors", () => {
+  // Given: filename with U+E0100 VARIATION SELECTOR-17
+  // When:  sanitizeFilenamesForPrompt(input)
+  // Then:  raw U+E0100 is absent and \u{e0100} extended escape literal is present
+  const input = ["glyph" + String.fromCodePoint(0xe0100) + ".ts"];
+
+  const out = sanitizeFilenamesForPrompt(input);
+
+  assert.equal(out.includes(String.fromCodePoint(0xe0100)), false);
+  assert.equal(out.includes("\\u{e0100}"), true);
+});
+
+test("sanitizeFilenamesForPrompt escapes lone surrogate halves", () => {
+  // Given: filename with a lone high surrogate (U+D800) that would normally split a pair
+  // When:  sanitizeFilenamesForPrompt(input)
+  // Then:  raw surrogate code unit is absent and \ud800 escape literal is present
+  const input = ["x\ud800y.ts"];
+
+  const out = sanitizeFilenamesForPrompt(input);
+
+  assert.equal(out.includes("\ud800"), false);
+  assert.equal(out.includes("\\ud800"), true);
+});


### PR DESCRIPTION
## Summary

Caller-controlled filenames flow into adversarial review prompts via three self-collected `Changed Files` sections plus a lightweight fallback summary. A repository owner could inject bidi overrides (U+202E), ANSI escapes, zero-width characters, BOM, or other invisible payloads into reviewer prompts, lending themselves to prompt injection (e.g. an `evil<U+202E>reversed.ts` filename would render as visually reversed text inside the reviewer's context).

This PR adds a `prompt-sanitize.mjs` helper that funnels each filename through `escapeRenderUnsafeChars` (Unicode code-point iteration covering 18 ranges across BMP + supplementary plane) → `truncatePayload(512)` → `JSON.stringify`, then joins with `"\n"`. The escape policy covers C0/DEL/C1 controls, ZWS/ZWNJ/ZWJ, LRM/RLM, bidi overrides (LRE/RLE/PDF/LRO/RLO), bidi isolates (LRI/RLI/FSI/PDI), BOM, BMP default-ignorable / format characters (`U+00AD`, `U+061C`, `U+180E`, `U+2060-U+2064`, `U+FE00-U+FE0F`), lone surrogates, BMP specials/non-characters, shorthand format controls, supplementary tag characters (`U+E0000-U+E007F`), and supplementary variation selectors (`U+E0100-U+E01EF`). ECMA-262 24.5.2.2 leaves `U+202E` raw in `JSON.stringify` output, so the escape pass must run before stringification. Supplementary-plane code points are emitted as `\u{XXXX}` extended escapes.

Applied to:
- `lib/git.mjs:248` working-tree Changed Files
- `lib/git.mjs:284` branch Changed Files (now using `git diff --name-only -z` so raw bytes survive the C-escape default)
- `codex-companion.mjs` lightweight Changed Files fallback
- `codex-companion.mjs` lightweight Summary line (JSON.stringify wrap)
- `lib/git.mjs:formatUntrackedFile` untracked heading

Out of scope (`scope-out-followup`):
- `lib/git.mjs` Git Status / Diff Stat sections
- `target.label` derived from `--base`
- `userFocus` from CLI positional arguments

These are operator-controlled rather than repo-owner-controlled in the current threat model and are tracked as follow-up candidates.

## Design notes

- **Why not disable `core.quotePath` globally**: an earlier draft injected `git -c core.quotePath=false` into every git invocation. Local /parallel-review (Codex adversarial-review × 2 rounds + Generator-Verifier) showed that this **regressed** the inline-diff paths: `Staged Diff` / `Unstaged Diff` / `Branch Diff` (default when `collectReviewContext({ includeDiff: true })` is small enough) embed raw `git diff` output, and removing the C-escape exposed raw bidi/format characters there. The shipped PR keeps Git's default quoting for diff output and switches only the `--name-only` lookups (which feed the sanitizer) to `-z` (NUL-delimited) so the raw bytes survive into `sanitizeFilenamesForPrompt`.
- **Why code-point iteration**: the first sanitize draft walked UTF-16 code units via `charCodeAt`, so supplementary-plane invisibles (e.g. `String.fromCodePoint(0xE0001) + "hidden.ts"`) survived end-to-end. The shipped version iterates by `codePointAt` so a single supplementary character is matched against the range list as one unit and `String.fromCodePoint` is used to copy through allowed supplementary code points.
- **Why a denylist instead of a visible-allowlist**: filename round-tripping has to keep arbitrary path characters (CJK, emoji, etc.) intact for human reviewers. An allowlist of "visibly safe" code points would reject any path with non-ASCII letters in practice, which is unacceptable for a real repository. The denylist is broadened to cover documented default-ignorable / format / lone-surrogate / non-character classes per Unicode 16.0.

## Tests

- `tests/sanitize.test.mjs` (10 cases): plain / C0+ANSI / bidi / ZWS+ZWJ+BOM / truncate JSON-parseable / non-array + BMP invisible bundle (U+00AD + U+061C + U+2060 + U+FE0F) + supplementary tag character (U+E0001) + supplementary variation selector (U+E0100) + lone surrogate (U+D800)
- `tests/git-changed-files-sanitize.test.mjs` (3 cases): working-tree + branch mode integration via real git repos (Windows skipped) + inline-diff regression test confirming Git default C-quoting keeps the raw U+202E byte out of `Branch Diff` content
- `tests/codex-companion.test.mjs` (+3 cases): lightweight fallback bidi / bidi isolate / summary stringification (5 existing cap/fallback cases unchanged)

`node --test tests/*.test.mjs` runs **107 tests / 103 PASS / 4 pre-existing FAIL** on an isolated clone at HEAD. The 4 pre-existing failures (`status` × 2, `result`, `resolveStateDir`) reproduce on the `dc4752b` base and are independent of this PR.

## Test plan

- [x] `node --test tests/sanitize.test.mjs tests/git-changed-files-sanitize.test.mjs tests/codex-companion.test.mjs` → 21/21 PASS
- [x] `node --test tests/*.test.mjs` on isolated clone → 103 PASS / 4 pre-existing FAIL
- [x] Local /parallel-review (Codex adversarial × 2 rounds + Generator-Verifier) → 4 blockers (CRITICAL 1 + MAJOR 3) all `fixed-in-pr`, 1 MINOR `scope-out-followup`
- [x] `dc4752b` base regression: existing 5 prompt-cap/fallback test cases in `tests/codex-companion.test.mjs` unchanged + still PASS
- [x] Unicode coverage: `String.fromCodePoint(0xE0001)` and lone-surrogate inputs verified absent from sanitizer output
- [ ] Reviewer: please confirm denylist range scope (especially BMP specials `U+FFF0-FFFF` and shorthand format controls `U+1BCA0-1BCA3`) is appropriate for this codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7 1M planning + Codex CLI gpt-5.4 implementation + Codex adversarial-review)
