### PR TITLE
fix: run the stop-gate review as an ephemeral, untracked one-shot

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -479,6 +479,7 @@ async function executeTaskRun(request) {
     throw new Error("Provide a prompt, a prompt file, piped stdin, or use --resume-last.");
   }
 
+  const persistThread = request.persistThread ?? true;
   const result = await runAppServerTurn(workspaceRoot, {
     resumeThreadId,
     prompt: request.prompt,
@@ -487,8 +488,8 @@ async function executeTaskRun(request) {
     effort: request.effort,
     sandbox: request.write ? "workspace-write" : "read-only",
     onProgress: request.onProgress,
-    persistThread: true,
-    threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
+    persistThread,
+    threadName: resumeThreadId || !persistThread ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
   });
 
   const rawOutput = typeof result.finalMessage === "string" ? result.finalMessage : "";
@@ -771,6 +772,26 @@ async function handleTask(argv) {
     });
     const { payload } = enqueueBackgroundTask(cwd, job, request);
     outputCommandResult(payload, renderQueuedTaskLaunch(payload), options.json);
+    return;
+  }
+
+  if (!resumeLast && String(prompt ?? "").includes(STOP_REVIEW_TASK_MARKER)) {
+    ensureCodexAvailable(cwd);
+    const execution = await executeTaskRun({
+      cwd,
+      model,
+      effort,
+      prompt,
+      write,
+      resumeLast: false,
+      jobId: null,
+      persistThread: false,
+      onProgress: createProgressReporter({ stderr: !options.json })
+    });
+    outputResult(options.json ? execution.payload : execution.rendered, options.json);
+    if (execution.exitStatus !== 0) {
+      process.exitCode = execution.exitStatus;
+    }
     return;
   }
 

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1832,6 +1832,15 @@ test("stop hook runs a stop-time review task and blocks on findings when the rev
   assert.match(fakeState.lastTurnStart.prompt, /Only review the work from the previous Claude turn/i);
   assert.match(fakeState.lastTurnStart.prompt, /I completed the refactor and updated the retry logic\./);
 
+  // The stop-gate review is a one-shot consumed inline by the hook: it must run on an
+  // ephemeral thread (no on-disk rollout) and leave no record in the job catalog.
+  const stopGateThread = fakeState.threads.find((thread) => thread.id === fakeState.lastTurnStart.threadId);
+  assert.ok(stopGateThread, "stop-gate review thread should exist");
+  assert.equal(stopGateThread.ephemeral, true);
+
+  const catalog = JSON.parse(fs.readFileSync(path.join(resolveStateDir(repo), "state.json"), "utf8"));
+  assert.ok(!catalog.jobs.some((job) => job.title === "Codex Stop Gate Review"));
+
   const status = run("node", [SCRIPT, "status"], {
     cwd: repo,
     env: {
@@ -1840,7 +1849,7 @@ test("stop hook runs a stop-time review task and blocks on findings when the rev
     }
   });
   assert.equal(status.status, 0, status.stderr);
-  assert.match(status.stdout, /Codex Stop Gate Review/);
+  assert.doesNotMatch(status.stdout, /Codex Stop Gate Review/);
 });
 
 test("stop hook logs running tasks to stderr without blocking when the review gate is disabled", () => {


### PR DESCRIPTION
## Problem

When the stop-time review gate is enabled, the `Stop` hook runs `codex-companion.mjs task` on every turn. The `task` path always sets `persistThread: true` (persisting the thread as an on-disk rollout) and registers a tracked job in the companion catalog (`state.json` + `jobs/<id>.{json,log}`).

But the stop-gate review is a one-shot: the hook consumes its result inline (parsing `ALLOW:`/`BLOCK:` from stdout) and never resumes or inspects it via `/codex:status`, `/codex:result`, or `--resume-last`. So every turn leaves behind:

- a persisted Codex rollout on disk, and
- a "Codex Stop Gate Review" job that churns through the 50-job catalog cap, pushing out real tasks and reviews.

On a busy machine this accumulates into hundreds of orphaned rollouts and a catalog dominated by stop-gate noise.

## Fix

Route the stop-gate one-shot (already recognized via `STOP_REVIEW_TASK_MARKER`) through an ephemeral, untracked path in `handleTask`:

- `executeTaskRun` now honors `request.persistThread` (default `true`), so the stop-gate passes `persistThread: false` → the thread starts `ephemeral: true` (no rollout) with no persistent thread name.
- The stop-gate skips `runForegroundCommand` / `runTrackedJob`, so no job record or log file is written. The same JSON payload is still printed to stdout, so the hook contract (and the gate's ALLOW/BLOCK behavior) is unchanged.

Normal `/codex:task` runs are unaffected (`persistThread` defaults to `true`).

## Tests

Updated the stop-hook end-to-end test to assert the new contract: the review still runs and blocks on findings, the review thread is `ephemeral`, and no "Codex Stop Gate Review" job is added to the catalog.
