### PR TITLE
fix(app-server): pass `-c model="..."` to `codex app-server` so options.model takes effect

### DIFF
--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -52,7 +52,7 @@ async function main() {
   }
 
   const { options } = parseArgs(argv, {
-    valueOptions: ["cwd", "pid-file", "endpoint"]
+    valueOptions: ["cwd", "pid-file", "endpoint", "model"]
   });
 
   if (!options.endpoint) {
@@ -65,7 +65,7 @@ async function main() {
   const pidFile = options["pid-file"] ? path.resolve(options["pid-file"]) : null;
   writePidFile(pidFile);
 
-  const appClient = await CodexAppServerClient.connect(cwd, { disableBroker: true });
+  const appClient = await CodexAppServerClient.connect(cwd, { disableBroker: true, model: options.model });
   let activeRequestSocket = null;
   let activeStreamSocket = null;
   let activeStreamThreadIds = null;

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -186,7 +186,11 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
   }
 
   async initialize() {
-    this.proc = spawn("codex", ["app-server"], {
+    const args = ["app-server"];
+    if (this.options.model) {
+      args.push("-c", `model=${JSON.stringify(String(this.options.model))}`);
+    }
+    this.proc = spawn("codex", args, {
       cwd: this.cwd,
       env: this.options.env,
       stdio: ["pipe", "pipe", "pipe"],

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -338,7 +338,7 @@ export class CodexAppServerClient {
     if (!options.disableBroker) {
       brokerEndpoint = options.brokerEndpoint ?? options.env?.[BROKER_ENDPOINT_ENV] ?? process.env[BROKER_ENDPOINT_ENV] ?? null;
       if (!brokerEndpoint) {
-        const brokerSession = await ensureBrokerSession(cwd, { env: options.env });
+        const brokerSession = await ensureBrokerSession(cwd, { env: options.env, model: options.model });
         brokerEndpoint = brokerSession?.endpoint ?? null;
       }
     }

--- a/plugins/codex/scripts/lib/broker-lifecycle.mjs
+++ b/plugins/codex/scripts/lib/broker-lifecycle.mjs
@@ -56,9 +56,13 @@ export async function sendBrokerShutdown(endpoint) {
   });
 }
 
-export function spawnBrokerProcess({ scriptPath, cwd, endpoint, pidFile, logFile, env = process.env }) {
+export function spawnBrokerProcess({ scriptPath, cwd, endpoint, pidFile, logFile, model, env = process.env }) {
   const logFd = fs.openSync(logFile, "a");
-  const child = spawn(process.execPath, [scriptPath, "serve", "--endpoint", endpoint, "--cwd", cwd, "--pid-file", pidFile], {
+  const args = [scriptPath, "serve", "--endpoint", endpoint, "--cwd", cwd, "--pid-file", pidFile];
+  if (model) {
+    args.push("--model", String(model));
+  }
+  const child = spawn(process.execPath, args, {
     cwd,
     env,
     detached: true,
@@ -143,6 +147,7 @@ export async function ensureBrokerSession(cwd, options = {}) {
     endpoint,
     pidFile,
     logFile,
+    model: options.model,
     env: options.env ?? process.env
   });
 

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -604,10 +604,10 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
   }
 }
 
-async function withAppServer(cwd, fn) {
+async function withAppServer(cwd, fn, clientOptions = {}) {
   let client = null;
   try {
-    client = await CodexAppServerClient.connect(cwd);
+    client = await CodexAppServerClient.connect(cwd, clientOptions);
     const result = await fn(client);
     await client.close();
     return result;
@@ -626,7 +626,7 @@ async function withAppServer(cwd, fn) {
       throw error;
     }
 
-    const directClient = await CodexAppServerClient.connect(cwd, { disableBroker: true });
+    const directClient = await CodexAppServerClient.connect(cwd, { ...clientOptions, disableBroker: true });
     try {
       return await fn(directClient);
     } finally {
@@ -823,7 +823,7 @@ export async function runAppServerReview(cwd, options = {}) {
       error: turnState.error,
       stderr: cleanCodexStderr(client.stderr)
     };
-  });
+  }, { model: options.model });
 }
 
 export async function runAppServerTurn(cwd, options = {}) {
@@ -890,7 +890,7 @@ export async function runAppServerTurn(cwd, options = {}) {
       touchedFiles: collectTouchedFiles(turnState.fileChanges),
       commandExecutions: turnState.commandExecutions
     };
-  });
+  }, { model: options.model });
 }
 
 export async function findLatestTaskThread(cwd) {


### PR DESCRIPTION
## Summary

`runAppServerTurn` / `runAppServerReview` accept a `model` option that is forwarded to the `thread/start` and `turn/start` requests. However, the spawn of `codex app-server` itself (in `lib/app-server.mjs`) never adds a corresponding `-c model=\"…\"` config override, so the codex CLI session boots with the **CLI's built-in default model**.

On a ChatGPT account where the default (`gpt-5.3-codex`) is unsupported, every task launched via:

```bash
node scripts/codex-companion.mjs task --background --model gpt-5.4 "<prompt>"
```

fails during the first `turn/start` with:

```
Codex error: 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.
```

even though the user explicitly passed `--model gpt-5.4`.

`codex exec --model gpt-5.4 "say hi"` works fine — the regression is specific to the app-server path used by the companion.

## Fix

Thread the `model` option through to the spawn site:

- **`lib/app-server.mjs`** — when `this.options.model` is set, add `-c model=${JSON.stringify(model)}` to the spawned argv. JSON quoting yields a valid TOML string literal the codex CLI's `-c` parser accepts unambiguously (e.g. `model=\"gpt-5.4\"`).
- **`lib/codex.mjs` `withAppServer`** — accept a third `clientOptions` argument and forward it to `CodexAppServerClient.connect` for both the primary and the direct-retry connection.
- **`lib/codex.mjs` `runAppServerReview` / `runAppServerTurn`** — pass `{ model: options.model }` through to `withAppServer`.

When the caller does not set `options.model`, behavior is unchanged (no `-c` flag is appended).

`interruptAppServerTurn` and `findLatestTaskThread` still create their own short-lived clients without a model override; they are not exercised by the failing `task --background --model` path and are left for a follow-up.

## Test plan

Local verification on macOS / codex-cli 0.130.0:

- [x] Before this patch: `node companion.mjs task --background --fresh --model gpt-5.4 \"say hi\"` → job fails with the `gpt-5.3-codex is not supported` error during `turn/start`.
- [x] After this patch: identical command → status=`completed`, ~7 s, assistant returns \"Hi\". Job id `task-mqzvgcqz-7o506t`, thread `019f15cb-b60a-7013-ace1-ed235e61de96`.
- [x] When `--model` is omitted, no `-c model=...` flag is appended (verified by inspecting the spawned argv) — behavior unchanged for callers that rely on the CLI default.

## Notes

- Originally surfaced while debugging tester orchestration in [hiirott/claude-config#2](https://github.com/hiirott/claude-config/issues/2).
- Broker mode is also covered: the broker daemon spawns its inner app-server via the same `CodexAppServerClient.connect(..., { disableBroker: true })` path in `app-server-broker.mjs`, so this fix is effective for both Spawned and Broker transports.