### PR TITLE
fix: reap zombie 'running' jobs at the resume gate via pid-liveness check (#222, #202)

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -288,6 +288,41 @@ function isActiveJobStatus(status) {
   return status === "queued" || status === "running";
 }
 
+/** Portable liveness probe. ESRCH => dead; EPERM => alive (exists, not ours). */
+function isWorkerAlive(pid) {
+  if (!pid || pid <= 0) return false; // no pid recorded -> cannot be alive
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return Boolean(err && err.code === "EPERM"); // exists but not ours -> alive
+  }
+}
+
+/**
+ * Mark a dead-pid job failed: write state.json (what the gate reads) and mirror
+ * the per-job file so status/result readers stay consistent.
+ */
+function reconcileDeadJob(workspaceRoot, job) {
+  const patch = {
+    id: job.id,
+    status: "failed",
+    pid: null,
+    errorMessage: "Worker process not alive; reconciled by resume gate.",
+    completedAt: nowIso()
+  };
+  // upsertJob writes state.json, which is what the gate (and resolution) reads.
+  upsertJob(workspaceRoot, patch);
+  // Best-effort: keep the per-job file consistent so /codex:status and result
+  // readers don't show a stale "running". The state.json write above is the
+  // authoritative un-stick; a per-job write failure is non-fatal.
+  try {
+    writeJobFile(workspaceRoot, job.id, { ...job, ...patch });
+  } catch {
+    // ignore: state.json write is authoritative
+  }
+}
+
 function getCurrentClaudeSessionId() {
   return process.env[SESSION_ID_ENV] ?? null;
 }
@@ -337,7 +372,16 @@ async function resolveLatestTrackedTaskThread(cwd, options = {}) {
   const visibleJobs = filterJobsForCurrentClaudeSession(jobs);
   const activeTask = visibleJobs.find((job) => job.jobClass === "task" && (job.status === "queued" || job.status === "running"));
   if (activeTask) {
-    throw new Error(`Task ${activeTask.id} is still running. Use /codex:status before continuing it.`);
+    if (isWorkerAlive(activeTask.pid)) {
+      throw new Error(`Task ${activeTask.id} is still running. Use /codex:status before continuing it.`);
+    }
+    // Worker pid is dead -> the "running" record is a zombie. Reconcile it so it
+    // never blocks the gate again, then fall through to normal resolution.
+    reconcileDeadJob(workspaceRoot, activeTask);
+    // Reflect the reconcile in the in-memory snapshot too, so the resolution
+    // below sees a non-active job in THIS call (not only on the next one).
+    activeTask.status = "failed";
+    activeTask.pid = null;
   }
 
   const trackedTask = findLatestResumableTaskJob(visibleJobs);


### PR DESCRIPTION
### Problem
When a Codex task worker crashes or is killed externally, its job record stays `status: "running"` forever. The next `task`/resume call in that cwd then throws and is permanently blocked:

> `Task <id> is still running. Use /codex:status before continuing it.`

`resolveLatestTrackedTaskThread()` finds any `queued|running` job and throws **without checking whether the worker process is actually alive** — there is no pid-liveness check, so a dead worker's record is indelible. (Root cause: #222; symptoms: #202, #164.)

### Fix
Before the blocking throw, probe the worker pid:

1. `process.kill(pid, 0)` → `ESRCH` ⇒ dead, `EPERM` ⇒ alive-but-not-ours (treat as alive). Portable across macOS/Linux/Windows via libuv; no new dependency.
2. If the worker is **dead**, reconcile the job to `failed` — writing `state.json` (the store the gate reads) plus a best-effort per-job-file mirror for status/result readers — then mutate the in-memory snapshot and fall through to normal resolution.
3. Only throw the "still running" error if the worker is **actually alive** (live jobs are unaffected).

### Why minimal (vs #216)
This touches only the gate function: ~12 lines + two small helpers. It does **not** add a deadline/timeout, a background reaper, or a daemon — just "don't block on a provably-dead worker." Builds on the approach in the now-conflicting #216, scoped to the surgical, conflict-free subset.

### Known limitation (PID reuse)
A PID-based probe inherits the standard caveat: if the OS recycles the crashed worker's PID before the next `task` call and an unrelated process holds it, the probe briefly treats the zombie as alive. It self-corrects on a later call, and the dominant case (immediate crash) is handled correctly. A future hardening could store the job id in a pidfile and verify identity, not just existence — out of scope here.

### Test
- Spawn a task, `kill -9` the worker, run another task in the same cwd → previously throws forever; now the dead job is reconciled to `failed` and the new task proceeds.
- Live job unaffected: a running worker still correctly blocks with the original message.

`node --check` passes on the patched file.