### PR TITLE
fix(rescue): pass timeout: 600000 on the inner task Bash call

### DIFF
--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -20,6 +20,7 @@ Selection guidance:
 Forwarding rules:
 
 - Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ...`.
+- Pass `timeout: 600000` (the 10-minute Bash maximum) on that call. The default 2-minute Bash timeout truncates Codex mid-turn on large-diff rescues and leaves the companion job stranded in `status: running`.
 - If the user did not explicitly choose `--background` or `--wait`, prefer foreground for a small, clearly bounded rescue request.
 - If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution.
 - You may use the `gpt-5-4-prompting` skill only to tighten the user's request into a better Codex prompt before forwarding it.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -25,6 +25,7 @@ Execution rules:
 
 Command selection:
 - Use exactly one `task` invocation per rescue handoff.
+- Pass `timeout: 600000` (the 10-minute Bash maximum) on the `Bash` call that invokes `task`. The default 2-minute Bash timeout kills Codex mid-turn on large-diff rescues.
 - If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only. Strip it before calling `task`, and do not treat it as part of the natural-language task text.
 - If the forwarded request includes `--model`, normalize `spark` to `gpt-5.3-codex-spark` and pass it through to `task`.
 - If the forwarded request includes `--effort`, pass it through to `task`.

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -129,6 +129,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(agent, /prefer foreground for a small, clearly bounded rescue request/i);
   assert.match(agent, /If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution/i);
   assert.match(agent, /Use exactly one `Bash` call/i);
+  assert.match(agent, /Pass `timeout: 600000` \(the 10-minute Bash maximum\) on that call/i);
   assert.match(agent, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(agent, /Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`/i);
   assert.match(agent, /Leave `--effort` unset unless the user explicitly requests a specific reasoning effort/i);
@@ -149,6 +150,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /Map `spark` to `--model gpt-5\.3-codex-spark`/i);
   assert.match(runtimeSkill, /If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only/i);
   assert.match(runtimeSkill, /Strip it before calling `task`/i);
+  assert.match(runtimeSkill, /Pass `timeout: 600000` \(the 10-minute Bash maximum\) on the `Bash` call that invokes `task`/i);
   assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`/i);
   assert.match(runtimeSkill, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);


### PR DESCRIPTION
## Problem

The `/codex:rescue` command dispatches to the `codex:codex-rescue` subagent, which makes one `Bash` call to `codex-companion.mjs task`. Neither the agent nor the `codex-cli-runtime` skill tells the model to pass a `timeout`, so the call inherits Claude Code's default Bash timeout of 120s. Codex rescues against non-trivial diffs routinely take several minutes; they get SIGTERM'd mid-turn at the 120s cap, leaving the companion job dangling in `status: running`.
The 120s default and 600s ceiling are documented in [Claude Code's Bash tool reference](https://code.claude.com/docs/en/tools-reference.md#bash-tool-behavior) under "Timeout: two minutes by default. Claude can request up to 10 minutes per command with the `timeout` parameter." Both are overridable via `BASH_DEFAULT_TIMEOUT_MS` / `BASH_MAX_TIMEOUT_MS` env vars, but passing `timeout: 600000` explicitly works regardless of the user's `BASH_DEFAULT_TIMEOUT_MS`.

Reported in #122.

## Fix

Add one bullet in each of two places, requiring `timeout: 600000` (the Bash tool's 10-minute maximum) on the inner `task` invocation:

- `plugins/codex/agents/codex-rescue.md` (Forwarding rules)
- `plugins/codex/skills/codex-cli-runtime/SKILL.md` (Command selection)

Small rescues are unaffected; large-diff ones now have room to finish.

## Why not the same approach as PR #239

PR #239 fixes the same 120s-cap symptom for `/codex:review` and `/codex:adversarial-review` by embedding a `Bash({timeout: 600000})` block directly in those command templates. `/codex:rescue` cannot be fixed that way because its `Bash` call is constructed dynamically by the subagent, not declared in the command template — so the instruction has to live in the agent and the runtime skill that build the call.

## Relationship to other open PRs

- **PR #214** (closes #198) touches the same two files but on different lines, addressing the orthogonal `run_in_background` problem. The two PRs merge cleanly in either order.
- **PRs #184 / #302 / #312** add wall-clock timeouts at the `captureTurn` / RPC layer. They are defense-in-depth at a different layer and remain useful even with this PR landed, since they catch app-server-side hangs that a Bash-tool timeout cannot.

## Test plan

- [x] `node --test tests/commands.test.mjs` → 8/8 pass. The new contract assertions hold (`Pass \`timeout: 600000\`...` matches in both the agent and the runtime skill).
- [x] `npm test` (full suite): 82/86 pass. The same 4 failures are present on a pristine `origin/main` checkout — verified by temporarily replacing only the three files this PR modifies with their `origin/main` versions (`git checkout origin/main -- <files>`) and re-running `npm test` in the same environment. Identical failure set. The four are already documented as pre-existing in PR #302 and PR #184 bodies:
  - `status shows phases, hints, and the latest finished job`
  - `status preserves adversarial review kind labels`
  - `result returns the stored output for the latest finished job by default`
  - `resolveStateDir uses a temp-backed per-workspace directory`
- [ ] Manual: a `/codex:rescue` invocation over a ~30-file diff that previously died at the 120s cap completes end-to-end. (Not run from the session that prepared this PR.)

Closes #122