### PR TITLE
fix: reconcile orphaned jobs whose launcher process has died

### DIFF
--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -146,8 +146,85 @@ export function upsertJob(cwd, jobPatch) {
   });
 }
 
+function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return true; // unknown pid -> never treat as dead
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === "ESRCH") {
+      return false; // no such process
+    }
+    return true; // EPERM (process exists, other owner) or anything else -> assume alive
+  }
+}
+
+// A tracked job's completion is written by the launcher process that owns it
+// (see tracked-jobs.mjs::runTrackedJob). If that launcher dies before the turn
+// finishes (cancelled background job, ended session, crash, sleep), the job is
+// frozen at "running"/"queued" with a stale pid forever. Reconcile such orphans
+// to "failed" at read time so /status, /result and /cancel reflect reality.
+function reconcileJobLiveness(jobs) {
+  const changedIds = [];
+  const now = nowIso();
+  const reconciled = jobs.map((job) => {
+    if (job.status !== "running" && job.status !== "queued") {
+      return job;
+    }
+    if (job.pid == null || isProcessAlive(job.pid)) {
+      return job;
+    }
+    changedIds.push(job.id);
+    return {
+      ...job,
+      status: "failed",
+      phase: "failed",
+      pid: null,
+      completedAt: job.completedAt ?? now,
+      updatedAt: now,
+      errorMessage:
+        job.errorMessage ??
+        `Codex job orphaned: launcher process (pid ${job.pid}) is no longer running.`
+    };
+  });
+  return { jobs: reconciled, changedIds };
+}
+
+function persistReconciledJobFile(cwd, job) {
+  const jobFile = resolveJobFile(cwd, job.id);
+  if (!fs.existsSync(jobFile)) {
+    return;
+  }
+  let stored;
+  try {
+    stored = readJobFile(jobFile);
+  } catch {
+    return;
+  }
+  writeJobFile(cwd, job.id, {
+    ...stored,
+    status: job.status,
+    phase: job.phase,
+    pid: null,
+    completedAt: stored.completedAt ?? job.completedAt,
+    errorMessage: stored.errorMessage ?? job.errorMessage
+  });
+}
+
 export function listJobs(cwd) {
-  return loadState(cwd).jobs;
+  const state = loadState(cwd);
+  const { jobs, changedIds } = reconcileJobLiveness(state.jobs);
+  if (changedIds.length > 0) {
+    saveState(cwd, { ...state, jobs });
+    for (const job of jobs) {
+      if (changedIds.includes(job.id)) {
+        persistReconciledJobFile(cwd, job);
+      }
+    }
+  }
+  return jobs;
 }
 
 export function setConfig(cwd, key, value) {

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -5,7 +5,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { makeTempDir } from "./helpers.mjs";
-import { resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState } from "../plugins/codex/scripts/lib/state.mjs";
+import { listJobs, resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState, upsertJob, writeJobFile } from "../plugins/codex/scripts/lib/state.mjs";
 
 test("resolveStateDir uses a temp-backed per-workspace directory", () => {
   const workspace = makeTempDir();
@@ -102,4 +102,53 @@ test("saveState prunes dropped job artifacts when indexed jobs exceed the cap", 
       .flatMap((jobId) => [`${jobId}.json`, `${jobId}.log`])
       .sort()
   );
+});
+
+const DEAD_PID = 2147480000; // implausibly high -> process.kill(pid, 0) raises ESRCH
+
+test("listJobs reconciles a running job whose launcher pid is dead", () => {
+  const workspace = makeTempDir();
+  upsertJob(workspace, { id: "orphan", status: "running", pid: DEAD_PID, workspaceRoot: workspace });
+  writeJobFile(workspace, "orphan", { id: "orphan", status: "running", pid: DEAD_PID, workspaceRoot: workspace });
+
+  const jobs = listJobs(workspace);
+  const orphan = jobs.find((job) => job.id === "orphan");
+
+  assert.equal(orphan.status, "failed");
+  assert.equal(orphan.phase, "failed");
+  assert.equal(orphan.pid, null);
+  assert.equal(typeof orphan.completedAt, "string");
+  assert.match(orphan.errorMessage, /orphaned/);
+
+  // Reconciliation is persisted to both the index and the per-job file.
+  const indexJob = JSON.parse(fs.readFileSync(resolveStateFile(workspace), "utf8")).jobs.find((job) => job.id === "orphan");
+  assert.equal(indexJob.status, "failed");
+  const fileJob = JSON.parse(fs.readFileSync(resolveJobFile(workspace, "orphan"), "utf8"));
+  assert.equal(fileJob.status, "failed");
+});
+
+test("listJobs reconciles a queued job with a dead pid", () => {
+  const workspace = makeTempDir();
+  upsertJob(workspace, { id: "queued-orphan", status: "queued", pid: DEAD_PID, workspaceRoot: workspace });
+
+  const jobs = listJobs(workspace);
+  assert.equal(jobs.find((job) => job.id === "queued-orphan").status, "failed");
+});
+
+test("listJobs leaves a running job with a live pid untouched", () => {
+  const workspace = makeTempDir();
+  upsertJob(workspace, { id: "live", status: "running", pid: process.pid, workspaceRoot: workspace });
+
+  const jobs = listJobs(workspace);
+  assert.equal(jobs.find((job) => job.id === "live").status, "running");
+});
+
+test("listJobs does not reconcile jobs without a pid or already-finished jobs", () => {
+  const workspace = makeTempDir();
+  upsertJob(workspace, { id: "no-pid", status: "queued", workspaceRoot: workspace });
+  upsertJob(workspace, { id: "done", status: "completed", pid: DEAD_PID, workspaceRoot: workspace });
+
+  const jobs = listJobs(workspace);
+  assert.equal(jobs.find((job) => job.id === "no-pid").status, "queued");
+  assert.equal(jobs.find((job) => job.id === "done").status, "completed");
 });


### PR DESCRIPTION
## Problem

A tracked job's completion is written by the launcher process that owns it
(`tracked-jobs.mjs::runTrackedJob`): it marks the job `running`, `await`s the
turn, then writes `completed`/`failed`. If that launcher dies before the turn
finishes — a cancelled background job, an ended Claude Code session, a crash, or
the machine sleeping — the completion write never runs and the job is frozen at
`running`/`queued` with a now-dead pid.

Nothing reconciles this: `buildStatusSnapshot` / `buildSingleJobSnapshot` filter
purely on the stored `status` string, and the only `ESRCH` handling in the
codebase is in the cancel path. So `/codex:status` reports the job `running`
forever and `/codex:result` refuses with "still running". In practice these
orphans accumulate (I had several stuck for days).

## Fix

`listJobs()` — which every status/result/cancel path flows through — now probes
the recorded launcher pid with `process.kill(pid, 0)`:

- `ESRCH` (process gone) → reconcile the job to `failed`, clear the pid, set
  `completedAt` and an explanatory `errorMessage`. The correction is persisted to
  both the state index and the per-job file.
- `EPERM` / unknown → treat as alive (fail safe).
- Jobs without a pid, or already in a terminal state, are left untouched.

A dead background turn now surfaces as `failed` (and is retryable) instead of
hanging `running` indefinitely.

## Tests

Adds coverage in `tests/state.test.mjs`: dead-pid running/queued reconciliation,
persistence across reads, and live-pid / pidless / finished jobs left untouched.
`node --test tests/state.test.mjs` → 7/7 green.

Note: 3 unrelated tests (#63/#65/#67) fail under the aggregate `npm test` due to
pre-existing cross-file state leakage; they pass in isolation and fail
identically on `main` without this change.
