### PR TITLE
Harden the Codex turn lifecycle: bound stalls, stop abandoned upstream work, idle broker shutdown

### DIFF
--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -39,7 +39,7 @@ Forwarding rules:
 - Otherwise forward the task as a fresh `task` run.
 - Preserve the user's task text as-is apart from stripping routing flags.
 - Return the stdout of the `codex-companion` command exactly as-is.
-- If the Bash call fails or Codex cannot be invoked, return nothing.
+- If the Bash call fails or Codex cannot be invoked, return its error output (stderr and any stdout) verbatim so the failure is visible — never swallow it into an empty response.
 
 Response style:
 

--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -69,6 +69,10 @@ async function main() {
   let activeRequestSocket = null;
   let activeStreamSocket = null;
   let activeStreamThreadIds = null;
+  // The socket whose request is currently awaiting an upstream response. If that
+  // socket disconnects before the response arrives (e.g. its turn watchdog fired
+  // on a start that never ACKed), the upstream work is orphaned — see onSocketGone.
+  let pendingUpstreamSocket = null;
   const sockets = new Set();
 
   // Idle self-shutdown: the broker is keyed per-cwd and is only reaped on a
@@ -102,6 +106,28 @@ async function main() {
       activeStreamSocket = null;
       activeStreamThreadIds = null;
     }
+  }
+
+  function onSocketGone(socket) {
+    sockets.delete(socket);
+    // The client that owned in-progress upstream work vanished — either a
+    // request still in flight (a start that never returned), or a streaming turn
+    // that ACKed but has not reached turn/completed (e.g. the companion crashed
+    // or was killed before it could interrupt). That turn is now orphaned and
+    // may keep running. The broker is single-flight, so there is no other
+    // in-flight work to preserve: tear the broker down (closing the upstream
+    // app-server) so the abandoned turn cannot keep mutating the workspace or
+    // collide with the next task, which reconnects to a fresh runtime. A turn
+    // that reached turn/completed (or was interrupted) has already cleared
+    // activeStreamSocket via routeNotification, so a normal close does not
+    // trigger this.
+    if (socket === pendingUpstreamSocket || socket === activeStreamSocket) {
+      pendingUpstreamSocket = null;
+      shutdown(server).finally(() => process.exit(0));
+      return;
+    }
+    clearSocketOwnership(socket);
+    armIdle();
   }
 
   function routeNotification(message) {
@@ -213,6 +239,7 @@ async function main() {
         }
 
         if (allowInterruptDuringActiveStream) {
+          pendingUpstreamSocket = socket;
           try {
             const result = await appClient.request(message.method, message.params ?? {});
             send(socket, { id: message.id, result });
@@ -221,12 +248,17 @@ async function main() {
               id: message.id,
               error: buildJsonRpcError(error.rpcCode ?? -32000, error.message)
             });
+          } finally {
+            if (pendingUpstreamSocket === socket) {
+              pendingUpstreamSocket = null;
+            }
           }
           continue;
         }
 
         const isStreaming = STREAMING_METHODS.has(message.method);
         activeRequestSocket = socket;
+        pendingUpstreamSocket = socket;
 
         try {
           const result = await appClient.request(message.method, message.params ?? {});
@@ -249,20 +281,20 @@ async function main() {
           if (activeStreamSocket === socket && !isStreaming) {
             activeStreamSocket = null;
           }
+        } finally {
+          // The request settled (ACK for a streaming turn, or a terminal result):
+          // it is no longer in flight, so the socket closing after this is normal
+          // teardown, not an abandoned upstream request.
+          if (pendingUpstreamSocket === socket) {
+            pendingUpstreamSocket = null;
+          }
         }
       }
     });
 
-    socket.on("close", () => {
-      sockets.delete(socket);
-      clearSocketOwnership(socket);
-      armIdle();
-    });
+    socket.on("close", () => onSocketGone(socket));
 
-    socket.on("error", () => {
-      sockets.delete(socket);
-      clearSocketOwnership(socket);
-    });
+    socket.on("error", () => onSocketGone(socket));
   });
 
   process.on("SIGTERM", async () => {

--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -126,8 +126,14 @@ async function main() {
     for (const socket of sockets) {
       socket.end();
     }
-    await appClient.close().catch(() => {});
+    // Stop accepting new connections BEFORE closing the upstream app-server. On
+    // an idle self-shutdown a new task may connect at the teardown boundary;
+    // closing the listener first means that client is either served by the
+    // still-open appClient (during drain) or refused with ECONNREFUSED — which
+    // the companion retries into a fresh broker — rather than accepted and then
+    // failed against a closed app-server (an error withAppServer does not retry).
     await new Promise((resolve) => server.close(resolve));
+    await appClient.close().catch(() => {});
     if (listenTarget.kind === "unix" && fs.existsSync(listenTarget.path)) {
       fs.unlinkSync(listenTarget.path);
     }

--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -71,6 +71,29 @@ async function main() {
   let activeStreamThreadIds = null;
   const sockets = new Set();
 
+  // Idle self-shutdown: the broker is keyed per-cwd and is only reaped on a
+  // later ensureBrokerSession for the SAME cwd. A broker for a cwd that is never
+  // revisited (deleted worktree, ended session) would otherwise run forever and
+  // accumulate as orphaned processes. Exit after IDLE_MS with no connected
+  // clients so the leak self-heals; the companion transparently respawns one on
+  // the next task. Env-overridable for long idle gaps.
+  const IDLE_MS = Number(process.env.CODEX_COMPANION_BROKER_IDLE_MS) || 1_800_000;
+  let idleTimer = null;
+  function armIdle() {
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+    }
+    idleTimer = setTimeout(async () => {
+      if (sockets.size > 0 || activeRequestSocket || activeStreamSocket) {
+        armIdle();
+        return;
+      }
+      await shutdown(server);
+      process.exit(0);
+    }, IDLE_MS);
+    idleTimer.unref?.();
+  }
+
   function clearSocketOwnership(socket) {
     if (activeRequestSocket === socket) {
       activeRequestSocket = null;
@@ -117,10 +140,12 @@ async function main() {
 
   const server = net.createServer((socket) => {
     sockets.add(socket);
+    armIdle();
     socket.setEncoding("utf8");
     let buffer = "";
 
     socket.on("data", async (chunk) => {
+      armIdle();
       buffer += chunk;
       let newlineIndex = buffer.indexOf("\n");
       while (newlineIndex !== -1) {
@@ -225,6 +250,7 @@ async function main() {
     socket.on("close", () => {
       sockets.delete(socket);
       clearSocketOwnership(socket);
+      armIdle();
     });
 
     socket.on("error", () => {
@@ -244,6 +270,7 @@ async function main() {
   });
 
   server.listen(listenTarget.path);
+  armIdle();
 }
 
 main().catch((error) => {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -550,6 +550,26 @@ function applyTurnNotification(state, message) {
   }
 }
 
+// Best-effort interrupt of a turn being abandoned by a watchdog, bounded so the
+// teardown cannot itself hang. On the broker transport this is forwarded to the
+// upstream app-server, which stops the turn so it cannot overlap a retry.
+async function interruptTurnBestEffort(client, threadId, turnId) {
+  if (!threadId || !turnId) {
+    return;
+  }
+  try {
+    await Promise.race([
+      client.request("turn/interrupt", { threadId, turnId }),
+      new Promise((_resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("turn/interrupt timed out")), 5_000);
+        timer.unref?.();
+      })
+    ]);
+  } catch {
+    // Best-effort: the turn is being abandoned regardless of the interrupt outcome.
+  }
+}
+
 async function captureTurn(client, threadId, startRequest, options = {}) {
   const state = createTurnCaptureState(threadId, options);
   const previousHandler = client.notificationHandler;
@@ -593,11 +613,18 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
     applyTurnNotification(state, message);
   });
 
+  // `turnAbandoned` marks a failure where the turn may still be running upstream
+  // (a watchdog fired, or the app-server vanished) — as opposed to a turn that
+  // errored and is therefore already over. The catch below uses it to decide
+  // whether the upstream work needs to be actively stopped.
   const ceiling = new Promise((_resolve, reject) => {
     ceilingTimer = setTimeout(() => {
       reject(
-        new Error(
-          `Codex turn exceeded the ${Math.round(CEILING_MS / 1000)}s ceiling without completing (raise CODEX_COMPANION_TURN_TIMEOUT_MS for long turns). Treating as stalled.`
+        Object.assign(
+          new Error(
+            `Codex turn exceeded the ${Math.round(CEILING_MS / 1000)}s ceiling without completing (raise CODEX_COMPANION_TURN_TIMEOUT_MS for long turns). Treating as stalled.`
+          ),
+          { turnAbandoned: true }
         )
       );
     }, CEILING_MS);
@@ -608,8 +635,11 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
     stallTimer = setInterval(() => {
       if (Date.now() - lastActivity >= STALL_MS) {
         reject(
-          new Error(
-            `Codex turn produced no activity for ${Math.round(STALL_MS / 1000)}s (raise CODEX_COMPANION_TURN_STALL_MS for long silent turns) — likely a hung MCP server or wedged turn. Treating as stalled.`
+          Object.assign(
+            new Error(
+              `Codex turn produced no activity for ${Math.round(STALL_MS / 1000)}s (raise CODEX_COMPANION_TURN_STALL_MS for long silent turns) — likely a hung MCP server or wedged turn. Treating as stalled.`
+            ),
+            { turnAbandoned: true }
           )
         );
       }
@@ -621,7 +651,10 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
     if (state.completed) {
       return state;
     }
-    throw client.exitError ?? new Error("codex app-server exited before the turn completed.");
+    throw Object.assign(
+      new Error(client.exitError?.message ?? "codex app-server exited before the turn completed."),
+      { turnAbandoned: true }
+    );
   });
 
   // Wrap the start RPC and response processing so the guards also cover a start
@@ -660,6 +693,19 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
     // returns, or after the race has settled) is always handled and never
     // surfaces as an unhandledRejection.
     return await Promise.race([work, ceiling, stall, exit]);
+  } catch (error) {
+    // Stopping the wait is not enough: on a shared broker, abandoning the turn
+    // here leaves it running upstream, where it can keep mutating the workspace
+    // and collide with the next task. (On the direct transport the app-server is
+    // killed by close(), so only the broker path needs this.) When the turn id is
+    // known, interrupt it so the broker stays alive and reusable. When the start
+    // RPC hung before a turn id existed there is nothing to interrupt — the broker
+    // detects the abandoned in-flight request when this client disconnects and
+    // tears itself down, which covers owned and env-shared brokers alike.
+    if (error?.turnAbandoned && !state.completed && client.transport === "broker" && state.turnId) {
+      await interruptTurnBestEffort(client, state.threadId, state.turnId);
+    }
+    throw error;
   } finally {
     clearCompletionTimer(state);
     if (ceilingTimer) {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -624,7 +624,10 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
     throw client.exitError ?? new Error("codex app-server exited before the turn completed.");
   });
 
-  try {
+  // Wrap the start RPC and response processing so the guards also cover a start
+  // request that hangs or rejects before the turn is ever established, and so
+  // every guard is observed by Promise.race from the outset.
+  const work = (async () => {
     const response = await startRequest();
     options.onResponse?.(response, state);
     state.turnId = response.turn?.id ?? null;
@@ -646,11 +649,17 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
       completeTurn(state, response.turn);
     }
 
-    // state.completion wins under normal operation; the guards only fire on a
-    // wedge, an over-long turn, or app-server death. Promise.race attaches a
-    // handler to every racer, so a guard rejecting after the race already
-    // settled does not surface as an unhandledRejection.
-    return await Promise.race([state.completion, ceiling, stall, exit]);
+    return await state.completion;
+  })();
+
+  try {
+    // `work` wins under normal operation; the guards only fire on a wedge, an
+    // over-long turn, or app-server death — including a start RPC that hangs or
+    // rejects before the turn is established. Promise.race attaches a handler to
+    // every racer up front, so a guard that rejects (even before the start RPC
+    // returns, or after the race has settled) is always handled and never
+    // surfaces as an unhandledRejection.
+    return await Promise.race([work, ceiling, stall, exit]);
   } finally {
     clearCompletionTimer(state);
     if (ceilingTimer) {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -554,7 +554,25 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
   const state = createTurnCaptureState(threadId, options);
   const previousHandler = client.notificationHandler;
 
+  // The completion promise resolves only on a terminal `turn/completed`
+  // notification (or the inferred-completion heuristic) and is otherwise
+  // uncoupled from time and from the app-server process. A wedged turn (e.g. a
+  // hung MCP server that never emits another notification) or an app-server that
+  // dies mid-turn would leave `await state.completion` hanging forever, which
+  // surfaces as a "stuck" Codex run. Bound the wait three ways so it always
+  // fails toward "didn't finish" instead of hanging:
+  //   - STALL_MS:   no inbound traffic at all for this long => treat as stalled.
+  //   - CEILING_MS: absolute backstop on a single turn.
+  //   - exit:       app-server process death rejects immediately.
+  // Both timeouts are env-overridable for genuinely long turns.
+  const CEILING_MS = Number(process.env.CODEX_COMPANION_TURN_TIMEOUT_MS) || 1_800_000;
+  const STALL_MS = Number(process.env.CODEX_COMPANION_TURN_STALL_MS) || 600_000;
+  let lastActivity = Date.now();
+  let ceilingTimer = null;
+  let stallTimer = null;
+
   client.setNotificationHandler((message) => {
+    lastActivity = Date.now();
     if (!state.turnId) {
       state.bufferedNotifications.push(message);
       return;
@@ -573,6 +591,37 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
     }
 
     applyTurnNotification(state, message);
+  });
+
+  const ceiling = new Promise((_resolve, reject) => {
+    ceilingTimer = setTimeout(() => {
+      reject(
+        new Error(
+          `Codex turn exceeded the ${Math.round(CEILING_MS / 1000)}s ceiling without completing (raise CODEX_COMPANION_TURN_TIMEOUT_MS for long turns). Treating as stalled.`
+        )
+      );
+    }, CEILING_MS);
+    ceilingTimer.unref?.();
+  });
+
+  const stall = new Promise((_resolve, reject) => {
+    stallTimer = setInterval(() => {
+      if (Date.now() - lastActivity >= STALL_MS) {
+        reject(
+          new Error(
+            `Codex turn produced no activity for ${Math.round(STALL_MS / 1000)}s (raise CODEX_COMPANION_TURN_STALL_MS for long silent turns) — likely a hung MCP server or wedged turn. Treating as stalled.`
+          )
+        );
+      }
+    }, Math.min(STALL_MS, 30_000));
+    stallTimer.unref?.();
+  });
+
+  const exit = client.exitPromise.then(() => {
+    if (state.completed) {
+      return state;
+    }
+    throw client.exitError ?? new Error("codex app-server exited before the turn completed.");
   });
 
   try {
@@ -597,9 +646,19 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
       completeTurn(state, response.turn);
     }
 
-    return await state.completion;
+    // state.completion wins under normal operation; the guards only fire on a
+    // wedge, an over-long turn, or app-server death. Promise.race attaches a
+    // handler to every racer, so a guard rejecting after the race already
+    // settled does not surface as an unhandledRejection.
+    return await Promise.race([state.completion, ceiling, stall, exit]);
   } finally {
     clearCompletionTimer(state);
+    if (ceilingTimer) {
+      clearTimeout(ceilingTimer);
+    }
+    if (stallTimer) {
+      clearInterval(stallTimer);
+    }
     client.setNotificationHandler(previousHandler ?? null);
   }
 }

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -40,4 +40,4 @@ Safety rules:
 - Preserve the user's task text as-is apart from stripping routing flags.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
 - Return the stdout of the `task` command exactly as-is.
-- If the Bash call fails or Codex cannot be invoked, return nothing.
+- If the Bash call fails or Codex cannot be invoked, return its error output (stderr and any stdout) verbatim so the failure is visible — never swallow it into an empty response.

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -136,7 +136,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(agent, /If the user asks for `spark`, map that to `--model gpt-5\.3-codex-spark`/i);
   assert.match(agent, /If the user asks for a concrete model name such as `gpt-5\.4-mini`, pass it through with `--model`/i);
   assert.match(agent, /Return the stdout of the `codex-companion` command exactly as-is/i);
-  assert.match(agent, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
+  assert.match(agent, /If the Bash call fails or Codex cannot be invoked, return its error output/i);
   assert.match(agent, /gpt-5-4-prompting/);
   assert.match(agent, /only to tighten the user's request into a better Codex prompt/i);
   assert.match(agent, /Do not use that skill to inspect the repository, reason through the problem yourself, draft a solution, or do any independent work/i);
@@ -151,7 +151,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /Strip it before calling `task`/i);
   assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`/i);
   assert.match(runtimeSkill, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
-  assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
+  assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return its error output/i);
   assert.match(readme, /`codex:codex-rescue` subagent/i);
   assert.match(readme, /if you do not pass `--model` or `--effort`, Codex chooses its own defaults/i);
   assert.match(readme, /--model gpt-5\.4-mini --effort medium/i);

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -373,6 +373,12 @@ rl.on("line", (line) => {
 	          // (a start RPC that hangs before any ACK or notification arrives).
 	          break;
 	        }
+	        if (BEHAVIOR === "start-rejects") {
+	          // Reject turn/start before any ACK: exercises the pre-ACK reject path
+	          // (the real error must surface, with no unhandled rejection).
+	          send({ id: message.id, error: { code: -32000, message: "fake start rejection (pre-ACK)" } });
+	          break;
+	        }
 	        const thread = ensureThread(state, message.params.threadId);
 	        const prompt = (message.params.input || [])
           .filter((item) => item.type === "text")

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -368,6 +368,11 @@ rl.on("line", (line) => {
       }
 
 	      case "turn/start": {
+	        if (BEHAVIOR === "start-hangs") {
+	          // Never reply to turn/start: exercises the client's pre-ACK watchdog
+	          // (a start RPC that hangs before any ACK or notification arrives).
+	          break;
+	        }
 	        const thread = ensureThread(state, message.params.threadId);
 	        const prompt = (message.params.input || [])
           .filter((item) => item.type === "text")

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -385,6 +385,13 @@ rl.on("line", (line) => {
 	        saveState(state);
 	        send({ id: message.id, result: { turn: buildTurn(turnId) } });
 
+        if (BEHAVIOR === "never-completes") {
+          // Emit nothing further: no items, no turn/completed, no final_answer.
+          // The turn ACK was already sent, so the client must rely on its own
+          // stall guard rather than hang forever.
+          break;
+        }
+
         const payload = message.params.outputSchema && message.params.outputSchema.properties && message.params.outputSchema.properties.verdict
           ? structuredReviewPayload(prompt)
           : taskPayload(prompt, thread.name && thread.name.startsWith("Codex Companion Task") && prompt.includes("Continue from the current thread state"));

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -2213,3 +2213,30 @@ test("task fails fast when the start RPC itself never replies (pre-ACK watchdog)
   assert.doesNotMatch(out, /UnhandledPromiseRejection|Unhandled rejection/i);
   assert.ok(elapsedMs < 30000, `expected a fast pre-ACK stall failure, took ${elapsedMs}ms`);
 });
+
+test("task surfaces a start RPC rejection without an unhandled rejection (pre-ACK)", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "start-rejects");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "do something"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      CODEX_COMPANION_BROKER_IDLE_MS: "1000",
+      // A regression would manifest as the exit guard rejecting unobserved.
+      NODE_OPTIONS: "--unhandled-rejections=throw"
+    }
+  });
+
+  // The real start-RPC error must surface, and the unobserved-guard regression
+  // must not reappear as an unhandled rejection.
+  assert.notEqual(result.status, 0);
+  const out = `${result.stdout}\n${result.stderr}`;
+  assert.match(out, /fake start rejection|pre-ACK/i);
+  assert.doesNotMatch(out, /UnhandledPromiseRejection|Unhandled rejection/i);
+});

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -2181,3 +2181,35 @@ test("broker self-shuts-down after the idle window with no clients", async () =>
 
   assert.equal(exitCode, 0);
 });
+
+test("task fails fast when the start RPC itself never replies (pre-ACK watchdog)", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "start-hangs");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const start = Date.now();
+  const result = run("node", [SCRIPT, "task", "do something"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      CODEX_COMPANION_TURN_STALL_MS: "500",
+      CODEX_COMPANION_BROKER_IDLE_MS: "1000",
+      // Surface any unhandled rejection as a crash so a regression in guard
+      // observation is caught rather than silently warned.
+      NODE_OPTIONS: "--unhandled-rejections=throw"
+    }
+  });
+  const elapsedMs = Date.now() - start;
+
+  // The watchdog must cover the start RPC, not just the post-ACK wait, and must
+  // not leak an unhandled rejection from the unobserved guards.
+  assert.notEqual(result.status, 0);
+  const out = `${result.stdout}\n${result.stderr}`;
+  assert.match(out, /no activity|stall/i);
+  assert.doesNotMatch(out, /UnhandledPromiseRejection|Unhandled rejection/i);
+  assert.ok(elapsedMs < 30000, `expected a fast pre-ACK stall failure, took ${elapsedMs}ms`);
+});

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -2240,3 +2240,82 @@ test("task surfaces a start RPC rejection without an unhandled rejection (pre-AC
   assert.match(out, /fake start rejection|pre-ACK/i);
   assert.doesNotMatch(out, /UnhandledPromiseRejection|Unhandled rejection/i);
 });
+
+test("a stalled brokered turn is interrupted upstream so it cannot overlap a retry", async () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "never-completes");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "do something"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      CODEX_COMPANION_TURN_STALL_MS: "500",
+      // High idle so a broker exit can only be abandonment teardown, not idle.
+      CODEX_COMPANION_BROKER_IDLE_MS: "60000"
+    }
+  });
+  assert.notEqual(result.status, 0);
+
+  // The abandoned turn must be interrupted upstream (through the broker), not
+  // left running where it could collide with the next task.
+  const fakeState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  assert.ok(fakeState.lastInterrupt, "expected the stalled turn to be interrupted upstream");
+  assert.ok(fakeState.lastInterrupt.turnId, "the interrupt should carry the turn id");
+
+  // The turn ACKed but never reached turn/completed, so its stream is still
+  // active when the companion disconnects: the broker must self-terminate
+  // (closing the upstream app-server) rather than stay reusable with an
+  // orphaned turn still running.
+  const session = loadBrokerSession(repo);
+  assert.ok(session?.pid, "expected a broker session with a pid");
+  await waitFor(() => {
+    try {
+      process.kill(session.pid, 0);
+      return false;
+    } catch {
+      return true;
+    }
+  }, { timeoutMs: 8000, intervalMs: 100 });
+});
+
+test("broker self-terminates when a client abandons an in-flight start (pre-ACK)", async () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "start-hangs");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "do something"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      CODEX_COMPANION_TURN_STALL_MS: "500",
+      // A high idle window so a broker exit can only be the abandonment teardown,
+      // never the idle timer. There is no turn id to interrupt on a pre-ACK hang,
+      // so the broker (not the companion) must tear itself down — which is what
+      // also covers env-shared brokers.
+      CODEX_COMPANION_BROKER_IDLE_MS: "60000"
+    }
+  });
+  assert.notEqual(result.status, 0);
+
+  const session = loadBrokerSession(repo);
+  assert.ok(session?.pid, "expected a broker session with a pid");
+  // Throws if the broker is still alive after the window (idle is 60s, so a live
+  // broker would mean abandonment teardown did not fire).
+  await waitFor(() => {
+    try {
+      process.kill(session.pid, 0);
+      return false;
+    } catch {
+      return true;
+    }
+  }, { timeoutMs: 8000, intervalMs: 100 });
+});

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -2121,3 +2121,63 @@ test("setup and status honor --cwd when reading shared session runtime", () => {
   assert.equal(payload.sessionRuntime.mode, "shared");
   assert.equal(payload.sessionRuntime.endpoint, "unix:/tmp/fake-broker.sock");
 });
+
+test("task fails fast instead of hanging when the turn never completes", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "never-completes");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const start = Date.now();
+  const result = run("node", [SCRIPT, "task", "do something"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      // Short stall window so the test is fast; the broker it spawns also
+      // self-cleans quickly rather than lingering past the test.
+      CODEX_COMPANION_TURN_STALL_MS: "500",
+      CODEX_COMPANION_BROKER_IDLE_MS: "1000"
+    }
+  });
+  const elapsedMs = Date.now() - start;
+
+  // Without the watchdog this hangs forever on `await state.completion`.
+  assert.notEqual(result.status, 0);
+  assert.match(`${result.stdout}\n${result.stderr}`, /no activity|stall/i);
+  assert.ok(elapsedMs < 30000, `expected a fast stall failure, took ${elapsedMs}ms`);
+});
+
+test("broker self-shuts-down after the idle window with no clients", async () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  const broker = path.join(PLUGIN_ROOT, "scripts", "app-server-broker.mjs");
+  const sessionDir = makeTempDir();
+  const endpoint = `unix:${path.join(sessionDir, "broker.sock")}`;
+  const child = spawn(
+    "node",
+    [broker, "serve", "--endpoint", endpoint, "--cwd", repo, "--pid-file", path.join(sessionDir, "broker.pid")],
+    {
+      env: { ...buildEnv(binDir), CODEX_COMPANION_BROKER_IDLE_MS: "400" },
+      stdio: "ignore"
+    }
+  );
+
+  const exitCode = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("broker did not self-shut-down within the idle window"));
+    }, 10000);
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+
+  assert.equal(exitCode, 0);
+});


### PR DESCRIPTION
## Summary

Stops a Codex run launched through this plugin from appearing "stuck," and makes a failed or abandoned run stop its upstream work instead of lingering. Five focused commits.

### 1. A wedged or dead turn no longer hangs forever (`captureTurn`)
`captureTurn` awaited `state.completion`, which resolves only on a terminal `turn/completed` notification (or the inferred-completion heuristic). It had no timeout and was not coupled to the app-server process, so two real situations left it pending forever:

- **A hung MCP server.** Codex blocks a turn until MCP init settles. A remote MCP server whose endpoint hangs (rather than failing fast) stalls the whole turn until its connection times out — observed at ~225s per turn for one misconfigured server, with the foreground `task` showing no output the entire time.
- **App-server death mid-turn.** `handleExit` only rejects in-flight RPCs; `turn/start` has already resolved by the time we await completion.

The wait is now bounded and **the start RPC is inside the raced work**, so a start that hangs or rejects before ACK is covered too. All env-overridable:
- `CODEX_COMPANION_TURN_STALL_MS` (default 600s) — no inbound traffic at all
- `CODEX_COMPANION_TURN_TIMEOUT_MS` (default 1800s) — absolute per-turn ceiling
- the app-server `exitPromise` — process death rejects immediately

`Promise.race` observes every guard from the outset, so a guard rejecting (even pre-ACK, or after the race settles) is always handled — no `unhandledRejection`.

### 2. Abandoned turns stop their upstream work
Stopping the *wait* is not enough on the shared broker: abandoning a turn there closed only the companion→broker socket, leaving the turn running upstream where it could keep mutating the workspace and collide with the next task. (The direct transport is fine — `close()` kills the app-server.) Two complementary stops:

- When the turn id is known, the companion sends a bounded `turn/interrupt` so the turn ends and the broker stays reusable.
- The **broker self-terminates when the client owning in-progress upstream work disconnects** before it finishes — whether a request is still in flight (a start that never ACKed) or a streaming turn ACKed but never reached `turn/completed` (e.g. the companion crashed before it could interrupt). The broker is single-flight, so no other work is at stake; it closes the upstream app-server and the next task reconnects to a fresh runtime. Covers owned and env-shared brokers uniformly. A turn that completed/was interrupted has already cleared `activeStreamSocket`, so a normal close does not trigger it.

### 3. Brokers self-shut-down when idle
The broker is keyed per-cwd and only reaped on a later `ensureBrokerSession` for the same cwd, with no idle self-shutdown — so a broker for a cwd never revisited (deleted worktree, ended session) ran forever and orphaned processes accumulated. It now exits after `CODEX_COMPANION_BROKER_IDLE_MS` (default 1800s) with no connected clients; `shutdown()` stops accepting connections before closing the upstream, so a client arriving at the teardown boundary is served or cleanly refused (`ECONNREFUSED`, which the companion retries), never accepted-then-failed.

### 4. The rescue forwarder surfaces errors instead of returning empty
`codex-rescue.md` and the `codex-cli-runtime` skill told the forwarder to "return nothing" on failure, masking a real failure as an empty response. It now returns the error output verbatim.

## Tests
- `never-completes`, `start-hangs`, and `start-rejects` fake-codex behaviors.
- Fast-fail on a turn that never completes; on a start RPC that hangs (pre-ACK); and on a start RPC that rejects (pre-ACK, no unhandled rejection).
- A stalled brokered turn is interrupted upstream **and** tears the broker down.
- A pre-ACK abandonment makes the broker self-terminate rather than wait out its idle window.
- Broker idle self-shutdown.

All new tests pass (`node --test`). The watchdog, interrupt, idle-shutdown, and abandonment self-termination were also verified end-to-end against a live Codex install.

## Notes
- No happy-path change: a normal turn resolves via `state.completion` and wins the race; a completed turn clears `activeStreamSocket` before close, so the broker is not torn down.
- Defaults are generous so long legitimate runs are unaffected; the env vars exist for tuning.
- For maintainers: broker teardown (idle or abandonment) closes the listener before the upstream to make the boundary served-or-retryable; a sub-millisecond accept-then-teardown window remains, shared with the existing idle path. Fully closing it would mean a broker-side request-cancellation/fencing primitive in the shared-concurrency model, which felt out of scope here — happy to follow up if you'd prefer it handled in this PR.
