### PR TITLE
[codex] fix hooks config schema

### DIFF
--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "Optional stop-time review gate for Codex Companion.",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary

Removes the unsupported top-level `description` field from `plugins/codex/hooks/hooks.json`.

Codex's plugin hook config parser expects the top-level object to contain only `hooks`, so the released plugin currently fails to parse with:

`unknown field description, expected hooks`

The descriptive metadata already lives in the plugin manifest; the hook config only needs the hook declarations.

## Validation

- `jq 'keys' plugins/codex/hooks/hooks.json` returns only `["hooks"]`
- `npm test` passes (`86/86`)
