### PR TITLE
fix: preserve taskkill flags under Git Bash

### DIFF
--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -54,6 +54,14 @@ function looksLikeMissingProcessMessage(text) {
   return /not found|no running instance|cannot find|does not exist|no such process/i.test(text);
 }
 
+function envWithoutMsysPathConversion(env) {
+  return {
+    ...(env ?? process.env),
+    MSYS_NO_PATHCONV: "1",
+    MSYS2_ARG_CONV_EXCL: "*"
+  };
+}
+
 export function terminateProcessTree(pid, options = {}) {
   if (!Number.isFinite(pid)) {
     return { attempted: false, delivered: false, method: null };
@@ -66,7 +74,8 @@ export function terminateProcessTree(pid, options = {}) {
   if (platform === "win32") {
     const result = runCommandImpl("taskkill", ["/PID", String(pid), "/T", "/F"], {
       cwd: options.cwd,
-      env: options.env
+      // Keep taskkill's /PID and /T flags intact when Claude Code runs under Git Bash/MSYS.
+      env: envWithoutMsysPathConversion(options.env)
     });
 
     if (!result.error && result.status === 0) {

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -7,8 +7,9 @@ test("terminateProcessTree uses taskkill on Windows", () => {
   let captured = null;
   const outcome = terminateProcessTree(1234, {
     platform: "win32",
-    runCommandImpl(command, args) {
-      captured = { command, args };
+    env: { PATH: "C:\\Windows\\System32", SHELL: "C:\\Program Files\\Git\\bin\\bash.exe" },
+    runCommandImpl(command, args, options) {
+      captured = { command, args, options };
       return {
         command,
         args,
@@ -26,7 +27,16 @@ test("terminateProcessTree uses taskkill on Windows", () => {
 
   assert.deepEqual(captured, {
     command: "taskkill",
-    args: ["/PID", "1234", "/T", "/F"]
+    args: ["/PID", "1234", "/T", "/F"],
+    options: {
+      cwd: undefined,
+      env: {
+        PATH: "C:\\Windows\\System32",
+        SHELL: "C:\\Program Files\\Git\\bin\\bash.exe",
+        MSYS_NO_PATHCONV: "1",
+        MSYS2_ARG_CONV_EXCL: "*"
+      }
+    }
   });
   assert.equal(outcome.delivered, true);
   assert.equal(outcome.method, "taskkill");


### PR DESCRIPTION
## Summary
- scope MSYS path-conversion opt-out to the Windows `taskkill` process-tree cleanup call
- preserve `/PID`, `/T`, and `/F` when Claude Code is launched from Git Bash/MSYS
- cover the Windows helper path with a regression assertion for the child env

Addresses #331. Related to #409.

## Tests
- `node --test tests\process.test.mjs`
- `git diff --check`

Not run: full `npm.cmd test` timed out locally on Windows while runtime broker fixtures kept running; this change is covered by the focused process helper test.