### PR TITLE
Remove unsupported hooks description field

### DIFF
--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "Optional stop-time review gate for Codex Companion.",
   "hooks": {
     "SessionStart": [
       {


### PR DESCRIPTION
## Summary
- remove the top-level `description` field from `plugins/codex/hooks/hooks.json`
- keep hook behavior unchanged

## Why
Strict hook config loaders reject the extra top-level field with `unknown field description, expected hooks`.

## Validation
- `jq -e '.hooks and (keys == ["hooks"])' plugins/codex/hooks/hooks.json`