### PR TITLE
fix: align app-server capabilities and thread params with the current codex protocol

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -32,6 +32,7 @@ const DEFAULT_CLIENT_INFO = {
 /** @type {InitializeCapabilities} */
 const DEFAULT_CAPABILITIES = {
   experimentalApi: false,
+  requestAttestation: false,
   optOutNotificationMethods: [
     "item/agentMessage/delta",
     "item/reasoning/summaryTextDelta",

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -60,8 +60,7 @@ function buildThreadParams(cwd, options = {}) {
     approvalPolicy: options.approvalPolicy ?? "never",
     sandbox: options.sandbox ?? "read-only",
     serviceName: SERVICE_NAME,
-    ephemeral: options.ephemeral ?? true,
-    experimentalRawEvents: false
+    ephemeral: options.ephemeral ?? true
   };
 }
 


### PR DESCRIPTION
## Summary

- `npm run build` (the tsc check against the generated app-server types) currently fails on `main` with the latest codex CLI (0.141.0): `InitializeCapabilities` now requires `requestAttestation`, and `experimentalRawEvents` has been removed from `thread/start` params.
- Declares `requestAttestation: false` in the default capabilities and stops sending the removed `experimentalRawEvents` field, so the typecheck passes against the current protocol again.

## Testing

- `npm run build`
- `node --test tests/runtime.test.mjs`
