### PR TITLE
fix(stop-review-gate): honor stop_hook_active to prevent infinite Stop loop

### DIFF
--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -141,6 +141,13 @@ function runStopReview(cwd, input = {}) {
 
 function main() {
   const input = readHookInput();
+  // Prevent infinite Stop-hook loops: Claude Code sets stop_hook_active=true on a
+  // Stop event that fires because a previous Stop hook blocked. Re-running the
+  // review here (and re-blocking, or crashing) would loop until the block cap.
+  // Honor the contract and allow the turn to end on the continuation pass.
+  if (input.stop_hook_active) {
+    return;
+  }
   const cwd = input.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd();
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const config = getConfig(workspaceRoot);


### PR DESCRIPTION
## Problem

The `Stop` hook (`plugins/codex/scripts/stop-review-gate-hook.mjs`) re-runs the stop-time review on **every** `Stop` event — including the continuation `Stop` events Claude Code fires *because the previous Stop hook blocked*. When the review returns `BLOCK`, or when the underlying `codex-companion task` review job fails (exit 1, empty output), the hook blocks again on every retry, producing an infinite loop that only terminates when Claude Code's `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` (default 9) is hit and the turn is force-ended.

Observed: a review task failing with `{"status":1,"rawOutput":"","touchedFiles":[],"reasoningSummary":[]}` re-blocked the turn indefinitely, unrelated to whether the current turn made any reviewable code changes.

## Fix

Claude Code sets `stop_hook_active: true` on the hook input for `Stop` events that fire as a continuation of a prior blocking Stop hook. Per the Claude Code hook contract, a Stop hook must return success on those events rather than re-block. This adds that guard at the top of `main()`:

```js
if (input.stop_hook_active) {
  return;
}
```

The gate still runs normally on the first `Stop` of a turn (`stop_hook_active` absent/false), so the review it is designed to perform is unchanged — the change only prevents the re-entrant loop. Verified: feeding `{"stop_hook_active":true}` now exits 0 with no `block` decision.
