### PR TITLE
docs(changelog): backfill 1.0.1 through 1.0.4

### DIFF
--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.0.4
+
+- Route `/codex:rescue` through the Agent tool to stop Skill recursion (#234, #235)
+- Quote `$ARGUMENTS` in `cancel`, `result`, and `status` commands (#168)
+- Declare model in `codex-rescue` agent frontmatter (#169)
+- Honor `--cwd` when reporting session runtime (#35)
+
+## 1.0.3
+
+- Avoid embedding large adversarial review diffs (#179)
+- Scope default cancel selection to the current Claude session (#84)
+- Scope implicit resume-last selection to the current Claude session (#83)
+- Gracefully handle unsupported thread/name/set on older Codex CLI (#126)
+- Inherit `process.env` in app-server spawn when no explicit env is provided (#159)
+- Use app-server auth status for Codex readiness (#177)
+- Respect `SHELL` on Windows for Git Bash (#178)
+- Fix working-tree review crash on untracked directories / broken symlinks (#166)
+
+## 1.0.2
+
+- Fix `/codex:rescue` AskUserQuestion contract (#43)
+- Resolve Windows ENOENT when spawning Codex app-server (#55)
+
+## 1.0.1
+
+- Add `shell: true` on Windows so `spawnSync` can resolve `.cmd` shims (#13)
+
 ## 1.0.0
 
 - Initial version of the Codex plugin for Claude Code


### PR DESCRIPTION
## Summary

`plugins/codex/CHANGELOG.md` is stuck at `1.0.0` while `plugins/codex/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` are at `1.0.4`. The last four version bumps (#22, #74, #180, #244) updated the metadata but not the changelog.

This PR backfills the four missing entries by attributing the PRs that actually shipped between each bump commit:

- **1.0.1** — #13
- **1.0.2** — #43, #55
- **1.0.3** — #83, #84, #126, #159, #166, #177, #178, #179
- **1.0.4** — #35, #168, #169, #234/#235

Entries were derived from \`git log\` between consecutive version-bump commits.

## Test plan

- [x] CHANGELOG.md reflects every shipped PR for 1.0.1+
- [x] No source file changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)