### PR TITLE
feat(stop-review-gate): add monorepo mode for sibling git repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,19 @@ When the review gate is enabled, the plugin uses a `Stop` hook to run a targeted
 > [!WARNING]
 > The review gate can create a long-running Claude/Codex loop and may drain usage limits quickly. Only enable it when you plan to actively monitor the session.
 
+#### Monorepo mode (multiple sibling git repos)
+
+By default the review gate only reviews the workspace identified by `git rev-parse --show-toplevel` from the session's cwd. In a layout where several independent git repositories live under one parent directory (a common pattern for monorepos managed with submodules-like checkouts, or simply by convention), changes Claude makes in a *sibling* repo are never seen by the gate.
+
+Enable monorepo mode on the primary repo to make the `Stop` hook also scan the parent directory for sibling git repos and run a review in each one that has the gate enabled and has uncommitted changes:
+
+```bash
+/codex:setup --enable-monorepo
+/codex:setup --disable-monorepo
+```
+
+Setup must still be run separately in each sibling repo to enable the gate for it (`/codex:setup --enable-review-gate`). The hook respects each sibling's own state — a repo whose gate is off is skipped.
+
 ## Typical Flows
 
 ### Review Before Shipping

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -195,6 +195,11 @@ async function buildSetupReport(cwd, actionsTaken = []) {
   if (!config.stopReviewGate) {
     nextSteps.push("Optional: run `/codex:setup --enable-review-gate` to require a fresh review before stop.");
   }
+  if (config.stopReviewGate && !config.monorepoMode) {
+    nextSteps.push(
+      "Optional: run `/codex:setup --enable-monorepo` to make the stop-time review gate also scan sibling git repos under the parent directory."
+    );
+  }
 
   return {
     ready: nodeStatus.available && codexStatus.available && authStatus.loggedIn,
@@ -204,6 +209,7 @@ async function buildSetupReport(cwd, actionsTaken = []) {
     auth: authStatus,
     sessionRuntime: getSessionRuntimeStatus(process.env, workspaceRoot),
     reviewGateEnabled: Boolean(config.stopReviewGate),
+    monorepoModeEnabled: Boolean(config.monorepoMode),
     actionsTaken,
     nextSteps
   };
@@ -212,11 +218,20 @@ async function buildSetupReport(cwd, actionsTaken = []) {
 async function handleSetup(argv) {
   const { options } = parseCommandInput(argv, {
     valueOptions: ["cwd"],
-    booleanOptions: ["json", "enable-review-gate", "disable-review-gate"]
+    booleanOptions: [
+      "json",
+      "enable-review-gate",
+      "disable-review-gate",
+      "enable-monorepo",
+      "disable-monorepo"
+    ]
   });
 
   if (options["enable-review-gate"] && options["disable-review-gate"]) {
     throw new Error("Choose either --enable-review-gate or --disable-review-gate.");
+  }
+  if (options["enable-monorepo"] && options["disable-monorepo"]) {
+    throw new Error("Choose either --enable-monorepo or --disable-monorepo.");
   }
 
   const cwd = resolveCommandCwd(options);
@@ -229,6 +244,16 @@ async function handleSetup(argv) {
   } else if (options["disable-review-gate"]) {
     setConfig(workspaceRoot, "stopReviewGate", false);
     actionsTaken.push(`Disabled the stop-time review gate for ${workspaceRoot}.`);
+  }
+
+  if (options["enable-monorepo"]) {
+    setConfig(workspaceRoot, "monorepoMode", true);
+    actionsTaken.push(
+      `Enabled monorepo mode for ${workspaceRoot}: stop-time review gate now also scans sibling git repos under the parent directory.`
+    );
+  } else if (options["disable-monorepo"]) {
+    setConfig(workspaceRoot, "monorepoMode", false);
+    actionsTaken.push(`Disabled monorepo mode for ${workspaceRoot}.`);
   }
 
   const finalReport = await buildSetupReport(cwd, actionsTaken);

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -187,6 +187,7 @@ export function renderSetupReport(report) {
     `- auth: ${report.auth.detail}`,
     `- session runtime: ${report.sessionRuntime.label}`,
     `- review gate: ${report.reviewGateEnabled ? "enabled" : "disabled"}`,
+    `- monorepo mode: ${report.monorepoModeEnabled ? "enabled" : "disabled"}`,
     ""
   ];
 

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -20,7 +20,8 @@ function defaultState() {
   return {
     version: STATE_VERSION,
     config: {
-      stopReviewGate: false
+      stopReviewGate: false,
+      monorepoMode: false
     },
     jobs: []
   };

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -139,6 +139,71 @@ function runStopReview(cwd, input = {}) {
   }
 }
 
+/**
+ * Discover sibling git repositories under the parent of [workspaceRoot].
+ * Used when monorepo mode is enabled: each sibling has its own state and
+ * is reviewed independently, so changes outside the cwd's repo are not
+ * silently skipped by the stop-time gate.
+ *
+ * Depth is fixed at 1 (immediate children of the parent dir) — recursive
+ * scanning is intentionally avoided to keep the hook fast and predictable.
+ */
+function discoverSiblingWorkspaces(workspaceRoot) {
+  try {
+    const parent = path.dirname(workspaceRoot);
+    if (!parent || parent === workspaceRoot) {
+      return [];
+    }
+    const entries = fs.readdirSync(parent, { withFileTypes: true });
+    const siblings = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const candidate = path.join(parent, entry.name);
+      if (candidate === workspaceRoot) continue;
+      // Treat both `.git/` dirs and worktree `.git` files as a git repo.
+      const gitMarker = path.join(candidate, ".git");
+      if (fs.existsSync(gitMarker)) {
+        siblings.push(candidate);
+      }
+    }
+    return siblings;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Return true when the workspace has uncommitted changes (tracked or
+ * untracked). If git is unavailable or the directory is not a repo, the
+ * function returns false so the hook does not waste a Codex review on
+ * an empty diff.
+ */
+function workspaceHasChanges(workspaceRoot) {
+  const result = spawnSync("git", ["status", "--porcelain"], {
+    cwd: workspaceRoot,
+    encoding: "utf8"
+  });
+  if (result.status !== 0) {
+    return false;
+  }
+  return String(result.stdout ?? "").trim().length > 0;
+}
+
+function reviewWorkspace(workspaceRoot, input) {
+  const setupNote = buildSetupNote(workspaceRoot);
+  if (setupNote) {
+    return { ok: true, note: setupNote };
+  }
+  const review = runStopReview(workspaceRoot, input);
+  if (!review.ok) {
+    return {
+      ok: false,
+      reason: `[${path.basename(workspaceRoot)}] ${review.reason}`
+    };
+  }
+  return { ok: true };
+}
+
 function main() {
   const input = readHookInput();
   const cwd = input.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd();
@@ -156,18 +221,38 @@ function main() {
     return;
   }
 
-  const setupNote = buildSetupNote(cwd);
-  if (setupNote) {
-    logNote(setupNote);
-    logNote(runningTaskNote);
-    return;
+  // Build the list of workspaces to review. The primary workspace is
+  // always included to preserve existing single-repo behavior. When
+  // monorepo mode is enabled, sibling git repos under the parent dir
+  // are added if their own state has the gate enabled *and* they have
+  // uncommitted changes (otherwise Codex would just respond ALLOW for
+  // an empty diff and waste tokens).
+  const workspaces = [workspaceRoot];
+  if (config.monorepoMode) {
+    for (const sibling of discoverSiblingWorkspaces(workspaceRoot)) {
+      const siblingConfig = getConfig(sibling);
+      if (!siblingConfig.stopReviewGate) continue;
+      if (!workspaceHasChanges(sibling)) continue;
+      workspaces.push(sibling);
+    }
   }
 
-  const review = runStopReview(cwd, input);
-  if (!review.ok) {
+  const failures = [];
+  for (const ws of workspaces) {
+    const result = reviewWorkspace(ws, input);
+    if (result.note) {
+      logNote(result.note);
+    }
+    if (!result.ok) {
+      failures.push(result.reason);
+    }
+  }
+
+  if (failures.length > 0) {
+    const combined = failures.join("\n\n");
     emitDecision({
       decision: "block",
-      reason: runningTaskNote ? `${runningTaskNote} ${review.reason}` : review.reason
+      reason: runningTaskNote ? `${runningTaskNote} ${combined}` : combined
     });
     return;
   }

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -5,7 +5,16 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { makeTempDir } from "./helpers.mjs";
-import { resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState } from "../plugins/codex/scripts/lib/state.mjs";
+import {
+  getConfig,
+  loadState,
+  resolveJobFile,
+  resolveJobLogFile,
+  resolveStateDir,
+  resolveStateFile,
+  saveState,
+  setConfig
+} from "../plugins/codex/scripts/lib/state.mjs";
 
 test("resolveStateDir uses a temp-backed per-workspace directory", () => {
   const workspace = makeTempDir();
@@ -102,4 +111,25 @@ test("saveState prunes dropped job artifacts when indexed jobs exceed the cap", 
       .flatMap((jobId) => [`${jobId}.json`, `${jobId}.log`])
       .sort()
   );
+});
+
+test("default config includes monorepoMode disabled", () => {
+  const workspace = makeTempDir();
+  const config = getConfig(workspace);
+
+  assert.equal(config.stopReviewGate, false);
+  assert.equal(config.monorepoMode, false);
+});
+
+test("setConfig persists monorepoMode independently from stopReviewGate", () => {
+  const workspace = makeTempDir();
+
+  setConfig(workspace, "monorepoMode", true);
+  const config = getConfig(workspace);
+
+  assert.equal(config.monorepoMode, true);
+  assert.equal(config.stopReviewGate, false);
+
+  const reloaded = loadState(workspace).config;
+  assert.equal(reloaded.monorepoMode, true);
 });


### PR DESCRIPTION
## Summary

The stop-time review gate currently resolves a single workspace via `git rev-parse --show-toplevel` from the session cwd. In layouts where several independent git repos sit under one parent directory (a common monorepo pattern — sibling clones managed by convention rather than git submodules), changes Claude makes in a *sibling* repo are silently skipped: the hook runs review only in the primary repo, sees no diff there, returns `ALLOW`, the session ends without the review actually covering the work.

This PR adds an opt-in `monorepoMode` config flag (default `false`, fully backwards-compatible). When enabled on the primary repo, the `Stop` hook scans the parent directory for sibling git repos and runs an independent stop-time review for each one that

- has its own `stopReviewGate` enabled, and
- has uncommitted changes.

Empty-diff siblings are skipped (Codex would just reply `ALLOW` and waste tokens). If any review blocks, the combined reason is returned and the gate blocks the Stop.

When `monorepoMode` is off (the default), behavior is identical to today: only the primary workspace is reviewed.

## Configuration

```bash
/codex:setup --enable-monorepo
/codex:setup --disable-monorepo
```

Setup must still be run separately in each sibling repo to enable the gate for it (`/codex:setup --enable-review-gate`). The hook respects each sibling's own state — a repo whose gate is off is skipped.

## Why opt-in

- Auto-scanning the parent dir without an explicit opt-in could surprise users with single-repo workflows where the parent happens to contain other git checkouts (e.g. `~/code/` with dozens of unrelated clones).
- Keeps single-repo semantics deterministic and free of any FS walk.

## Test plan

- `npm test` — 86 → 88 tests (two new state tests for the flag); only pre-existing failures remain (#133-style flake on `resolveStateDir` and the `status`/`result` formatter tests). No regressions from this change.
- End-to-end stop hook tests in `tests/runtime.test.mjs` (which set up a git repo + a committed change) continue to pass — primary workspace review path is unchanged.

## Out of scope

- Recursive scanning (depth > 1) — kept fixed at immediate children for predictability.
- Cross-platform path quirks (e.g. case-insensitive FS) — uses existing `fs.realpath` resolution already in `state.mjs`.
- User-level defaults — that's #213, complementary, not duplicated here.