### PR TITLE
test: isolate from host-runtime plugin env vars

### DIFF
--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -4,6 +4,14 @@ import path from "node:path";
 import process from "node:process";
 import { spawnSync } from "node:child_process";
 
+// Isolate tests from host-runtime plugin env vars. Claude Code (and similar
+// plugin hosts) injects CLAUDE_PLUGIN_DATA and CODEX_COMPANION_SESSION_ID into
+// the plugin process; if those leak into `npm test`, fallback-path assertions
+// (e.g. `resolveStateDir uses a temp-backed per-workspace directory`) fail.
+// Tests that need these vars set them explicitly with try/finally.
+delete process.env.CLAUDE_PLUGIN_DATA;
+delete process.env.CODEX_COMPANION_SESSION_ID;
+
 export function makeTempDir(prefix = "codex-plugin-test-") {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }


### PR DESCRIPTION
## Summary

Host plugin runtimes (e.g. Claude Code) inject `CLAUDE_PLUGIN_DATA` and `CODEX_COMPANION_SESSION_ID` into the plugin process. When these leak into `npm test`, two tests fail with non-bug assertions:

- `tests/state.test.mjs` — *resolveStateDir uses a temp-backed per-workspace directory*: `CLAUDE_PLUGIN_DATA` redirects state to `~/.claude/plugins/data/...` instead of `os.tmpdir()`.
- `tests/runtime.test.mjs` — *result without a job id ...*: fixture writer and the spawned `result` subprocess look at different state dirs because of the same redirection.

CI passes (no host-runtime env), so this only bites contributors running `npm test` from inside a plugin host. Fix: `delete` these env vars at the top of `tests/helpers.mjs` (the shared import) so every test gets a clean slate. Tests that exercise the env var explicitly (*resolveStateDir uses CLAUDE_PLUGIN_DATA when it is provided*) already use try/finally to set and restore it, so they continue to pass.

## Repro (before this PR)

```sh
CLAUDE_PLUGIN_DATA=/tmp/anywhere CODEX_COMPANION_SESSION_ID=any-uuid npm test
# ✖ tests/state.test.mjs    — resolveStateDir uses a temp-backed per-workspace directory
# ✖ tests/runtime.test.mjs  — result without a job id prefers the latest finished job ...
```

## Verification

```
ℹ tests 86
ℹ pass 86
ℹ fail 0
```

Verified locally with the polluting env vars still set in the parent shell — the module-level `delete` runs before any test reads `process.env`.

## Test plan

- [x] Run `npm test` with `CLAUDE_PLUGIN_DATA` and `CODEX_COMPANION_SESSION_ID` set in parent shell — all 86 tests pass
- [x] Run `npm test` without those vars set — all 86 tests still pass
- [x] `resolveStateDir uses CLAUDE_PLUGIN_DATA when it is provided` still passes (uses its own try/finally)