### PR TITLE
fix(hooks): remove unsupported codex hook metadata

### DIFF
--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "Optional stop-time review gate for Codex Companion.",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary
- remove unsupported top-level description metadata from the Codex plugin hooks manifest
- preserve the existing SessionStart, SessionEnd, and Stop hook registrations

## Root Cause
Codex 0.141 parses plugin hook configs strictly and reports an unknown-field error when hooks.json includes top-level metadata fields outside the hooks object.

## Validation
- jq empty plugins/codex/hooks/hooks.json
- npm test