### PR TITLE
fix: defer getWorkingTreeState call and clean up process exit handling

### DIFF
--- a/plugins/codex/scripts/lib/git.mjs
+++ b/plugins/codex/scripts/lib/git.mjs
@@ -136,7 +136,6 @@ export function resolveReviewTarget(cwd, options = {}) {
 
   const requestedScope = options.scope ?? "auto";
   const baseRef = options.base ?? null;
-  const state = getWorkingTreeState(cwd);
   const supportedScopes = new Set(["auto", "working-tree", "branch"]);
 
   if (baseRef) {
@@ -171,6 +170,8 @@ export function resolveReviewTarget(cwd, options = {}) {
       explicit: true
     };
   }
+
+  const state = getWorkingTreeState(cwd);
 
   if (state.isDirty) {
     return {

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { resolveWorkspaceRoot } from "./workspace.mjs";
+import { nowIso } from "./tracked-jobs.mjs";
 
 const STATE_VERSION = 1;
 const PLUGIN_DATA_ENV = "CLAUDE_PLUGIN_DATA";
@@ -11,10 +12,6 @@ const FALLBACK_STATE_ROOT_DIR = path.join(os.tmpdir(), "codex-companion");
 const STATE_FILE_NAME = "state.json";
 const JOBS_DIR_NAME = "jobs";
 const MAX_JOBS = 50;
-
-function nowIso() {
-  return new Date().toISOString();
-}
 
 function defaultState() {
   return {

--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -129,5 +129,5 @@ async function main() {
 
 main().catch((error) => {
   process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
A few things I noticed while reading through the code:

- `resolveReviewTarget()` was calling `getWorkingTreeState(cwd)` right at the top, which runs 3 git commands — but if `--base` is provided, it returns immediately without ever using the result. moved the call down to just before it's actually needed, so those git commands don't run for nothing
- the session lifecycle hook was using `process.exit(1)` in its catch handler, which kills the process before stderr has time to flush. the main companion script already uses `process.exitCode = 1` correctly, so matched the hook to the same pattern
- `nowIso()` was defined identically in both `state.mjs` and `tracked-jobs.mjs` — consolidated to a single import from tracked-jobs