### PR TITLE
[Night Shift] docs: add --prompt-file guidance for shell-safe prompt passing

### DIFF
--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -9,7 +9,19 @@ user-invocable: false
 Use this skill only inside the `codex:codex-rescue` subagent.
 
 Primary helper:
-- `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task "<raw arguments>"`
+- `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task --prompt-file /tmp/codex-prompt.txt [flags]`
+
+Prompt passing:
+- Always use `--prompt-file` instead of positional arguments for shell-safe prompt passing.
+- Write the prompt to a temp file first, then reference it:
+  ```bash
+  cat << 'EOF' > /tmp/codex-prompt.txt
+  Fix the authentication bug in src/auth.ts where tokens expire prematurely
+  EOF
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task --prompt-file /tmp/codex-prompt.txt --write
+  ```
+- This avoids shell escaping issues with quotes, backticks, dollar signs, and special characters in prompts.
+- Positional arguments (`task "prompt text"`) still work but are fragile when prompts contain shell metacharacters.
 
 Execution rules:
 - The rescue subagent is a forwarder, not an orchestrator. Its only job is to invoke `task` once and return that stdout unchanged.

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -186,8 +186,9 @@ test("internal docs use task terminology for rescue runs", () => {
   const promptingSkill = read("skills/gpt-5-4-prompting/SKILL.md");
   const promptRecipes = read("skills/gpt-5-4-prompting/references/codex-prompt-recipes.md");
 
-  assert.match(runtimeSkill, /codex-companion\.mjs" task "<raw arguments>"/);
+  assert.match(runtimeSkill, /codex-companion\.mjs" task --prompt-file/);
   assert.match(runtimeSkill, /Use `task` for every rescue request/i);
+  assert.match(runtimeSkill, /Always use `--prompt-file` instead of positional arguments/i);
   assert.match(runtimeSkill, /task --resume-last/i);
   assert.match(promptingSkill, /Use `task` when the task is diagnosis/i);
   assert.match(promptRecipes, /Codex task prompts/i);


### PR DESCRIPTION
## Summary
- Updated `plugins/codex/skills/codex-cli-runtime/SKILL.md` to instruct agents to use `--prompt-file` instead of positional arguments for shell-safe prompt passing
- Added example showing how to write prompt to temp file and use `--prompt-file` flag
- Updated test assertions to verify new documentation pattern

## Changes
- **SKILL.md**: Added "Prompt passing" section with:
  - Instruction to always use `--prompt-file` for shell safety
  - Example using heredoc to write prompt to `/tmp/codex-prompt.txt`
  - Explanation of why this avoids shell escaping issues
  - Note that positional arguments still work but are fragile
- **tests/commands.test.mjs**: Updated test to match new `--prompt-file` documentation

## Test plan
- [x] All 86 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)