### PR TITLE
fix: keep adversarial review focus text out of option parsing

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -683,6 +683,7 @@ async function handleReviewCommand(argv, config) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["base", "scope", "model", "cwd"],
     booleanOptions: ["json", "background", "wait"],
+    stopParsingOptionsAfterFirstPositional: true,
     aliasMap: {
       m: "model"
     }

--- a/plugins/codex/scripts/lib/args.mjs
+++ b/plugins/codex/scripts/lib/args.mjs
@@ -2,6 +2,7 @@ export function parseArgs(argv, config = {}) {
   const valueOptions = new Set(config.valueOptions ?? []);
   const booleanOptions = new Set(config.booleanOptions ?? []);
   const aliasMap = config.aliasMap ?? {};
+  const stopParsingOptionsAfterFirstPositional = Boolean(config.stopParsingOptionsAfterFirstPositional);
   const options = {};
   const positionals = [];
   let passthrough = false;
@@ -21,6 +22,10 @@ export function parseArgs(argv, config = {}) {
 
     if (!token.startsWith("-") || token === "-") {
       positionals.push(token);
+      if (stopParsingOptionsAfterFirstPositional) {
+        positionals.push(...argv.slice(index + 1));
+        break;
+      }
       continue;
     }
 

--- a/plugins/codex/scripts/lib/args.mjs
+++ b/plugins/codex/scripts/lib/args.mjs
@@ -51,6 +51,10 @@ export function parseArgs(argv, config = {}) {
       }
 
       positionals.push(token);
+      if (stopParsingOptionsAfterFirstPositional) {
+        positionals.push(...argv.slice(index + 1));
+        break;
+      }
       continue;
     }
 
@@ -73,6 +77,10 @@ export function parseArgs(argv, config = {}) {
     }
 
     positionals.push(token);
+    if (stopParsingOptionsAfterFirstPositional) {
+      positionals.push(...argv.slice(index + 1));
+      break;
+    }
   }
 
   return { options, positionals };

--- a/tests/args.test.mjs
+++ b/tests/args.test.mjs
@@ -1,0 +1,15 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseArgs, splitRawArgumentString } from "../plugins/codex/scripts/lib/args.mjs";
+
+test("parseArgs can keep option-like text positional after focus starts", () => {
+  const argv = splitRawArgumentString("--base main review whether --model pm_v6_2 leaks");
+  const { options, positionals } = parseArgs(argv, {
+    valueOptions: ["base", "model"],
+    stopParsingOptionsAfterFirstPositional: true
+  });
+
+  assert.deepEqual(options, { base: "main" });
+  assert.deepEqual(positionals, ["review", "whether", "--model", "pm_v6_2", "leaks"]);
+});

--- a/tests/args.test.mjs
+++ b/tests/args.test.mjs
@@ -13,3 +13,14 @@ test("parseArgs can keep option-like text positional after focus starts", () => 
   assert.deepEqual(options, { base: "main" });
   assert.deepEqual(positionals, ["review", "whether", "--model", "pm_v6_2", "leaks"]);
 });
+
+test("parseArgs can keep leading option-like text positional in focus mode", () => {
+  const argv = splitRawArgumentString("--base main --not --model pm_v6_2 leaks");
+  const { options, positionals } = parseArgs(argv, {
+    valueOptions: ["base", "model"],
+    stopParsingOptionsAfterFirstPositional: true
+  });
+
+  assert.deepEqual(options, { base: "main" });
+  assert.deepEqual(positionals, ["--not", "--model", "pm_v6_2", "leaks"]);
+});


### PR DESCRIPTION
## Summary
- stop review option parsing once the first focus-text positional starts
- keep leading flags like `--base main` parseable for review commands
- add a parser regression test for focus text containing `--model`

Closes #333.

## Tests
- `node --test tests/args.test.mjs tests/commands.test.mjs`
- `npx tsc -p tsconfig.app-server.json --pretty false`