### PR TITLE
fix(stop-review-gate-hook): always emit valid JSON on stdout

### DIFF
--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -153,6 +153,7 @@ function main() {
 
   if (!config.stopReviewGate) {
     logNote(runningTaskNote);
+    emitDecision({});
     return;
   }
 
@@ -160,6 +161,7 @@ function main() {
   if (setupNote) {
     logNote(setupNote);
     logNote(runningTaskNote);
+    emitDecision({});
     return;
   }
 
@@ -173,6 +175,7 @@ function main() {
   }
 
   logNote(runningTaskNote);
+  emitDecision({});
 }
 
 try {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1894,7 +1894,7 @@ test("stop hook logs running tasks to stderr without blocking when the review ga
   });
 
   assert.equal(blocked.status, 0, blocked.stderr);
-  assert.equal(blocked.stdout.trim(), "");
+  assert.equal(blocked.stdout.trim(), "{}");
   assert.match(blocked.stderr, /Codex task task-live is still running/i);
   assert.match(blocked.stderr, /\/codex:status/i);
   assert.match(blocked.stderr, /\/codex:cancel task-live/i);
@@ -1922,7 +1922,7 @@ test("stop hook allows the stop when the review gate is enabled and the stop-tim
   });
 
   assert.equal(allowed.status, 0, allowed.stderr);
-  assert.equal(allowed.stdout.trim(), "");
+  assert.equal(allowed.stdout.trim(), "{}");
 });
 
 test("stop hook does not block when Codex is unavailable even if the review gate is enabled", () => {
@@ -1947,7 +1947,7 @@ test("stop hook does not block when Codex is unavailable even if the review gate
   });
 
   assert.equal(allowed.status, 0, allowed.stderr);
-  assert.equal(allowed.stdout.trim(), "");
+  assert.equal(allowed.stdout.trim(), "{}");
   assert.match(allowed.stderr, /Codex is not set up for the review gate/i);
   assert.match(allowed.stderr, /Run \/codex:setup/i);
 });


### PR DESCRIPTION
## Summary

`scripts/stop-review-gate-hook.mjs` returns silently in three no-decision paths in `main()`:

1. `if (!config.stopReviewGate)` — the default, hit on every Stop event when the user has not opted into the review gate
2. `if (setupNote)` — Codex not yet set up
3. The trailing path where the review came back `ALLOW`

In all three, `logNote()` writes to stderr but stdout is never touched. Newer hook executors (observed in current Claude Code / Codex CLI builds) strict-parse hook stdout as JSON. Empty stdout is no longer treated as "no decision" — it surfaces as a visible error after every Claude turn:

```
Stop hook (failed)
error: hook returned invalid stop hook JSON output
```

Older Claude Code tolerated empty stdout, which is why this only became visible recently.

## Fix

Emit `{}` (a no-decision JSON object) before each silent `return`. Three-line change, no behavior change other than satisfying the strict parser. The block path is untouched — it already emits a `{decision: "block", reason}` object.

## Test plan

- [x] `echo '{"hook_event_name":"Stop","session_id":"test","stop_hook_active":false}' | node scripts/stop-review-gate-hook.mjs` → stdout is `{}`, exit 0
- [x] `JSON.parse(stdout)` succeeds
- [x] stderr `logNote` messages preserved (no regression in user-facing diagnostics)
- [x] `decision: "block"` path unchanged

## Related issues / context

I searched open issues and PRs for `stop-review-gate`, `empty stdout`, `hook returned invalid`, `JSON output` — none describe this specific defect. The closest are:

- #191 (Stop hook hangs on Windows when review gate disabled) — different root cause (stdin blocking, not stdout shape)
- #248 (Stop review gate blocks Claude on infrastructure errors) — touches `parseStopReviewOutput`, but only the gate-enabled paths

Both are orthogonal to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)