### PR TITLE
fix(codex-rescue): require Bash call unconditionally to stop fabricated forwarder output

### DIFF
--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -16,9 +16,11 @@ Selection guidance:
 
 - Do not wait for the user to explicitly ask for Codex. Use this subagent proactively when the main Claude thread should hand a substantial debugging or implementation task to Codex.
 - Do not grab simple asks that the main Claude thread can finish quickly on its own.
+- The two rules above apply to the **caller** deciding whether to invoke this subagent. Once you (this subagent) have been invoked, those rules no longer apply to you — you MUST forward unconditionally per the Forwarding rules below, regardless of how trivial the request now appears.
 
 Forwarding rules:
 
+- **You MUST invoke the Bash `task` call exactly once for every invocation, no matter how trivial, conversational, or self-answerable the request appears.** Never answer from your own knowledge, never fabricate a Codex-style reply, never claim absence of context or memory on Codex's behalf, never decide the request is "too simple to forward". If you are about to produce output without having called Bash, that is a bug — call Bash first.
 - Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ...`.
 - If the user did not explicitly choose `--background` or `--wait`, prefer foreground for a small, clearly bounded rescue request.
 - If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution.
@@ -39,7 +41,7 @@ Forwarding rules:
 - Otherwise forward the task as a fresh `task` run.
 - Preserve the user's task text as-is apart from stripping routing flags.
 - Return the stdout of the `codex-companion` command exactly as-is.
-- If the Bash call fails or Codex cannot be invoked, return nothing.
+- If the Bash call fails or Codex cannot be invoked, return nothing. Returning any text without first calling Bash is forbidden under all circumstances.
 
 Response style:
 


### PR DESCRIPTION
## Summary

The `codex-rescue` subagent is meant to be a thin Bash forwarder around `codex-companion task`, but in practice the Sonnet subagent sometimes skips the Bash call entirely and produces a fabricated Codex-style reply on its own — most reproducibly when the request looks conversational, when `--resume` is used with a short question, or when the user prompt offers a fallback hint such as *if you have no context, say "no context"*.

This PR tightens the agent prompt so the subagent must always invoke Bash, regardless of how trivial the request appears.

## Repro (before this patch)

1. Round 1 — start a fresh thread and ask Codex to memorize two tokens:
   ```
   /codex:rescue --fresh --wait Please remember tokenA=purple-unicorn-42 and tokenB=kStarlightCheckpoint, and reply "memorized".
   ```
   Subagent forwards correctly, Bash call happens, Codex replies "memorized".
2. Round 2 — ask back through `--resume`, but include a fallback hint:
   ```
   /codex:rescue --resume --wait What are tokenA and tokenB you remembered? If you have no context, just say "no context".
   ```
   Subagent returns `no context.` with `tool_uses: 0` — **no Bash call was made.** The reply is fabricated by the subagent, not by Codex.
3. Round 3 — same Round 2 prompt phrased differently (any conversational phrasing): the subagent again skips Bash and self-answers.

Calling `codex-companion task --resume-last` directly from Bash in the same Claude session works perfectly and returns both tokens — proving the resume plumbing itself is fine, and the issue is entirely in the subagent's forwarding behavior.

## Root cause

Two things in the existing agent definition combine to let the subagent rationalize skipping the Bash call:

1. The `Selection guidance` block contains *"Do not grab simple asks that the main Claude thread can finish quickly on its own."* This rule is intended for **the caller** deciding whether to invoke this subagent, but the subagent reads it as advice to **itself** — and if the current request looks simple, it decides not to "really" forward.
2. The `Forwarding rules` block enumerates many specific dos and don'ts but never states the underlying invariant: *every invocation must result in exactly one Bash call.* Under prompt pressure (especially fallback-hint phrasing like "if X, say Y"), the model treats the fallback as an allowed shortcut.

## Fix

Three small prompt changes in `plugins/codex/agents/codex-rescue.md`:

1. Add a clarifying sentence at the end of `Selection guidance` stating that those rules apply to the caller, not to this subagent after it has already been invoked.
2. Add an explicit invariant at the top of `Forwarding rules`: the Bash `task` call MUST happen exactly once for every invocation, and the subagent must never answer from its own knowledge, fabricate Codex-style replies, claim absence of context on Codex's behalf, or decide a request is "too simple to forward".
3. Tighten the existing *"return nothing on Bash failure"* line to also forbid returning any text without first having called Bash.

No code, schema, or test changes. The patch is prompt-only and touches a single Markdown file.

## Verification

With patch applied, the same Round 2 / Round 3 style queries trigger the Bash call and return the correct resumed context (3/3 natural-phrasing queries succeeded with `tool_uses: 1`). Without the patch, the same queries return fabricated `no context.` with `tool_uses: 0`.

## Known limitation

Prompts that explicitly hand the subagent a fallback answer (e.g. *"if you have no context, just say 'no context'"*) can still occasionally bypass the rule — this is a prompt-injection-shaped edge case that's hard to eliminate purely through prompt tightening. In normal usage (engineering tasks, plain follow-up questions), the patch is sufficient. Callers should avoid embedding fallback-answer hints when they want guaranteed forwarding.

## Test plan

- [ ] CI green
- [ ] Manual: `/codex:rescue --fresh` + `/codex:rescue --resume` round trip with a short follow-up question returns real Codex output, not a fabricated reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)