### PR TITLE
Add new two commands monitor & shift

### DIFF
--- a/plugins/codex/commands/monitor.md
+++ b/plugins/codex/commands/monitor.md
@@ -1,0 +1,69 @@
+---
+description: Start a background Codex session that builds project context for this Claude Code session
+argument-hint: "[--resume | --resume-session <id|number>] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>]"
+context: fork
+allowed-tools: Bash(node:*), AskUserQuestion
+---
+
+Start a background Codex monitor for this session.
+
+Raw slash-command arguments:
+`$ARGUMENTS`
+
+---
+
+## No flags — always start fresh immediately, no questions
+
+If `$ARGUMENTS` contains no `--resume` or `--resume-session` flag:
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" monitor $ARGUMENTS
+```
+Return stdout verbatim. Stop here — do not check sessions, do not ask anything.
+
+---
+
+## `--resume` or `--resume-session` flag present — check sessions first
+
+Extract any runtime flags from `$ARGUMENTS` to forward (everything except `--resume` and `--resume-session <value>`):
+- `--model <value>` if present → append `--model <value>` to every command below
+- `--effort <value>` if present → append `--effort <value>` to every command below
+
+Run:
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" monitor --list-sessions --json
+```
+
+Parse `sessions` from the JSON output.
+
+**0 sessions** — no history yet, start fresh:
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" monitor [--model <value>] [--effort <value>]
+```
+
+**1 session** — auto-resume it, no question needed:
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" monitor --resume-session <that-session-id> [--model <value>] [--effort <value>]
+```
+
+**2+ sessions** — use `AskUserQuestion` exactly once. Options:
+- One option per session:
+  - label: `<startedAt date> — <turnCount> turns` — append `[active]` if it is the active session and mark it `(Recommended)`, list it first.
+  - description: use the session's `lastSummary` field verbatim if present, otherwise `"No summary available"`.
+- Last option always: label `Start a fresh session`, description `"Begin a new context."`
+
+After the user picks:
+- Fresh → run without resume flags (but keep `--model`/`--effort` if supplied)
+- A session → run with `--resume-session <chosen-id>` (and keep `--model`/`--effort` if supplied)
+
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" monitor --resume-session <chosen-id> [--model <value>] [--effort <value>]
+```
+
+Return stdout verbatim.
+
+---
+
+## Operating rules
+- Do not paraphrase, summarize, or add commentary around the monitor output.
+- Do not wait for the monitor job to complete — it runs entirely in the background.
+- If Codex is not installed or unauthenticated, tell the user to run `/codex:setup`.

--- a/plugins/codex/commands/monitor.md
+++ b/plugins/codex/commands/monitor.md
@@ -1,0 +1,65 @@
+---
+description: Start a background Codex session that builds project context for this Claude Code session
+argument-hint: "[--resume | --resume-session <id|number>] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>]"
+context: fork
+allowed-tools: Bash(node:*), AskUserQuestion
+---
+
+Start a background Codex monitor for this session.
+
+Raw slash-command arguments:
+`$ARGUMENTS`
+
+---
+
+## No flags — always start fresh immediately, no questions
+
+If `$ARGUMENTS` contains no `--resume` or `--resume-session` flag:
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" monitor $ARGUMENTS
+```
+Return stdout verbatim. Stop here — do not check sessions, do not ask anything.
+
+---
+
+## `--resume` or `--resume-session` flag present — check sessions first
+
+Run:
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" monitor --list-sessions --json
+```
+
+Parse `sessions` from the JSON output.
+
+**0 sessions** — no history yet, start fresh:
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" monitor
+```
+
+**1 session** — auto-resume it, no question needed:
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" monitor --resume-session <that-session-id>
+```
+
+**2+ sessions** — use `AskUserQuestion` exactly once. Options:
+- One option per session:
+  - label: `<startedAt date> — <turnCount> turns` — append `[active]` if it is the active session and mark it `(Recommended)`, list it first.
+  - description: use the session's `lastSummary` field verbatim if present, otherwise `"No summary available"`.
+- Last option always: label `Start a fresh session`, description `"Begin a new context."`
+
+After the user picks:
+- Fresh → run without resume flags
+- A session → run with `--resume-session <chosen-id>`
+
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" monitor --resume-session <chosen-id>
+```
+
+Return stdout verbatim.
+
+---
+
+## Operating rules
+- Do not paraphrase, summarize, or add commentary around the monitor output.
+- Do not wait for the monitor job to complete — it runs entirely in the background.
+- If Codex is not installed or unauthenticated, tell the user to run `/codex:setup`.

--- a/plugins/codex/commands/shift.md
+++ b/plugins/codex/commands/shift.md
@@ -1,0 +1,51 @@
+---
+description: Hand off the current session to Codex — pick a monitor session, write a shift package, and open a new Codex terminal
+argument-hint: ""
+context: fork
+allowed-tools: Bash(node:*), AskUserQuestion
+---
+
+Hand off to Codex.
+
+## Step 1 — check for sessions
+
+Run:
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" shift --list-sessions --json
+```
+
+Parse `sessions` from the JSON output.
+
+**0 sessions** — nothing to shift. Tell the user:
+> No monitor sessions found for this project. Run `/codex:monitor` first to start recording context.
+
+Stop here.
+
+**1 session** — auto-select it, no question needed:
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" shift --session <that-session-id> --launch
+```
+
+**2+ sessions** — use `AskUserQuestion` exactly once. Options:
+- One option per session:
+  - label: `<startedAt date> — <turnCount> turns` — if `active === true`, append `[active]` and mark it `(Recommended)`, list it first.
+  - description: use the session's `lastSummary` field verbatim if present, otherwise `"No summary available"`.
+- Last option always: label `All sessions`, description `"Merge context from every session for this directory"`.
+
+After the user picks:
+- A specific session → run with `--session <chosen-id> --launch`
+- All sessions → run without `--session` but with `--launch`
+
+```bash
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" shift --session <chosen-id> --launch
+# or, for "All sessions":
+CLAUDE_PLUGIN_DATA="${CLAUDE_PLUGIN_DATA}" node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" shift --launch
+```
+
+Return stdout verbatim.
+
+---
+
+## Operating rules
+- Do not paraphrase, summarize, or add commentary before or after the output.
+- If Codex is not installed or unauthenticated, tell the user to run `/codex:setup`.

--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -28,6 +28,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/shift-history-hook.mjs\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/stop-review-gate-hook.mjs\"",
             "timeout": 900
           }

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
@@ -51,6 +51,17 @@ import {
   SESSION_ID_ENV
 } from "./lib/tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
+import {
+  compactShiftHistory,
+  formatCompactForPrompt,
+  getActiveShiftSessionId,
+  initShiftSession,
+  listShiftSessions,
+  mergeAllShiftSessions,
+  readShiftHistory,
+  readShiftCompact,
+  setShiftSessionCodexJobId
+} from "./lib/shift-history.mjs";
 import {
   renderNativeReviewResult,
   renderReviewResult,
@@ -465,7 +476,10 @@ async function executeTaskRun(request) {
   });
 
   let resumeThreadId = null;
-  if (request.resumeLast) {
+  if (request.resumeThreadId) {
+    // Explicit thread supplied (e.g. monitor resume reusing same Codex thread)
+    resumeThreadId = request.resumeThreadId;
+  } else if (request.resumeLast) {
     const latestThread = await resolveLatestTrackedTaskThread(workspaceRoot, {
       excludeJobId: request.jobId
     });
@@ -598,7 +612,7 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId, resumeThreadId = null }) {
   return {
     cwd,
     model,
@@ -606,7 +620,8 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     prompt,
     write,
     resumeLast,
-    jobId
+    jobId,
+    resumeThreadId
   };
 }
 
@@ -978,6 +993,436 @@ async function handleCancel(argv) {
   outputCommandResult(payload, renderCancelReport(nextJob), options.json);
 }
 
+async function handleMonitor(argv) {
+  const { options } = parseCommandInput(argv, {
+    valueOptions: ["model", "effort", "cwd", "resume-session"],
+    booleanOptions: ["json", "resume", "list-sessions"]
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+
+  // --list-sessions: just print existing sessions and exit, don't start anything
+  if (options["list-sessions"]) {
+    const sessions = listShiftSessions(workspaceRoot);
+    if (sessions.length === 0) {
+      const rendered = "No shift sessions found for this project.\n";
+      outputCommandResult({ sessions: [] }, rendered, options.json);
+      return;
+    }
+    const lines = sessions.map((s) =>
+      `${s.active ? "[active] " : "         "}${s.id}  ${s.startedAt.slice(0, 10)}  ${s.turnCount} turn${s.turnCount !== 1 ? "s" : ""}${s.resumed ? "  (resumed)" : ""}`
+    );
+    const rendered = [
+      "Shift sessions for this project:",
+      ...lines,
+      "",
+      `To resume a session:  /codex:monitor --resume-session <id>`,
+      `To resume the active: /codex:monitor --resume`,
+      `To start fresh:       /codex:monitor`,
+      ""
+    ].join("\n");
+    outputCommandResult({ sessions }, rendered, options.json);
+    return;
+  }
+
+  const model = normalizeRequestedModel(options.model);
+  const effort = normalizeReasoningEffort(options.effort);
+
+  ensureCodexAvailable(cwd);
+
+  // Resolve which session to use before initializing
+  let resolvedResumeSessionId = null;
+
+  if (options.resume || options["resume-session"]) {
+    const existing = listShiftSessions(workspaceRoot);
+    const rawPick = options["resume-session"] ?? null;
+
+    if (rawPick !== null) {
+      const asNumber = Number(rawPick);
+      if (Number.isInteger(asNumber) && asNumber >= 1 && asNumber <= existing.length) {
+        // User passed a list number like --resume-session 2
+        resolvedResumeSessionId = existing[asNumber - 1].id;
+      } else {
+        // User passed a full session ID
+        resolvedResumeSessionId = rawPick;
+      }
+    } else if (existing.length === 1) {
+      // --resume with exactly one session → auto-pick it
+      resolvedResumeSessionId = existing[0].id;
+    } else if (existing.length > 1) {
+      // --resume with multiple sessions → print numbered list with summaries, stop
+      const lines = existing.flatMap((s, i) => {
+        const badge = s.active ? " [active]" : "";
+        const meta = `${s.startedAt.slice(0, 10)}  ${s.turnCount} turn${s.turnCount !== 1 ? "s" : ""}`;
+        const header = `  ${i + 1}.${badge} ${meta}`;
+        const summary = s.lastSummary ? `       └─ ${s.lastSummary}` : null;
+        return summary ? [header, summary] : [header];
+      });
+      const rendered = [
+        "Multiple shift sessions found. Pick one:",
+        ...lines,
+        "",
+        "Re-run with:  /codex:monitor --resume-session <number>",
+        ""
+      ].join("\n");
+      outputCommandResult({ sessions: existing, needsPick: true }, rendered, options.json);
+      return;
+    }
+    // existing.length === 0 with --resume → fall through to fresh start
+  }
+
+  const isResumed = Boolean(resolvedResumeSessionId);
+  const shiftSessionId = initShiftSession(workspaceRoot, {
+    resume: isResumed,
+    sessionId: resolvedResumeSessionId
+  });
+
+  // When resuming, reuse the same Codex thread so `codex resume` doesn't
+  // accumulate a new entry every time the user runs /codex:monitor.
+  let prevCodexThreadId = null;
+  if (isResumed) {
+    const sessions = listShiftSessions(workspaceRoot);
+    const chosenMeta = sessions.find((s) => s.id === shiftSessionId);
+    if (chosenMeta?.codexJobId) {
+      const prevStoredJob = readStoredJob(workspaceRoot, chosenMeta.codexJobId);
+      prevCodexThreadId = prevStoredJob?.threadId ?? null;
+    }
+  }
+
+  const prompt =
+    "You are now monitoring a Claude Code session for this project. " +
+    "Explore the project structure, read key source files, review recent git commits, " +
+    "and understand what is currently being built. " +
+    "Build a complete mental model of the codebase. " +
+    "Do not make any changes. " +
+    "When /codex:shift is called you will receive a compacted summary of the Claude session " +
+    "and further instructions.";
+
+  const taskMetadata = { title: "Codex Monitor", summary: "Session monitor — building project context" };
+  const job = buildTaskJob(workspaceRoot, taskMetadata, false);
+  const request = buildTaskRequest({
+    cwd, model, effort, prompt, write: false, resumeLast: false, jobId: job.id,
+    resumeThreadId: prevCodexThreadId  // null for fresh, existing thread when resuming
+  });
+  const { payload } = enqueueBackgroundTask(cwd, job, request);
+
+  // Track the new job against this shift session so future resumes reuse the thread
+  setShiftSessionCodexJobId(workspaceRoot, shiftSessionId, job.id);
+
+  const modeLabel = isResumed
+    ? prevCodexThreadId
+      ? "Resuming previous shift session (continuing Codex thread)"
+      : "Resuming previous shift session (new Codex thread)"
+    : "Starting fresh shift session";
+  const rendered =
+    `Codex monitor started in the background as ${payload.jobId}.\n` +
+    `${modeLabel} (${shiftSessionId}).\n` +
+    `Codex is now building context for this project.\n` +
+    `Run /codex:shift when you are ready to hand off to Codex.\n`;
+
+  outputCommandResult({ ...payload, shiftSessionId, resumed: isResumed }, rendered, options.json);
+}
+
+function tryLaunchCodexTerminal(cwd, threadId, contextPrompt) {
+  // Try to copy context to clipboard (used when pre-send is unavailable)
+  let clipboardCopied = false;
+  if (contextPrompt) {
+    for (const { cmd, args } of [
+      { cmd: "xclip", args: ["-selection", "clipboard"] },
+      { cmd: "xsel", args: ["--clipboard", "--input"] },
+      { cmd: "pbcopy", args: [] }
+    ]) {
+      const which = spawnSync("which", [cmd], { encoding: "utf8" });
+      if (which.status !== 0) continue;
+      const proc = spawnSync(cmd, args, { input: contextPrompt, encoding: "utf8" });
+      if (proc.status === 0) { clipboardCopied = true; break; }
+    }
+  }
+
+  const codexCommand = `codex resume ${threadId}`;
+
+  // 1. tmux — new window inside the current tmux session.
+  //    When the IDE terminal runs inside tmux (common VS Code setup), this opens
+  //    a new tab inside the IDE rather than a separate system window.
+  if (process.env.TMUX) {
+    const res = spawnSync("tmux", ["new-window", "-n", "codex", codexCommand], { encoding: "utf8" });
+    if (res.status === 0) return { launched: true, terminal: "tmux", method: "new-window", clipboardCopied };
+  }
+
+  // 2. WezTerm — new tab via the WezTerm IPC CLI.
+  if (process.env.WEZTERM_UNIX_SOCKET || process.env.WEZTERM_PANE) {
+    const check = spawnSync("which", ["wezterm"], { encoding: "utf8" });
+    if (check.status === 0) {
+      const res = spawnSync("wezterm", ["cli", "spawn", "--", "bash", "-c", codexCommand], { encoding: "utf8" });
+      if (res.status === 0) return { launched: true, terminal: "wezterm", method: "cli spawn", clipboardCopied };
+    }
+  }
+
+  // 3. Zellij — new pane running the command.
+  if (process.env.ZELLIJ) {
+    const check = spawnSync("which", ["zellij"], { encoding: "utf8" });
+    if (check.status === 0) {
+      const res = spawnSync("zellij", ["run", "--name", "codex", "--", "bash", "-c", codexCommand], { encoding: "utf8" });
+      if (res.status === 0) return { launched: true, terminal: "zellij", method: "run", clipboardCopied };
+    }
+  }
+
+  // 4. System terminal emulators (fallback — opens outside the IDE).
+  for (const { name, args } of [
+    { name: "gnome-terminal", args: (c) => ["--", "bash", "-c", c] },
+    { name: "xterm", args: (c) => ["-e", c] },
+    { name: "konsole", args: (c) => ["-e", c] },
+    { name: "xfce4-terminal", args: (c) => ["-e", c] },
+    { name: "lxterminal", args: (c) => ["-e", c] },
+    { name: "alacritty", args: (c) => ["-e", "bash", "-c", c] },
+    { name: "kitty", args: (c) => ["bash", "-c", c] },
+    { name: "x-terminal-emulator", args: (c) => ["-e", c] }
+  ]) {
+    const which = spawnSync("which", [name], { encoding: "utf8" });
+    if (which.status !== 0) continue;
+    try {
+      const child = spawn(name, args(codexCommand), { cwd, detached: true, stdio: "ignore" });
+      child.unref();
+      return { launched: true, terminal: name, method: "system", clipboardCopied };
+    } catch {
+      // try next
+    }
+  }
+
+  return { launched: false, terminal: null, method: null, clipboardCopied };
+}
+
+async function handleShift(argv) {
+  const { options } = parseCommandInput(argv, {
+    valueOptions: ["cwd", "session"],
+    booleanOptions: ["json", "list-sessions", "launch"]
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+
+  // --list-sessions: informational only
+  if (options["list-sessions"]) {
+    const sessions = listShiftSessions(workspaceRoot);
+    const rendered = sessions.length === 0
+      ? "No shift sessions found. Run /codex:monitor to start one.\n"
+      : sessions.map((s) =>
+          `${s.active ? "* " : "  "}${s.id}  (${s.turnCount} turns, started ${s.startedAt.slice(0, 10)}${s.resumed ? ", resumed" : ""})`
+        ).join("\n") + "\n";
+    outputCommandResult({ sessions }, rendered, options.json);
+    return;
+  }
+
+  // Resolve which session(s) to use
+  const allSessions = listShiftSessions(workspaceRoot);
+  let compact = null;
+  let chosenSession = null;
+
+  if (options.session) {
+    const rawPick = String(options.session);
+    const asNumber = Number(rawPick);
+    let sessionId;
+    if (Number.isInteger(asNumber) && asNumber >= 1 && asNumber <= allSessions.length) {
+      sessionId = allSessions[asNumber - 1].id;
+    } else {
+      sessionId = rawPick;
+    }
+    chosenSession = allSessions.find((s) => s.id === sessionId) ?? null;
+    if (!chosenSession) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    compact = compactShiftHistory(workspaceRoot, sessionId);
+  } else {
+    // No specific session — merge all
+    compact = allSessions.length > 0 ? mergeAllShiftSessions(workspaceRoot) : null;
+  }
+
+  const contextBlock = formatCompactForPrompt(compact);
+
+  // Resolve Codex threadId: prefer the tracked job from the chosen shift session,
+  // then fall back to the current Claude session's most recent job.
+  let threadId = null;
+  if (chosenSession?.codexJobId) {
+    const trackedJob = readStoredJob(workspaceRoot, chosenSession.codexJobId);
+    threadId = trackedJob?.threadId ?? null;
+  }
+  if (!threadId) {
+    // Fallback: look across all sessions' tracked jobs
+    for (const s of allSessions) {
+      if (!s.codexJobId) continue;
+      const storedJob = readStoredJob(workspaceRoot, s.codexJobId);
+      if (storedJob?.threadId) { threadId = storedJob.threadId; break; }
+    }
+  }
+  if (!threadId) {
+    // Last resort: current Claude session filter
+    const jobs = filterJobsForCurrentClaudeSession(sortJobsNewestFirst(listJobs(workspaceRoot)));
+    threadId = jobs.find((job) => job.threadId)?.threadId ?? null;
+  }
+
+  // Create git-diff markdown file in project root
+  const now = new Date().toISOString().slice(0, 10);
+  const SHIFT_EXCLUDE = [":(exclude).codex-shift-*.md"];
+  const diffStat = spawnSync("git", ["diff", "--stat", "HEAD", "--", ".", ...SHIFT_EXCLUDE], { cwd, encoding: "utf8" });
+  const diffFull = spawnSync("git", ["diff", "HEAD", "--", ".", ...SHIFT_EXCLUDE], { cwd, encoding: "utf8" });
+  const logRecent = spawnSync("git", ["log", "--oneline", "-10"], { cwd, encoding: "utf8" });
+  const untrackedResult = spawnSync(
+    "git",
+    ["ls-files", "--others", "--exclude-standard", "--exclude=.codex-shift-*.md"],
+    { cwd, encoding: "utf8" }
+  );
+  const untrackedFiles = (untrackedResult.stdout ?? "").trim().split("\n")
+    .filter(Boolean)
+    .filter((f) => !/^\.codex-shift-.*\.md$/.test(f));
+
+  // Build untracked diff by running git diff --no-index /dev/null <file> for each
+  const untrackedDiffParts = [];
+  for (const file of untrackedFiles.slice(0, 20)) {
+    const fileDiff = spawnSync("git", ["diff", "--no-index", "/dev/null", file], { cwd, encoding: "utf8" });
+    if (fileDiff.stdout) untrackedDiffParts.push(fileDiff.stdout.trim());
+  }
+
+  const statBlock = [
+    (diffStat.stdout ?? "").trim() || "",
+    untrackedFiles.length > 0
+      ? `\nUntracked files:\n${untrackedFiles.map((f) => `  ${f}`).join("\n")}`
+      : ""
+  ].join("").trim() || "(no changes)";
+
+  const fullDiffBlock = [
+    (diffFull.stdout ?? "").trim(),
+    ...untrackedDiffParts
+  ].filter(Boolean).join("\n") || "(no diff)";
+
+  const mdLines = [
+    `# Codex Shift — ${now}`,
+    "",
+    "## Recent Commits",
+    "```",
+    (logRecent.stdout ?? "").trim() || "(none)",
+    "```",
+    "",
+    "## Changed Files",
+    "```",
+    statBlock,
+    "```",
+    "",
+    "## Full Diff",
+    "```diff",
+    fullDiffBlock,
+    "```"
+  ];
+
+  if (contextBlock) {
+    const sessionLabel = chosenSession
+      ? "## Claude Session Context"
+      : `## Claude Session Context (merged from ${allSessions.length} sessions)`;
+    mdLines.push("", sessionLabel, "", contextBlock);
+  }
+
+  const mdContent = mdLines.join("\n") + "\n";
+  const mdPath = path.join(cwd, `.codex-shift-${now}.md`);
+  fs.writeFileSync(mdPath, mdContent, "utf8");
+
+  // Build the initial Codex prompt
+  const contextSection = contextBlock
+    ? `\n\n${contextBlock}`
+    : "\n\n(No session history recorded yet — run /codex:monitor at the start of your next session.)";
+
+  const codexPrompt =
+    `Don't do anything with this query, just take context and follow my further instructions.\n` +
+    contextSection;
+
+  // When --launch is requested, pre-send the context to the Codex thread so it
+  // is already processed when the user opens the terminal. This avoids needing
+  // to paste anything manually.
+  let preSendOk = false;
+  let targetThreadId = threadId;
+  if (options.launch && threadId) {
+    process.stdout.write("Sending context to Codex...\n");
+    try {
+      ensureCodexAvailable(cwd);
+      const result = await runAppServerTurn(workspaceRoot, {
+        resumeThreadId: threadId,
+        prompt: codexPrompt,
+        sandbox: "read-only",
+        persistThread: true
+      });
+      targetThreadId = result.threadId ?? threadId;
+      preSendOk = true;
+      process.stdout.write("Context delivered. Opening terminal...\n");
+    } catch (err) {
+      process.stdout.write(`Note: could not pre-send context (${err.message}). Paste it manually.\n`);
+    }
+  }
+
+  // Launch terminal — pass contextPrompt only when pre-send failed (clipboard fallback)
+  let launchResult = null;
+  if (options.launch && targetThreadId) {
+    launchResult = tryLaunchCodexTerminal(cwd, targetThreadId, preSendOk ? null : codexPrompt);
+  }
+
+  const resumeLine = targetThreadId
+    ? `codex resume ${targetThreadId}`
+    : "(no Codex thread found — run /codex:monitor first or start a /codex:rescue)";
+
+  const sessionInfo = chosenSession
+    ? `${chosenSession.id} (${chosenSession.turnCount} turn${chosenSession.turnCount !== 1 ? "s" : ""})`
+    : `${allSessions.length} merged sessions`;
+
+  let rendered;
+  if (launchResult?.launched) {
+    const inIde = launchResult.terminal === "tmux" || launchResult.terminal === "wezterm" || launchResult.terminal === "zellij";
+    const where = inIde ? "IDE terminal" : "system terminal";
+    const statusLine = preSendOk
+      ? "Context already loaded — Codex is ready for your instructions."
+      : launchResult.clipboardCopied
+        ? "Context copied to clipboard — paste it as your first Codex message."
+        : `Paste as your first Codex message:\n---\n${codexPrompt}\n---`;
+    rendered = [
+      "=== Codex Shift Ready ===",
+      "",
+      `Changes saved to: ${mdPath}`,
+      `Context: ${sessionInfo}`,
+      "",
+      `Codex terminal opened in ${where} (${launchResult.terminal}).`,
+      statusLine,
+      ""
+    ].join("\n");
+  } else {
+    const pasteBlock = preSendOk
+      ? "(context already pre-loaded — just resume and start giving instructions)"
+      : `Then send this as your first message to Codex:\n---\n${codexPrompt}\n---`;
+    rendered = [
+      "=== Codex Shift Ready ===",
+      "",
+      `Changes saved to: ${mdPath}`,
+      `Context: ${sessionInfo}`,
+      "",
+      "Run this in a new terminal:",
+      `  ${resumeLine}`,
+      "",
+      pasteBlock,
+      ""
+    ].join("\n");
+  }
+
+  const payload = {
+    threadId: targetThreadId,
+    mdPath,
+    sessionCount: allSessions.length,
+    chosenSessionId: chosenSession?.id ?? null,
+    compact,
+    resumeCommand: resumeLine,
+    codexPrompt,
+    preSendOk,
+    launch: launchResult
+  };
+
+  outputCommandResult(payload, rendered, options.json);
+}
+
 async function main() {
   const [subcommand, ...argv] = process.argv.slice(2);
   if (!subcommand || subcommand === "help" || subcommand === "--help") {
@@ -1014,6 +1459,12 @@ async function main() {
       break;
     case "cancel":
       await handleCancel(argv);
+      break;
+    case "monitor":
+      await handleMonitor(argv);
+      break;
+    case "shift":
+      await handleShift(argv);
       break;
     default:
       throw new Error(`Unknown subcommand: ${subcommand}`);

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -60,6 +60,7 @@ import {
   mergeAllShiftSessions,
   readShiftHistory,
   readShiftCompact,
+  setShiftSessionClaudeId,
   setShiftSessionCodexJobId
 } from "./lib/shift-history.mjs";
 import {
@@ -1107,8 +1108,11 @@ async function handleMonitor(argv) {
   });
   const { payload } = enqueueBackgroundTask(cwd, job, request);
 
-  // Track the new job against this shift session so future resumes reuse the thread
+  // Track the new job and the current Claude session against this shift session.
+  // The Stop hook uses the Claude session ID to avoid recording turns from
+  // unrelated sessions that happen to share the same workspace.
   setShiftSessionCodexJobId(workspaceRoot, shiftSessionId, job.id);
+  setShiftSessionClaudeId(workspaceRoot, shiftSessionId, getCurrentClaudeSessionId());
 
   const modeLabel = isResumed
     ? prevCodexThreadId

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -1111,7 +1111,9 @@ async function handleMonitor(argv) {
   // Track the new job and the current Claude session against this shift session.
   // The Stop hook uses the Claude session ID to avoid recording turns from
   // unrelated sessions that happen to share the same workspace.
-  setShiftSessionCodexJobId(workspaceRoot, shiftSessionId, job.id);
+  // Pass prevCodexThreadId so the session record retains access to the previous
+  // thread while the new job is still queued and has not yet reported its threadId.
+  setShiftSessionCodexJobId(workspaceRoot, shiftSessionId, job.id, prevCodexThreadId);
   setShiftSessionClaudeId(workspaceRoot, shiftSessionId, getCurrentClaudeSessionId());
 
   const modeLabel = isResumed
@@ -1254,8 +1256,12 @@ async function handleShift(argv) {
       const trackedJob = readStoredJob(workspaceRoot, chosenSession.codexJobId);
       threadId = trackedJob?.threadId ?? null;
     }
-    // If still null the monitor hasn't reported a thread yet — leave threadId null
-    // and let the output below tell the user rather than using an unrelated thread.
+    // The new job may still be queued and have no threadId yet. Fall back to the
+    // previous thread that was preserved when the resume job was enqueued, so
+    // /codex:shift remains usable immediately after /codex:monitor --resume.
+    if (!threadId && chosenSession.prevCodexThreadId) {
+      threadId = chosenSession.prevCodexThreadId;
+    }
   } else {
     // Merge-all mode: search all sessions newest-first, then fall back to current session
     for (const s of allSessions) {

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -1341,7 +1341,7 @@ async function handleShift(argv) {
   let preSendOk = false;
   let targetThreadId = threadId;
   if (options.launch && threadId) {
-    process.stdout.write("Sending context to Codex...\n");
+    process.stderr.write("Sending context to Codex...\n");
     try {
       ensureCodexAvailable(cwd);
       const result = await runAppServerTurn(workspaceRoot, {
@@ -1352,9 +1352,9 @@ async function handleShift(argv) {
       });
       targetThreadId = result.threadId ?? threadId;
       preSendOk = true;
-      process.stdout.write("Context delivered. Opening terminal...\n");
+      process.stderr.write("Context delivered. Opening terminal...\n");
     } catch (err) {
-      process.stdout.write(`Note: could not pre-send context (${err.message}). Paste it manually.\n`);
+      process.stderr.write(`Note: could not pre-send context (${err.message}). Paste it manually.\n`);
     }
   }
 

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -1240,25 +1240,29 @@ async function handleShift(argv) {
 
   const contextBlock = formatCompactForPrompt(compact);
 
-  // Resolve Codex threadId: prefer the tracked job from the chosen shift session,
-  // then fall back to the current Claude session's most recent job.
+  // Resolve Codex threadId.
+  // When a specific session is selected, only use that session's tracked job —
+  // never fall back to another session's thread, which would send the wrong context.
+  // Cross-session fallback is only allowed in "merge all" mode (no --session flag).
   let threadId = null;
-  if (chosenSession?.codexJobId) {
-    const trackedJob = readStoredJob(workspaceRoot, chosenSession.codexJobId);
-    threadId = trackedJob?.threadId ?? null;
-  }
-  if (!threadId) {
-    // Fallback: look across all sessions' tracked jobs
+  if (chosenSession) {
+    if (chosenSession.codexJobId) {
+      const trackedJob = readStoredJob(workspaceRoot, chosenSession.codexJobId);
+      threadId = trackedJob?.threadId ?? null;
+    }
+    // If still null the monitor hasn't reported a thread yet — leave threadId null
+    // and let the output below tell the user rather than using an unrelated thread.
+  } else {
+    // Merge-all mode: search all sessions newest-first, then fall back to current session
     for (const s of allSessions) {
       if (!s.codexJobId) continue;
       const storedJob = readStoredJob(workspaceRoot, s.codexJobId);
       if (storedJob?.threadId) { threadId = storedJob.threadId; break; }
     }
-  }
-  if (!threadId) {
-    // Last resort: current Claude session filter
-    const jobs = filterJobsForCurrentClaudeSession(sortJobsNewestFirst(listJobs(workspaceRoot)));
-    threadId = jobs.find((job) => job.threadId)?.threadId ?? null;
+    if (!threadId) {
+      const jobs = filterJobsForCurrentClaudeSession(sortJobsNewestFirst(listJobs(workspaceRoot)));
+      threadId = jobs.find((job) => job.threadId)?.threadId ?? null;
+    }
   }
 
   // Create git-diff markdown file in project root

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
@@ -51,6 +51,17 @@ import {
   SESSION_ID_ENV
 } from "./lib/tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
+import {
+  compactShiftHistory,
+  formatCompactForPrompt,
+  getActiveShiftSessionId,
+  initShiftSession,
+  listShiftSessions,
+  mergeAllShiftSessions,
+  readShiftHistory,
+  readShiftCompact,
+  setShiftSessionCodexJobId
+} from "./lib/shift-history.mjs";
 import {
   renderNativeReviewResult,
   renderReviewResult,
@@ -465,7 +476,10 @@ async function executeTaskRun(request) {
   });
 
   let resumeThreadId = null;
-  if (request.resumeLast) {
+  if (request.resumeThreadId) {
+    // Explicit thread supplied (e.g. monitor resume reusing same Codex thread)
+    resumeThreadId = request.resumeThreadId;
+  } else if (request.resumeLast) {
     const latestThread = await resolveLatestTrackedTaskThread(workspaceRoot, {
       excludeJobId: request.jobId
     });
@@ -598,7 +612,7 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId, resumeThreadId = null }) {
   return {
     cwd,
     model,
@@ -606,7 +620,8 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     prompt,
     write,
     resumeLast,
-    jobId
+    jobId,
+    resumeThreadId
   };
 }
 
@@ -978,6 +993,431 @@ async function handleCancel(argv) {
   outputCommandResult(payload, renderCancelReport(nextJob), options.json);
 }
 
+async function handleMonitor(argv) {
+  const { options } = parseCommandInput(argv, {
+    valueOptions: ["model", "effort", "cwd", "resume-session"],
+    booleanOptions: ["json", "resume", "list-sessions"]
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+
+  // --list-sessions: just print existing sessions and exit, don't start anything
+  if (options["list-sessions"]) {
+    const sessions = listShiftSessions(workspaceRoot);
+    if (sessions.length === 0) {
+      const rendered = "No shift sessions found for this project.\n";
+      outputCommandResult({ sessions: [] }, rendered, options.json);
+      return;
+    }
+    const lines = sessions.map((s) =>
+      `${s.active ? "[active] " : "         "}${s.id}  ${s.startedAt.slice(0, 10)}  ${s.turnCount} turn${s.turnCount !== 1 ? "s" : ""}${s.resumed ? "  (resumed)" : ""}`
+    );
+    const rendered = [
+      "Shift sessions for this project:",
+      ...lines,
+      "",
+      `To resume a session:  /codex:monitor --resume-session <id>`,
+      `To resume the active: /codex:monitor --resume`,
+      `To start fresh:       /codex:monitor`,
+      ""
+    ].join("\n");
+    outputCommandResult({ sessions }, rendered, options.json);
+    return;
+  }
+
+  const model = normalizeRequestedModel(options.model);
+  const effort = normalizeReasoningEffort(options.effort);
+
+  ensureCodexAvailable(cwd);
+
+  // Resolve which session to use before initializing
+  let resolvedResumeSessionId = null;
+
+  if (options.resume || options["resume-session"]) {
+    const existing = listShiftSessions(workspaceRoot);
+    const rawPick = options["resume-session"] ?? null;
+
+    if (rawPick !== null) {
+      const asNumber = Number(rawPick);
+      if (Number.isInteger(asNumber) && asNumber >= 1 && asNumber <= existing.length) {
+        // User passed a list number like --resume-session 2
+        resolvedResumeSessionId = existing[asNumber - 1].id;
+      } else {
+        // User passed a full session ID
+        resolvedResumeSessionId = rawPick;
+      }
+    } else if (existing.length === 1) {
+      // --resume with exactly one session → auto-pick it
+      resolvedResumeSessionId = existing[0].id;
+    } else if (existing.length > 1) {
+      // --resume with multiple sessions → print numbered list with summaries, stop
+      const lines = existing.flatMap((s, i) => {
+        const badge = s.active ? " [active]" : "";
+        const meta = `${s.startedAt.slice(0, 10)}  ${s.turnCount} turn${s.turnCount !== 1 ? "s" : ""}`;
+        const header = `  ${i + 1}.${badge} ${meta}`;
+        const summary = s.lastSummary ? `       └─ ${s.lastSummary}` : null;
+        return summary ? [header, summary] : [header];
+      });
+      const rendered = [
+        "Multiple shift sessions found. Pick one:",
+        ...lines,
+        "",
+        "Re-run with:  /codex:monitor --resume-session <number>",
+        ""
+      ].join("\n");
+      outputCommandResult({ sessions: existing, needsPick: true }, rendered, options.json);
+      return;
+    }
+    // existing.length === 0 with --resume → fall through to fresh start
+  }
+
+  const isResumed = Boolean(resolvedResumeSessionId);
+  const shiftSessionId = initShiftSession(workspaceRoot, {
+    resume: isResumed,
+    sessionId: resolvedResumeSessionId
+  });
+
+  // When resuming, reuse the same Codex thread so `codex resume` doesn't
+  // accumulate a new entry every time the user runs /codex:monitor.
+  let prevCodexThreadId = null;
+  if (isResumed) {
+    const sessions = listShiftSessions(workspaceRoot);
+    const chosenMeta = sessions.find((s) => s.id === shiftSessionId);
+    if (chosenMeta?.codexJobId) {
+      const prevStoredJob = readStoredJob(workspaceRoot, chosenMeta.codexJobId);
+      prevCodexThreadId = prevStoredJob?.threadId ?? null;
+    }
+  }
+
+  const prompt =
+    "You are now monitoring a Claude Code session for this project. " +
+    "Explore the project structure, read key source files, review recent git commits, " +
+    "and understand what is currently being built. " +
+    "Build a complete mental model of the codebase. " +
+    "Do not make any changes. " +
+    "When /codex:shift is called you will receive a compacted summary of the Claude session " +
+    "and further instructions.";
+
+  const taskMetadata = { title: "Codex Monitor", summary: "Session monitor — building project context" };
+  const job = buildTaskJob(workspaceRoot, taskMetadata, false);
+  const request = buildTaskRequest({
+    cwd, model, effort, prompt, write: false, resumeLast: false, jobId: job.id,
+    resumeThreadId: prevCodexThreadId  // null for fresh, existing thread when resuming
+  });
+  const { payload } = enqueueBackgroundTask(cwd, job, request);
+
+  // Track the new job against this shift session so future resumes reuse the thread
+  setShiftSessionCodexJobId(workspaceRoot, shiftSessionId, job.id);
+
+  const modeLabel = isResumed
+    ? prevCodexThreadId
+      ? "Resuming previous shift session (continuing Codex thread)"
+      : "Resuming previous shift session (new Codex thread)"
+    : "Starting fresh shift session";
+  const rendered =
+    `Codex monitor started in the background as ${payload.jobId}.\n` +
+    `${modeLabel} (${shiftSessionId}).\n` +
+    `Codex is now building context for this project.\n` +
+    `Run /codex:shift when you are ready to hand off to Codex.\n`;
+
+  outputCommandResult({ ...payload, shiftSessionId, resumed: isResumed }, rendered, options.json);
+}
+
+function tryLaunchCodexTerminal(cwd, threadId, contextPrompt) {
+  // Try to copy context to clipboard (used when pre-send is unavailable)
+  let clipboardCopied = false;
+  if (contextPrompt) {
+    for (const { cmd, args } of [
+      { cmd: "xclip", args: ["-selection", "clipboard"] },
+      { cmd: "xsel", args: ["--clipboard", "--input"] },
+      { cmd: "pbcopy", args: [] }
+    ]) {
+      const which = spawnSync("which", [cmd], { encoding: "utf8" });
+      if (which.status !== 0) continue;
+      const proc = spawnSync(cmd, args, { input: contextPrompt, encoding: "utf8" });
+      if (proc.status === 0) { clipboardCopied = true; break; }
+    }
+  }
+
+  const codexCommand = `codex resume ${threadId}`;
+
+  // 1. tmux — new window inside the current tmux session.
+  //    When the IDE terminal runs inside tmux (common VS Code setup), this opens
+  //    a new tab inside the IDE rather than a separate system window.
+  if (process.env.TMUX) {
+    const res = spawnSync("tmux", ["new-window", "-n", "codex", codexCommand], { encoding: "utf8" });
+    if (res.status === 0) return { launched: true, terminal: "tmux", method: "new-window", clipboardCopied };
+  }
+
+  // 2. WezTerm — new tab via the WezTerm IPC CLI.
+  if (process.env.WEZTERM_UNIX_SOCKET || process.env.WEZTERM_PANE) {
+    const check = spawnSync("which", ["wezterm"], { encoding: "utf8" });
+    if (check.status === 0) {
+      const res = spawnSync("wezterm", ["cli", "spawn", "--", "bash", "-c", codexCommand], { encoding: "utf8" });
+      if (res.status === 0) return { launched: true, terminal: "wezterm", method: "cli spawn", clipboardCopied };
+    }
+  }
+
+  // 3. Zellij — new pane running the command.
+  if (process.env.ZELLIJ) {
+    const check = spawnSync("which", ["zellij"], { encoding: "utf8" });
+    if (check.status === 0) {
+      const res = spawnSync("zellij", ["run", "--name", "codex", "--", "bash", "-c", codexCommand], { encoding: "utf8" });
+      if (res.status === 0) return { launched: true, terminal: "zellij", method: "run", clipboardCopied };
+    }
+  }
+
+  // 4. System terminal emulators (fallback — opens outside the IDE).
+  for (const { name, args } of [
+    { name: "gnome-terminal", args: (c) => ["--", "bash", "-c", c] },
+    { name: "xterm", args: (c) => ["-e", c] },
+    { name: "konsole", args: (c) => ["-e", c] },
+    { name: "xfce4-terminal", args: (c) => ["-e", c] },
+    { name: "lxterminal", args: (c) => ["-e", c] },
+    { name: "alacritty", args: (c) => ["-e", "bash", "-c", c] },
+    { name: "kitty", args: (c) => ["bash", "-c", c] },
+    { name: "x-terminal-emulator", args: (c) => ["-e", c] }
+  ]) {
+    const which = spawnSync("which", [name], { encoding: "utf8" });
+    if (which.status !== 0) continue;
+    try {
+      const child = spawn(name, args(codexCommand), { cwd, detached: true, stdio: "ignore" });
+      child.unref();
+      return { launched: true, terminal: name, method: "system", clipboardCopied };
+    } catch {
+      // try next
+    }
+  }
+
+  return { launched: false, terminal: null, method: null, clipboardCopied };
+}
+
+async function handleShift(argv) {
+  const { options } = parseCommandInput(argv, {
+    valueOptions: ["cwd", "session"],
+    booleanOptions: ["json", "list-sessions", "launch"]
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+
+  // --list-sessions: informational only
+  if (options["list-sessions"]) {
+    const sessions = listShiftSessions(workspaceRoot);
+    const rendered = sessions.length === 0
+      ? "No shift sessions found. Run /codex:monitor to start one.\n"
+      : sessions.map((s) =>
+          `${s.active ? "* " : "  "}${s.id}  (${s.turnCount} turns, started ${s.startedAt.slice(0, 10)}${s.resumed ? ", resumed" : ""})`
+        ).join("\n") + "\n";
+    outputCommandResult({ sessions }, rendered, options.json);
+    return;
+  }
+
+  // Resolve which session(s) to use
+  const allSessions = listShiftSessions(workspaceRoot);
+  let compact = null;
+  let chosenSession = null;
+
+  if (options.session) {
+    const rawPick = String(options.session);
+    const asNumber = Number(rawPick);
+    let sessionId;
+    if (Number.isInteger(asNumber) && asNumber >= 1 && asNumber <= allSessions.length) {
+      sessionId = allSessions[asNumber - 1].id;
+    } else {
+      sessionId = rawPick;
+    }
+    chosenSession = allSessions.find((s) => s.id === sessionId) ?? null;
+    if (!chosenSession) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    compact = compactShiftHistory(workspaceRoot, sessionId);
+  } else {
+    // No specific session — merge all
+    compact = allSessions.length > 0 ? mergeAllShiftSessions(workspaceRoot) : null;
+  }
+
+  const contextBlock = formatCompactForPrompt(compact);
+
+  // Resolve Codex threadId: prefer the tracked job from the chosen shift session,
+  // then fall back to the current Claude session's most recent job.
+  let threadId = null;
+  if (chosenSession?.codexJobId) {
+    const trackedJob = readStoredJob(workspaceRoot, chosenSession.codexJobId);
+    threadId = trackedJob?.threadId ?? null;
+  }
+  if (!threadId) {
+    // Fallback: look across all sessions' tracked jobs
+    for (const s of allSessions) {
+      if (!s.codexJobId) continue;
+      const storedJob = readStoredJob(workspaceRoot, s.codexJobId);
+      if (storedJob?.threadId) { threadId = storedJob.threadId; break; }
+    }
+  }
+  if (!threadId) {
+    // Last resort: current Claude session filter
+    const jobs = filterJobsForCurrentClaudeSession(sortJobsNewestFirst(listJobs(workspaceRoot)));
+    threadId = jobs.find((job) => job.threadId)?.threadId ?? null;
+  }
+
+  // Create git-diff markdown file in project root
+  const now = new Date().toISOString().slice(0, 10);
+  const diffStat = spawnSync("git", ["diff", "--stat", "HEAD"], { cwd, encoding: "utf8" });
+  const diffFull = spawnSync("git", ["diff", "HEAD"], { cwd, encoding: "utf8" });
+  const logRecent = spawnSync("git", ["log", "--oneline", "-10"], { cwd, encoding: "utf8" });
+  const untrackedResult = spawnSync(
+    "git", ["ls-files", "--others", "--exclude-standard"], { cwd, encoding: "utf8" }
+  );
+  const untrackedFiles = (untrackedResult.stdout ?? "").trim().split("\n").filter(Boolean);
+
+  // Build untracked diff by running git diff --no-index /dev/null <file> for each
+  const untrackedDiffParts = [];
+  for (const file of untrackedFiles.slice(0, 20)) {
+    const fileDiff = spawnSync("git", ["diff", "--no-index", "/dev/null", file], { cwd, encoding: "utf8" });
+    if (fileDiff.stdout) untrackedDiffParts.push(fileDiff.stdout.trim());
+  }
+
+  const statBlock = [
+    (diffStat.stdout ?? "").trim() || "",
+    untrackedFiles.length > 0
+      ? `\nUntracked files:\n${untrackedFiles.map((f) => `  ${f}`).join("\n")}`
+      : ""
+  ].join("").trim() || "(no changes)";
+
+  const fullDiffBlock = [
+    (diffFull.stdout ?? "").trim(),
+    ...untrackedDiffParts
+  ].filter(Boolean).join("\n") || "(no diff)";
+
+  const mdLines = [
+    `# Codex Shift — ${now}`,
+    "",
+    "## Recent Commits",
+    "```",
+    (logRecent.stdout ?? "").trim() || "(none)",
+    "```",
+    "",
+    "## Changed Files",
+    "```",
+    statBlock,
+    "```",
+    "",
+    "## Full Diff",
+    "```diff",
+    fullDiffBlock,
+    "```"
+  ];
+
+  if (contextBlock) {
+    const sessionLabel = chosenSession
+      ? "## Claude Session Context"
+      : `## Claude Session Context (merged from ${allSessions.length} sessions)`;
+    mdLines.push("", sessionLabel, "", contextBlock);
+  }
+
+  const mdContent = mdLines.join("\n") + "\n";
+  const mdPath = path.join(cwd, `.codex-shift-${now}.md`);
+  fs.writeFileSync(mdPath, mdContent, "utf8");
+
+  // Build the initial Codex prompt
+  const contextSection = contextBlock
+    ? `\n\n${contextBlock}`
+    : "\n\n(No session history recorded yet — run /codex:monitor at the start of your next session.)";
+
+  const codexPrompt =
+    `Don't do anything with this query, just take context and follow my further instructions.\n` +
+    contextSection;
+
+  // When --launch is requested, pre-send the context to the Codex thread so it
+  // is already processed when the user opens the terminal. This avoids needing
+  // to paste anything manually.
+  let preSendOk = false;
+  let targetThreadId = threadId;
+  if (options.launch && threadId) {
+    process.stdout.write("Sending context to Codex...\n");
+    try {
+      ensureCodexAvailable(cwd);
+      const result = await runAppServerTurn(workspaceRoot, {
+        resumeThreadId: threadId,
+        prompt: codexPrompt,
+        sandbox: "read-only",
+        persistThread: true
+      });
+      targetThreadId = result.threadId ?? threadId;
+      preSendOk = true;
+      process.stdout.write("Context delivered. Opening terminal...\n");
+    } catch (err) {
+      process.stdout.write(`Note: could not pre-send context (${err.message}). Paste it manually.\n`);
+    }
+  }
+
+  // Launch terminal — pass contextPrompt only when pre-send failed (clipboard fallback)
+  let launchResult = null;
+  if (options.launch && targetThreadId) {
+    launchResult = tryLaunchCodexTerminal(cwd, targetThreadId, preSendOk ? null : codexPrompt);
+  }
+
+  const resumeLine = targetThreadId
+    ? `codex resume ${targetThreadId}`
+    : "(no Codex thread found — run /codex:monitor first or start a /codex:rescue)";
+
+  const sessionInfo = chosenSession
+    ? `${chosenSession.id} (${chosenSession.turnCount} turn${chosenSession.turnCount !== 1 ? "s" : ""})`
+    : `${allSessions.length} merged sessions`;
+
+  let rendered;
+  if (launchResult?.launched) {
+    const inIde = launchResult.terminal === "tmux" || launchResult.terminal === "wezterm" || launchResult.terminal === "zellij";
+    const where = inIde ? "IDE terminal" : "system terminal";
+    const statusLine = preSendOk
+      ? "Context already loaded — Codex is ready for your instructions."
+      : launchResult.clipboardCopied
+        ? "Context copied to clipboard — paste it as your first Codex message."
+        : `Paste as your first Codex message:\n---\n${codexPrompt}\n---`;
+    rendered = [
+      "=== Codex Shift Ready ===",
+      "",
+      `Changes saved to: ${mdPath}`,
+      `Context: ${sessionInfo}`,
+      "",
+      `Codex terminal opened in ${where} (${launchResult.terminal}).`,
+      statusLine,
+      ""
+    ].join("\n");
+  } else {
+    const pasteBlock = preSendOk
+      ? "(context already pre-loaded — just resume and start giving instructions)"
+      : `Then send this as your first message to Codex:\n---\n${codexPrompt}\n---`;
+    rendered = [
+      "=== Codex Shift Ready ===",
+      "",
+      `Changes saved to: ${mdPath}`,
+      `Context: ${sessionInfo}`,
+      "",
+      "Run this in a new terminal:",
+      `  ${resumeLine}`,
+      "",
+      pasteBlock,
+      ""
+    ].join("\n");
+  }
+
+  const payload = {
+    threadId: targetThreadId,
+    mdPath,
+    sessionCount: allSessions.length,
+    chosenSessionId: chosenSession?.id ?? null,
+    compact,
+    resumeCommand: resumeLine,
+    codexPrompt,
+    preSendOk,
+    launch: launchResult
+  };
+
+  outputCommandResult(payload, rendered, options.json);
+}
+
 async function main() {
   const [subcommand, ...argv] = process.argv.slice(2);
   if (!subcommand || subcommand === "help" || subcommand === "--help") {
@@ -1014,6 +1454,12 @@ async function main() {
       break;
     case "cancel":
       await handleCancel(argv);
+      break;
+    case "monitor":
+      await handleMonitor(argv);
+      break;
+    case "shift":
+      await handleShift(argv);
       break;
     default:
       throw new Error(`Unknown subcommand: ${subcommand}`);

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -1276,9 +1276,10 @@ async function handleShift(argv) {
     .filter(Boolean)
     .filter((f) => !/^\.codex-shift-.*\.md$/.test(f));
 
-  // Build untracked diff by running git diff --no-index /dev/null <file> for each
+  // Build untracked diff by running git diff --no-index /dev/null <file> for each.
+  // All files are included; no silent truncation.
   const untrackedDiffParts = [];
-  for (const file of untrackedFiles.slice(0, 20)) {
+  for (const file of untrackedFiles) {
     const fileDiff = spawnSync("git", ["diff", "--no-index", "/dev/null", file], { cwd, encoding: "utf8" });
     if (fileDiff.stdout) untrackedDiffParts.push(fileDiff.stdout.trim());
   }

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
@@ -51,6 +51,17 @@ import {
   SESSION_ID_ENV
 } from "./lib/tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
+import {
+  compactShiftHistory,
+  formatCompactForPrompt,
+  getActiveShiftSessionId,
+  initShiftSession,
+  listShiftSessions,
+  mergeAllShiftSessions,
+  readShiftHistory,
+  readShiftCompact,
+  setShiftSessionCodexJobId
+} from "./lib/shift-history.mjs";
 import {
   renderNativeReviewResult,
   renderReviewResult,
@@ -465,7 +476,10 @@ async function executeTaskRun(request) {
   });
 
   let resumeThreadId = null;
-  if (request.resumeLast) {
+  if (request.resumeThreadId) {
+    // Explicit thread supplied (e.g. monitor resume reusing same Codex thread)
+    resumeThreadId = request.resumeThreadId;
+  } else if (request.resumeLast) {
     const latestThread = await resolveLatestTrackedTaskThread(workspaceRoot, {
       excludeJobId: request.jobId
     });
@@ -598,7 +612,7 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId, resumeThreadId = null }) {
   return {
     cwd,
     model,
@@ -606,7 +620,8 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     prompt,
     write,
     resumeLast,
-    jobId
+    jobId,
+    resumeThreadId
   };
 }
 
@@ -978,6 +993,408 @@ async function handleCancel(argv) {
   outputCommandResult(payload, renderCancelReport(nextJob), options.json);
 }
 
+async function handleMonitor(argv) {
+  const { options } = parseCommandInput(argv, {
+    valueOptions: ["model", "effort", "cwd", "resume-session"],
+    booleanOptions: ["json", "resume", "list-sessions"]
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+
+  // --list-sessions: just print existing sessions and exit, don't start anything
+  if (options["list-sessions"]) {
+    const sessions = listShiftSessions(workspaceRoot);
+    if (sessions.length === 0) {
+      const rendered = "No shift sessions found for this project.\n";
+      outputCommandResult({ sessions: [] }, rendered, options.json);
+      return;
+    }
+    const lines = sessions.map((s) =>
+      `${s.active ? "[active] " : "         "}${s.id}  ${s.startedAt.slice(0, 10)}  ${s.turnCount} turn${s.turnCount !== 1 ? "s" : ""}${s.resumed ? "  (resumed)" : ""}`
+    );
+    const rendered = [
+      "Shift sessions for this project:",
+      ...lines,
+      "",
+      `To resume a session:  /codex:monitor --resume-session <id>`,
+      `To resume the active: /codex:monitor --resume`,
+      `To start fresh:       /codex:monitor`,
+      ""
+    ].join("\n");
+    outputCommandResult({ sessions }, rendered, options.json);
+    return;
+  }
+
+  const model = normalizeRequestedModel(options.model);
+  const effort = normalizeReasoningEffort(options.effort);
+
+  ensureCodexAvailable(cwd);
+
+  // Resolve which session to use before initializing
+  let resolvedResumeSessionId = null;
+
+  if (options.resume || options["resume-session"]) {
+    const existing = listShiftSessions(workspaceRoot);
+    const rawPick = options["resume-session"] ?? null;
+
+    if (rawPick !== null) {
+      const asNumber = Number(rawPick);
+      if (Number.isInteger(asNumber) && asNumber >= 1 && asNumber <= existing.length) {
+        // User passed a list number like --resume-session 2
+        resolvedResumeSessionId = existing[asNumber - 1].id;
+      } else {
+        // User passed a full session ID
+        resolvedResumeSessionId = rawPick;
+      }
+    } else if (existing.length === 1) {
+      // --resume with exactly one session → auto-pick it
+      resolvedResumeSessionId = existing[0].id;
+    } else if (existing.length > 1) {
+      // --resume with multiple sessions → print numbered list with summaries, stop
+      const lines = existing.flatMap((s, i) => {
+        const badge = s.active ? " [active]" : "";
+        const meta = `${s.startedAt.slice(0, 10)}  ${s.turnCount} turn${s.turnCount !== 1 ? "s" : ""}`;
+        const header = `  ${i + 1}.${badge} ${meta}`;
+        const summary = s.lastSummary ? `       └─ ${s.lastSummary}` : null;
+        return summary ? [header, summary] : [header];
+      });
+      const rendered = [
+        "Multiple shift sessions found. Pick one:",
+        ...lines,
+        "",
+        "Re-run with:  /codex:monitor --resume-session <number>",
+        ""
+      ].join("\n");
+      outputCommandResult({ sessions: existing, needsPick: true }, rendered, options.json);
+      return;
+    }
+    // existing.length === 0 with --resume → fall through to fresh start
+  }
+
+  const isResumed = Boolean(resolvedResumeSessionId);
+  const shiftSessionId = initShiftSession(workspaceRoot, {
+    resume: isResumed,
+    sessionId: resolvedResumeSessionId
+  });
+
+  // When resuming, reuse the same Codex thread so `codex resume` doesn't
+  // accumulate a new entry every time the user runs /codex:monitor.
+  let prevCodexThreadId = null;
+  if (isResumed) {
+    const sessions = listShiftSessions(workspaceRoot);
+    const chosenMeta = sessions.find((s) => s.id === shiftSessionId);
+    if (chosenMeta?.codexJobId) {
+      const prevStoredJob = readStoredJob(workspaceRoot, chosenMeta.codexJobId);
+      prevCodexThreadId = prevStoredJob?.threadId ?? null;
+    }
+  }
+
+  const prompt =
+    "You are now monitoring a Claude Code session for this project. " +
+    "Explore the project structure, read key source files, review recent git commits, " +
+    "and understand what is currently being built. " +
+    "Build a complete mental model of the codebase. " +
+    "Do not make any changes. " +
+    "When /codex:shift is called you will receive a compacted summary of the Claude session " +
+    "and further instructions.";
+
+  const taskMetadata = { title: "Codex Monitor", summary: "Session monitor — building project context" };
+  const job = buildTaskJob(workspaceRoot, taskMetadata, false);
+  const request = buildTaskRequest({
+    cwd, model, effort, prompt, write: false, resumeLast: false, jobId: job.id,
+    resumeThreadId: prevCodexThreadId  // null for fresh, existing thread when resuming
+  });
+  const { payload } = enqueueBackgroundTask(cwd, job, request);
+
+  // Track the new job against this shift session so future resumes reuse the thread
+  setShiftSessionCodexJobId(workspaceRoot, shiftSessionId, job.id);
+
+  const modeLabel = isResumed
+    ? prevCodexThreadId
+      ? "Resuming previous shift session (continuing Codex thread)"
+      : "Resuming previous shift session (new Codex thread)"
+    : "Starting fresh shift session";
+  const rendered =
+    `Codex monitor started in the background as ${payload.jobId}.\n` +
+    `${modeLabel} (${shiftSessionId}).\n` +
+    `Codex is now building context for this project.\n` +
+    `Run /codex:shift when you are ready to hand off to Codex.\n`;
+
+  outputCommandResult({ ...payload, shiftSessionId, resumed: isResumed }, rendered, options.json);
+}
+
+function tryLaunchCodexTerminal(cwd, threadId, contextPrompt) {
+  // Try to copy context to clipboard (used when pre-send is unavailable)
+  let clipboardCopied = false;
+  if (contextPrompt) {
+    for (const { cmd, args } of [
+      { cmd: "xclip", args: ["-selection", "clipboard"] },
+      { cmd: "xsel", args: ["--clipboard", "--input"] },
+      { cmd: "pbcopy", args: [] }
+    ]) {
+      const which = spawnSync("which", [cmd], { encoding: "utf8" });
+      if (which.status !== 0) continue;
+      const proc = spawnSync(cmd, args, { input: contextPrompt, encoding: "utf8" });
+      if (proc.status === 0) { clipboardCopied = true; break; }
+    }
+  }
+
+  const codexCommand = `codex resume ${threadId}`;
+
+  // 1. tmux — new window inside the current tmux session.
+  //    When the IDE terminal runs inside tmux (common VS Code setup), this opens
+  //    a new tab inside the IDE rather than a separate system window.
+  if (process.env.TMUX) {
+    const res = spawnSync("tmux", ["new-window", "-n", "codex", codexCommand], { encoding: "utf8" });
+    if (res.status === 0) return { launched: true, terminal: "tmux", method: "new-window", clipboardCopied };
+  }
+
+  // 2. WezTerm — new tab via the WezTerm IPC CLI.
+  if (process.env.WEZTERM_UNIX_SOCKET || process.env.WEZTERM_PANE) {
+    const check = spawnSync("which", ["wezterm"], { encoding: "utf8" });
+    if (check.status === 0) {
+      const res = spawnSync("wezterm", ["cli", "spawn", "--", "bash", "-c", codexCommand], { encoding: "utf8" });
+      if (res.status === 0) return { launched: true, terminal: "wezterm", method: "cli spawn", clipboardCopied };
+    }
+  }
+
+  // 3. Zellij — new pane running the command.
+  if (process.env.ZELLIJ) {
+    const check = spawnSync("which", ["zellij"], { encoding: "utf8" });
+    if (check.status === 0) {
+      const res = spawnSync("zellij", ["run", "--name", "codex", "--", "bash", "-c", codexCommand], { encoding: "utf8" });
+      if (res.status === 0) return { launched: true, terminal: "zellij", method: "run", clipboardCopied };
+    }
+  }
+
+  // 4. System terminal emulators (fallback — opens outside the IDE).
+  for (const { name, args } of [
+    { name: "gnome-terminal", args: (c) => ["--", "bash", "-c", c] },
+    { name: "xterm", args: (c) => ["-e", c] },
+    { name: "konsole", args: (c) => ["-e", c] },
+    { name: "xfce4-terminal", args: (c) => ["-e", c] },
+    { name: "lxterminal", args: (c) => ["-e", c] },
+    { name: "alacritty", args: (c) => ["-e", "bash", "-c", c] },
+    { name: "kitty", args: (c) => ["bash", "-c", c] },
+    { name: "x-terminal-emulator", args: (c) => ["-e", c] }
+  ]) {
+    const which = spawnSync("which", [name], { encoding: "utf8" });
+    if (which.status !== 0) continue;
+    try {
+      const child = spawn(name, args(codexCommand), { cwd, detached: true, stdio: "ignore" });
+      child.unref();
+      return { launched: true, terminal: name, method: "system", clipboardCopied };
+    } catch {
+      // try next
+    }
+  }
+
+  return { launched: false, terminal: null, method: null, clipboardCopied };
+}
+
+async function handleShift(argv) {
+  const { options } = parseCommandInput(argv, {
+    valueOptions: ["cwd", "session"],
+    booleanOptions: ["json", "list-sessions", "launch"]
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+
+  // --list-sessions: informational only
+  if (options["list-sessions"]) {
+    const sessions = listShiftSessions(workspaceRoot);
+    const rendered = sessions.length === 0
+      ? "No shift sessions found. Run /codex:monitor to start one.\n"
+      : sessions.map((s) =>
+          `${s.active ? "* " : "  "}${s.id}  (${s.turnCount} turns, started ${s.startedAt.slice(0, 10)}${s.resumed ? ", resumed" : ""})`
+        ).join("\n") + "\n";
+    outputCommandResult({ sessions }, rendered, options.json);
+    return;
+  }
+
+  // Resolve which session(s) to use
+  const allSessions = listShiftSessions(workspaceRoot);
+  let compact = null;
+  let chosenSession = null;
+
+  if (options.session) {
+    const rawPick = String(options.session);
+    const asNumber = Number(rawPick);
+    let sessionId;
+    if (Number.isInteger(asNumber) && asNumber >= 1 && asNumber <= allSessions.length) {
+      sessionId = allSessions[asNumber - 1].id;
+    } else {
+      sessionId = rawPick;
+    }
+    chosenSession = allSessions.find((s) => s.id === sessionId) ?? null;
+    if (!chosenSession) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    compact = compactShiftHistory(workspaceRoot, sessionId);
+  } else {
+    // No specific session — merge all
+    compact = allSessions.length > 0 ? mergeAllShiftSessions(workspaceRoot) : null;
+  }
+
+  const contextBlock = formatCompactForPrompt(compact);
+
+  // Resolve Codex threadId: prefer the tracked job from the chosen shift session,
+  // then fall back to the current Claude session's most recent job.
+  let threadId = null;
+  if (chosenSession?.codexJobId) {
+    const trackedJob = readStoredJob(workspaceRoot, chosenSession.codexJobId);
+    threadId = trackedJob?.threadId ?? null;
+  }
+  if (!threadId) {
+    // Fallback: look across all sessions' tracked jobs
+    for (const s of allSessions) {
+      if (!s.codexJobId) continue;
+      const storedJob = readStoredJob(workspaceRoot, s.codexJobId);
+      if (storedJob?.threadId) { threadId = storedJob.threadId; break; }
+    }
+  }
+  if (!threadId) {
+    // Last resort: current Claude session filter
+    const jobs = filterJobsForCurrentClaudeSession(sortJobsNewestFirst(listJobs(workspaceRoot)));
+    threadId = jobs.find((job) => job.threadId)?.threadId ?? null;
+  }
+
+  // Create git-diff markdown file in project root
+  const now = new Date().toISOString().slice(0, 10);
+  const diffStat = spawnSync("git", ["diff", "--stat", "HEAD"], { cwd, encoding: "utf8" });
+  const diffFull = spawnSync("git", ["diff", "HEAD"], { cwd, encoding: "utf8" });
+  const logRecent = spawnSync("git", ["log", "--oneline", "-10"], { cwd, encoding: "utf8" });
+
+  const mdLines = [
+    `# Codex Shift — ${now}`,
+    "",
+    "## Recent Commits",
+    "```",
+    (logRecent.stdout ?? "").trim() || "(none)",
+    "```",
+    "",
+    "## Changed Files",
+    "```",
+    (diffStat.stdout ?? "").trim() || "(no changes)",
+    "```",
+    "",
+    "## Full Diff",
+    "```diff",
+    (diffFull.stdout ?? "").trim() || "(no diff)",
+    "```"
+  ];
+
+  if (contextBlock) {
+    const sessionLabel = chosenSession
+      ? "## Claude Session Context"
+      : `## Claude Session Context (merged from ${allSessions.length} sessions)`;
+    mdLines.push("", sessionLabel, "", contextBlock);
+  }
+
+  const mdContent = mdLines.join("\n") + "\n";
+  const mdPath = path.join(cwd, `.codex-shift-${now}.md`);
+  fs.writeFileSync(mdPath, mdContent, "utf8");
+
+  // Build the initial Codex prompt
+  const contextSection = contextBlock
+    ? `\n\n${contextBlock}`
+    : "\n\n(No session history recorded yet — run /codex:monitor at the start of your next session.)";
+
+  const codexPrompt =
+    `Don't do anything with this query, just take context and follow my further instructions.\n` +
+    contextSection;
+
+  // When --launch is requested, pre-send the context to the Codex thread so it
+  // is already processed when the user opens the terminal. This avoids needing
+  // to paste anything manually.
+  let preSendOk = false;
+  let targetThreadId = threadId;
+  if (options.launch && threadId) {
+    process.stdout.write("Sending context to Codex...\n");
+    try {
+      ensureCodexAvailable(cwd);
+      const result = await runAppServerTurn(workspaceRoot, {
+        resumeThreadId: threadId,
+        prompt: codexPrompt,
+        sandbox: "read-only",
+        persistThread: true
+      });
+      targetThreadId = result.threadId ?? threadId;
+      preSendOk = true;
+      process.stdout.write("Context delivered. Opening terminal...\n");
+    } catch (err) {
+      process.stdout.write(`Note: could not pre-send context (${err.message}). Paste it manually.\n`);
+    }
+  }
+
+  // Launch terminal — pass contextPrompt only when pre-send failed (clipboard fallback)
+  let launchResult = null;
+  if (options.launch && targetThreadId) {
+    launchResult = tryLaunchCodexTerminal(cwd, targetThreadId, preSendOk ? null : codexPrompt);
+  }
+
+  const resumeLine = targetThreadId
+    ? `codex resume ${targetThreadId}`
+    : "(no Codex thread found — run /codex:monitor first or start a /codex:rescue)";
+
+  const sessionInfo = chosenSession
+    ? `${chosenSession.id} (${chosenSession.turnCount} turn${chosenSession.turnCount !== 1 ? "s" : ""})`
+    : `${allSessions.length} merged sessions`;
+
+  let rendered;
+  if (launchResult?.launched) {
+    const inIde = launchResult.terminal === "tmux" || launchResult.terminal === "wezterm" || launchResult.terminal === "zellij";
+    const where = inIde ? "IDE terminal" : "system terminal";
+    const statusLine = preSendOk
+      ? "Context already loaded — Codex is ready for your instructions."
+      : launchResult.clipboardCopied
+        ? "Context copied to clipboard — paste it as your first Codex message."
+        : `Paste as your first Codex message:\n---\n${codexPrompt}\n---`;
+    rendered = [
+      "=== Codex Shift Ready ===",
+      "",
+      `Changes saved to: ${mdPath}`,
+      `Context: ${sessionInfo}`,
+      "",
+      `Codex terminal opened in ${where} (${launchResult.terminal}).`,
+      statusLine,
+      ""
+    ].join("\n");
+  } else {
+    const pasteBlock = preSendOk
+      ? "(context already pre-loaded — just resume and start giving instructions)"
+      : `Then send this as your first message to Codex:\n---\n${codexPrompt}\n---`;
+    rendered = [
+      "=== Codex Shift Ready ===",
+      "",
+      `Changes saved to: ${mdPath}`,
+      `Context: ${sessionInfo}`,
+      "",
+      "Run this in a new terminal:",
+      `  ${resumeLine}`,
+      "",
+      pasteBlock,
+      ""
+    ].join("\n");
+  }
+
+  const payload = {
+    threadId: targetThreadId,
+    mdPath,
+    sessionCount: allSessions.length,
+    chosenSessionId: chosenSession?.id ?? null,
+    compact,
+    resumeCommand: resumeLine,
+    codexPrompt,
+    preSendOk,
+    launch: launchResult
+  };
+
+  outputCommandResult(payload, rendered, options.json);
+}
+
 async function main() {
   const [subcommand, ...argv] = process.argv.slice(2);
   if (!subcommand || subcommand === "help" || subcommand === "--help") {
@@ -1014,6 +1431,12 @@ async function main() {
       break;
     case "cancel":
       await handleCancel(argv);
+      break;
+    case "monitor":
+      await handleMonitor(argv);
+      break;
+    case "shift":
+      await handleShift(argv);
       break;
     default:
       throw new Error(`Unknown subcommand: ${subcommand}`);

--- a/plugins/codex/scripts/lib/shift-history.mjs
+++ b/plugins/codex/scripts/lib/shift-history.mjs
@@ -128,6 +128,31 @@ export function setShiftSessionCodexJobId(workspaceRoot, shiftSessionId, codexJo
 }
 
 /**
+ * Record which Claude session_id started (or resumed) a shift session.
+ * The Stop hook uses this to skip appending turns from unrelated Claude sessions.
+ */
+export function setShiftSessionClaudeId(workspaceRoot, shiftSessionId, claudeSessionId) {
+  if (!claudeSessionId) return;
+  const existing = readShiftActive(workspaceRoot);
+  if (!existing) return;
+  const updatedSessions = (existing.sessions ?? []).map((s) =>
+    s.id === shiftSessionId ? { ...s, claudeSessionId } : s
+  );
+  writeShiftActive(workspaceRoot, { ...existing, sessions: updatedSessions });
+}
+
+/**
+ * Return the Claude session_id stored for the currently active shift session,
+ * or null if none was recorded (pre-existing sessions or session ID unavailable).
+ */
+export function getActiveShiftClaudeSessionId(workspaceRoot) {
+  const active = readShiftActive(workspaceRoot);
+  if (!active?.activeShiftSessionId) return null;
+  const session = (active.sessions ?? []).find((s) => s.id === active.activeShiftSessionId);
+  return session?.claudeSessionId ?? null;
+}
+
+/**
  * List all known shift sessions for this workspace, newest first.
  * Includes turnCount derived from the JSONL file.
  */

--- a/plugins/codex/scripts/lib/shift-history.mjs
+++ b/plugins/codex/scripts/lib/shift-history.mjs
@@ -1,0 +1,369 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { ensureStateDir, resolveStateDir } from "./state.mjs";
+
+const SHIFT_ACTIVE_FILE = "shift-active.json";
+const MAX_HISTORY_ENTRIES = 200;
+const ASSISTANT_SUMMARY_LENGTH = 300;
+const COMPACT_RECENT_TURNS = 8;
+
+// ─── Path helpers ────────────────────────────────────────────────────────────
+
+export function resolveShiftActiveFile(workspaceRoot) {
+  return path.join(resolveStateDir(workspaceRoot), SHIFT_ACTIVE_FILE);
+}
+
+export function resolveShiftHistoryFile(workspaceRoot, shiftSessionId) {
+  return path.join(resolveStateDir(workspaceRoot), `${shiftSessionId}.jsonl`);
+}
+
+export function resolveShiftCompactFile(workspaceRoot, shiftSessionId) {
+  return path.join(resolveStateDir(workspaceRoot), `${shiftSessionId}-compact.json`);
+}
+
+// ─── Active session ──────────────────────────────────────────────────────────
+
+export function readShiftActive(workspaceRoot) {
+  const file = resolveShiftActiveFile(workspaceRoot);
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function writeShiftActive(workspaceRoot, data) {
+  ensureStateDir(workspaceRoot);
+  fs.writeFileSync(
+    resolveShiftActiveFile(workspaceRoot),
+    `${JSON.stringify(data, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+function generateShiftSessionId() {
+  const random = Math.random().toString(36).slice(2, 8);
+  return `shift-${Date.now().toString(36)}-${random}`;
+}
+
+/**
+ * Initialize or resume a shift session.
+ *
+ * - resume=false (default): generate a new shiftSessionId, write it as active,
+ *   add it to the sessions list. Previous sessions are kept on disk.
+ * - resume=true, sessionId=null: resume the currently active shiftSessionId.
+ *   If none exists, behaves the same as resume=false.
+ * - resume=true, sessionId="shift-xxx": set the given session as active and
+ *   resume it. Use this when the user picks a specific past session.
+ *
+ * Returns the active shiftSessionId.
+ */
+export function initShiftSession(workspaceRoot, options = {}) {
+  const existing = readShiftActive(workspaceRoot);
+  const now = new Date().toISOString();
+
+  if (options.resume) {
+    const targetId = options.sessionId ?? existing?.activeShiftSessionId ?? null;
+
+    if (targetId) {
+      // Promote the chosen session to active (it may already be active)
+      const prevSessions = existing?.sessions ?? [];
+      const sessionMeta = prevSessions.find((s) => s.id === targetId);
+      const updatedSessions = sessionMeta
+        ? prevSessions.map((s) =>
+            s.id === targetId ? { ...s, resumed: true, resumedAt: now } : s
+          )
+        : [{ id: targetId, startedAt: now, resumed: true, resumedAt: now }, ...prevSessions];
+
+      writeShiftActive(workspaceRoot, {
+        ...(existing ?? {}),
+        activeShiftSessionId: targetId,
+        resumed: true,
+        resumedAt: now,
+        sessions: updatedSessions
+      });
+      return targetId;
+    }
+    // No existing session to resume — fall through to fresh
+  }
+
+  // Fresh session
+  const id = generateShiftSessionId();
+  const prevSessions = existing?.sessions ?? [];
+
+  writeShiftActive(workspaceRoot, {
+    activeShiftSessionId: id,
+    startedAt: now,
+    resumed: false,
+    sessions: [
+      { id, startedAt: now, resumed: false },
+      ...prevSessions
+    ]
+  });
+
+  return id;
+}
+
+/**
+ * Get the currently active shiftSessionId without modifying anything.
+ * Returns null if no session has been initialized.
+ */
+export function getActiveShiftSessionId(workspaceRoot) {
+  return readShiftActive(workspaceRoot)?.activeShiftSessionId ?? null;
+}
+
+/**
+ * Attach a Codex job ID to a shift session so that resume can reuse the same
+ * Codex thread instead of spawning a new one each time.
+ */
+export function setShiftSessionCodexJobId(workspaceRoot, shiftSessionId, codexJobId) {
+  const existing = readShiftActive(workspaceRoot);
+  if (!existing) return;
+  const updatedSessions = (existing.sessions ?? []).map((s) =>
+    s.id === shiftSessionId ? { ...s, codexJobId } : s
+  );
+  writeShiftActive(workspaceRoot, { ...existing, sessions: updatedSessions });
+}
+
+/**
+ * List all known shift sessions for this workspace, newest first.
+ * Includes turnCount derived from the JSONL file.
+ */
+export function listShiftSessions(workspaceRoot) {
+  const active = readShiftActive(workspaceRoot);
+  if (!active?.sessions) return [];
+
+  return active.sessions.map((s) => {
+    const historyFile = resolveShiftHistoryFile(workspaceRoot, s.id);
+    let turnCount = 0;
+    let lastSummary = null;
+
+    if (fs.existsSync(historyFile)) {
+      try {
+        const lines = fs.readFileSync(historyFile, "utf8").split("\n").filter(Boolean);
+        turnCount = lines.length;
+        // Get the last entry's assistantSummary as a one-line preview
+        if (lines.length > 0) {
+          const last = JSON.parse(lines[lines.length - 1]);
+          const raw = String(last.assistantSummary ?? "").trim();
+          // Trim to first sentence or 80 chars, whichever is shorter
+          const firstSentence = raw.split(/[.!?\n]/)[0].trim();
+          lastSummary = firstSentence.length > 80
+            ? firstSentence.slice(0, 77) + "..."
+            : firstSentence || null;
+        }
+      } catch {
+        turnCount = 0;
+      }
+    }
+
+    return {
+      ...s,
+      turnCount,
+      lastSummary,
+      active: s.id === active.activeShiftSessionId
+    };
+  });
+}
+
+// ─── History JSONL ────────────────────────────────────────────────────────────
+
+/**
+ * Append one turn entry to the session's JSONL history log.
+ */
+export function appendShiftEntry(workspaceRoot, shiftSessionId, entry) {
+  ensureStateDir(workspaceRoot);
+  const file = resolveShiftHistoryFile(workspaceRoot, shiftSessionId);
+  fs.appendFileSync(file, `${JSON.stringify(entry)}\n`, "utf8");
+}
+
+/**
+ * Read all entries from a session's JSONL log.
+ */
+export function readShiftHistory(workspaceRoot, shiftSessionId) {
+  const file = resolveShiftHistoryFile(workspaceRoot, shiftSessionId);
+  if (!fs.existsSync(file)) return [];
+  const lines = fs.readFileSync(file, "utf8").split("\n").filter(Boolean);
+  const entries = [];
+  for (const line of lines) {
+    try {
+      entries.push(JSON.parse(line));
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return entries;
+}
+
+// ─── Compact ─────────────────────────────────────────────────────────────────
+
+export function readShiftCompact(workspaceRoot, shiftSessionId) {
+  const file = resolveShiftCompactFile(workspaceRoot, shiftSessionId);
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function writeShiftCompact(workspaceRoot, shiftSessionId, compact) {
+  ensureStateDir(workspaceRoot);
+  fs.writeFileSync(
+    resolveShiftCompactFile(workspaceRoot, shiftSessionId),
+    `${JSON.stringify(compact, null, 2)}\n`,
+    "utf8"
+  );
+}
+
+/**
+ * Script-based compaction — no LLM needed.
+ * Merges all JSONL entries for the session into a compact summary object.
+ */
+export function compactShiftHistory(workspaceRoot, shiftSessionId) {
+  const allEntries = readShiftHistory(workspaceRoot, shiftSessionId);
+  if (allEntries.length === 0) return null;
+
+  const existing = readShiftCompact(workspaceRoot, shiftSessionId);
+
+  const touchedFilesSet = new Set(existing?.touchedFiles ?? []);
+  for (const entry of allEntries) {
+    for (const f of entry.touchedFiles ?? []) {
+      touchedFilesSet.add(f);
+    }
+  }
+
+  const lastEntry = allEntries[allEntries.length - 1];
+  const compact = {
+    version: 1,
+    shiftSessionId,
+    compactedAt: new Date().toISOString(),
+    compactedThrough: lastEntry.turnIndex ?? allEntries.length - 1,
+    goal: existing?.goal ?? "",
+    decisions: existing?.decisions ?? [],
+    openQuestions: existing?.openQuestions ?? [],
+    touchedFiles: [...touchedFilesSet].sort(),
+    rawTurnCount: allEntries.length,
+    recentTurns: allEntries.slice(-COMPACT_RECENT_TURNS).map((e) => ({
+      turnIndex: e.turnIndex,
+      ts: e.ts,
+      summary: e.assistantSummary
+    }))
+  };
+
+  writeShiftCompact(workspaceRoot, shiftSessionId, compact);
+
+  // Prune JSONL if it gets too large
+  if (allEntries.length > MAX_HISTORY_ENTRIES) {
+    const keep = allEntries.slice(-MAX_HISTORY_ENTRIES);
+    fs.writeFileSync(
+      resolveShiftHistoryFile(workspaceRoot, shiftSessionId),
+      keep.map((e) => JSON.stringify(e)).join("\n") + "\n",
+      "utf8"
+    );
+  }
+
+  return compact;
+}
+
+/**
+ * Merge ALL sessions for this workspace into one combined compact.
+ * Combines touched files, decisions, open questions, and recent turns
+ * across every session, newest entries last.
+ */
+export function mergeAllShiftSessions(workspaceRoot) {
+  const sessions = listShiftSessions(workspaceRoot);
+  if (sessions.length === 0) return null;
+
+  const touchedFilesSet = new Set();
+  const allDecisions = [];
+  const allOpenQuestions = [];
+  const allTurns = [];
+
+  // Oldest session first so newer turns appear last
+  for (const session of [...sessions].reverse()) {
+    const compact = compactShiftHistory(workspaceRoot, session.id);
+    if (!compact) continue;
+
+    for (const f of compact.touchedFiles ?? []) touchedFilesSet.add(f);
+    for (const d of compact.decisions ?? []) {
+      if (!allDecisions.includes(d)) allDecisions.push(d);
+    }
+    for (const q of compact.openQuestions ?? []) {
+      if (!allOpenQuestions.includes(q)) allOpenQuestions.push(q);
+    }
+    for (const t of compact.recentTurns ?? []) {
+      allTurns.push({ ...t, sessionId: session.id, sessionDate: session.startedAt.slice(0, 10) });
+    }
+  }
+
+  return {
+    version: 1,
+    mergedAt: new Date().toISOString(),
+    sessionCount: sessions.length,
+    touchedFiles: [...touchedFilesSet].sort(),
+    decisions: allDecisions,
+    openQuestions: allOpenQuestions,
+    // Keep the most recent COMPACT_RECENT_TURNS * sessions worth
+    recentTurns: allTurns.slice(-COMPACT_RECENT_TURNS * 2)
+  };
+}
+
+// ─── Prompt formatting ───────────────────────────────────────────────────────
+
+/**
+ * Format a compact object into the context block prepended to the Codex prompt.
+ */
+export function formatCompactForPrompt(compact, recentHistory = []) {
+  if (!compact && recentHistory.length === 0) return null;
+
+  const lines = ["=== Claude Session Context ==="];
+
+  if (compact?.goal) {
+    lines.push(`Goal: ${compact.goal}`);
+  }
+
+  if (compact?.decisions?.length > 0) {
+    lines.push("Decisions made:");
+    for (const d of compact.decisions) lines.push(`  - ${d}`);
+  }
+
+  const touchedFiles = compact?.touchedFiles ?? [];
+  if (touchedFiles.length > 0) {
+    lines.push("Files touched this session:");
+    for (const f of touchedFiles.slice(0, 20)) lines.push(`  - ${f}`);
+    if (touchedFiles.length > 20) lines.push(`  ... and ${touchedFiles.length - 20} more`);
+  }
+
+  const turns = compact?.recentTurns ?? recentHistory.slice(-COMPACT_RECENT_TURNS);
+  if (turns.length > 0) {
+    lines.push("Recent Claude turn summaries:");
+    for (const t of turns) {
+      const label = t.sessionDate
+        ? `[${t.sessionDate} Turn ${t.turnIndex ?? "?"}]`
+        : `[Turn ${t.turnIndex ?? "?"}]`;
+      lines.push(`  ${label} ${t.summary ?? t.assistantSummary ?? ""}`);
+    }
+  }
+
+  if (compact?.openQuestions?.length > 0) {
+    lines.push("Open questions:");
+    for (const q of compact.openQuestions) lines.push(`  - ${q}`);
+  }
+
+  lines.push("==============================");
+  return lines.join("\n");
+}
+
+// ─── Entry builder ────────────────────────────────────────────────────────────
+
+export function buildShiftEntry({ turnIndex, assistantMessage, touchedFiles }) {
+  return {
+    ts: new Date().toISOString(),
+    turnIndex: turnIndex ?? 0,
+    assistantSummary: String(assistantMessage ?? "").trim().slice(0, ASSISTANT_SUMMARY_LENGTH),
+    touchedFiles: touchedFiles ?? []
+  };
+}

--- a/plugins/codex/scripts/lib/shift-history.mjs
+++ b/plugins/codex/scripts/lib/shift-history.mjs
@@ -117,13 +117,20 @@ export function getActiveShiftSessionId(workspaceRoot) {
 /**
  * Attach a Codex job ID to a shift session so that resume can reuse the same
  * Codex thread instead of spawning a new one each time.
+ *
+ * When prevCodexThreadId is supplied (a resume that already had a thread), it is
+ * stored alongside the new job so that /codex:shift can fall back to that thread
+ * while the replacement job is still queued and has not yet reported its own threadId.
  */
-export function setShiftSessionCodexJobId(workspaceRoot, shiftSessionId, codexJobId) {
+export function setShiftSessionCodexJobId(workspaceRoot, shiftSessionId, codexJobId, prevCodexThreadId = null) {
   const existing = readShiftActive(workspaceRoot);
   if (!existing) return;
-  const updatedSessions = (existing.sessions ?? []).map((s) =>
-    s.id === shiftSessionId ? { ...s, codexJobId } : s
-  );
+  const updatedSessions = (existing.sessions ?? []).map((s) => {
+    if (s.id !== shiftSessionId) return s;
+    const updated = { ...s, codexJobId };
+    if (prevCodexThreadId) updated.prevCodexThreadId = prevCodexThreadId;
+    return updated;
+  });
   writeShiftActive(workspaceRoot, { ...existing, sessions: updatedSessions });
 }
 

--- a/plugins/codex/scripts/shift-history-hook.mjs
+++ b/plugins/codex/scripts/shift-history-hook.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+/**
+ * Stop hook — fires after each Claude turn.
+ * Appends a compact entry (assistant summary + touched files) to the
+ * active shift session's JSONL history log, used by /codex:shift.
+ *
+ * Silently does nothing if /codex:monitor has not been run yet.
+ * Always exits 0 — never blocks Claude.
+ */
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import process from "node:process";
+
+import {
+  appendShiftEntry,
+  buildShiftEntry,
+  getActiveShiftSessionId,
+  readShiftHistory
+} from "./lib/shift-history.mjs";
+import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
+
+function readHookInput() {
+  try {
+    const raw = fs.readFileSync(0, "utf8").trim();
+    if (!raw) return {};
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function getTouchedFiles(cwd) {
+  const files = new Set();
+
+  // Staged + unstaged tracked changes
+  const diff = spawnSync("git", ["diff", "--name-only", "HEAD"], { cwd, encoding: "utf8" });
+  if (diff.status === 0 && diff.stdout) {
+    for (const f of diff.stdout.split("\n").filter(Boolean)) files.add(f);
+  }
+
+  // Untracked files
+  const untracked = spawnSync("git", ["ls-files", "--others", "--exclude-standard"], {
+    cwd,
+    encoding: "utf8"
+  });
+  if (untracked.status === 0 && untracked.stdout) {
+    for (const f of untracked.stdout.split("\n").filter(Boolean)) files.add(f);
+  }
+
+  return [...files].sort();
+}
+
+function main() {
+  const input = readHookInput();
+  const cwd = input.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  const lastAssistantMessage = String(input.last_assistant_message ?? "").trim();
+
+  if (!lastAssistantMessage) return;
+
+  let workspaceRoot;
+  try {
+    workspaceRoot = resolveWorkspaceRoot(cwd);
+  } catch {
+    return;
+  }
+
+  // Only record if /codex:monitor has been run and created an active session
+  const shiftSessionId = getActiveShiftSessionId(workspaceRoot);
+  if (!shiftSessionId) return;
+
+  // Turn index = number of entries already recorded for this session
+  const existing = readShiftHistory(workspaceRoot, shiftSessionId);
+  const turnIndex = existing.length;
+
+  const touchedFiles = getTouchedFiles(cwd);
+
+  const entry = buildShiftEntry({
+    turnIndex,
+    assistantMessage: lastAssistantMessage,
+    touchedFiles
+  });
+
+  try {
+    appendShiftEntry(workspaceRoot, shiftSessionId, entry);
+  } catch {
+    // Best-effort — never crash Claude
+  }
+}
+
+try {
+  main();
+} catch {
+  // Swallow all errors — this hook must never block Claude
+}

--- a/plugins/codex/scripts/shift-history-hook.mjs
+++ b/plugins/codex/scripts/shift-history-hook.mjs
@@ -16,6 +16,7 @@ import process from "node:process";
 import {
   appendShiftEntry,
   buildShiftEntry,
+  getActiveShiftClaudeSessionId,
   getActiveShiftSessionId,
   readShiftHistory
 } from "./lib/shift-history.mjs";
@@ -69,6 +70,12 @@ function main() {
   // Only record if /codex:monitor has been run and created an active session
   const shiftSessionId = getActiveShiftSessionId(workspaceRoot);
   if (!shiftSessionId) return;
+
+  // Only record turns from the Claude session that started or resumed this monitor.
+  // If the stored ID is missing (old sessions before this feature) we allow recording
+  // for backwards compatibility. If it is present and doesn't match, skip silently.
+  const storedClaudeSessionId = getActiveShiftClaudeSessionId(workspaceRoot);
+  if (storedClaudeSessionId && input.session_id && storedClaudeSessionId !== input.session_id) return;
 
   // Turn index = number of entries already recorded for this session
   const existing = readShiftHistory(workspaceRoot, shiftSessionId);


### PR DESCRIPTION
This pull request introduces a comprehensive session and history tracking system for Codex handoff and monitoring workflows in the Claude plugin. It adds new commands for session management, implements persistent recording and compaction of session history, and integrates a background hook to automatically log assistant turns and touched files. These changes enable seamless handoff between Claude and Codex, improved context sharing, and robust session resumption.

**New Command Definitions and Session Management:**

* Added `/codex:monitor` command for starting or resuming Codex background sessions, with logic for session selection, fresh starts, and user prompts when multiple sessions exist.
* Added `/codex:shift` command to hand off the current session to Codex, including session selection, merging, and launching a Codex terminal, with user prompts for multiple sessions and support for merging all sessions.

**Session and History Tracking Library:**

* Implemented `shift-history.mjs`, a library for managing shift sessions: creating/resuming sessions, recording entries (assistant summaries and touched files), compacting and merging session history, and formatting context for Codex prompts.

**Automated Session Logging Hook:**

* Added `shift-history-hook.mjs`, a hook that runs after each Claude turn to append a summary and touched files to the active shift session’s history log, ensuring session context is always up to date.
* Registered the new hook in the plugin’s `hooks.json` to fire on each Stop event.

**Key Features:**

- Persistent JSONL logs and compacted summaries for each session.
- Automatic detection and logging of files touched (tracked and untracked).
- Robust error handling to ensure hooks never block Claude.
- User-friendly session selection and merging for seamless handoff.