### PR TITLE
feat: forward CODEX_PLUGIN_CC_ARGS to codex launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,27 @@ Your configuration will be picked up based on:
 
 Check out the Codex docs for more [configuration options](https://developers.openai.com/codex/config-reference).
 
+### Passing Extra Codex CLI Arguments
+
+If you want the plugin to forward extra arguments to every Codex launch, set the `CODEX_PLUGIN_CC_ARGS` environment variable in your shell. Whatever you put there is parsed like a shell command line and prepended to each `codex` invocation the plugin makes (the app-server runtime and the availability checks).
+
+This is the easiest way to force a custom provider without editing `config.toml`:
+
+```bash
+export CODEX_PLUGIN_CC_ARGS='-c model_provider=my-provider'
+```
+
+results in the plugin running `codex -c model_provider=my-provider app-server`.
+
+You can pass multiple flags, and quoting is supported:
+
+```bash
+export CODEX_PLUGIN_CC_ARGS="-c model_provider=my-provider -c 'base_url=https://example/v1'"
+```
+
+> [!NOTE]
+> The variable is read when a Codex runtime is started. If a shared runtime is already active for the session, change the value and start a fresh session (or cancel the running jobs) so the new arguments take effect.
+
 ### Moving The Work Over To Codex
 
 Delegated tasks and any [stop gate](#what-does-the-review-gate-do) run can also be directly resumed inside Codex by running `codex resume` either with the specific session ID you received from running `/codex:result` or `/codex:status` or by selecting it from the list.

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ export CODEX_PLUGIN_CC_ARGS="-c model_provider=my-provider -c 'base_url=https://
 ```
 
 > [!NOTE]
-> The variable is read when a Codex runtime is started. If a shared runtime is already active for the session, change the value and start a fresh session (or cancel the running jobs) so the new arguments take effect.
+> The variable is read when a Codex runtime is started. If a shared runtime is already active, change the value and start a fresh session so the new arguments take effect.
 
 ### Moving The Work Over To Codex
 

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -15,6 +15,7 @@ import readline from "node:readline";
 import { parseBrokerEndpoint } from "./broker-endpoint.mjs";
 import { ensureBrokerSession, loadBrokerSession } from "./broker-lifecycle.mjs";
 import { terminateProcessTree } from "./process.mjs";
+import { getCodexPassthroughArgs } from "./args.mjs";
 
 const PLUGIN_MANIFEST_URL = new URL("../../.claude-plugin/plugin.json", import.meta.url);
 const PLUGIN_MANIFEST = JSON.parse(fs.readFileSync(PLUGIN_MANIFEST_URL, "utf8"));
@@ -187,9 +188,11 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
   }
 
   async initialize() {
-    this.proc = spawn("codex", ["app-server"], {
+    const childEnv = this.options.env ?? process.env;
+    const passthroughArgs = getCodexPassthroughArgs(childEnv);
+    this.proc = spawn("codex", [...passthroughArgs, "app-server"], {
       cwd: this.cwd,
-      env: this.options.env ?? process.env,
+      env: childEnv,
       stdio: ["pipe", "pipe", "pipe"],
       shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
       windowsHide: true

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -14,7 +14,7 @@ import { spawn } from "node:child_process";
 import readline from "node:readline";
 import { parseBrokerEndpoint } from "./broker-endpoint.mjs";
 import { ensureBrokerSession, loadBrokerSession } from "./broker-lifecycle.mjs";
-import { terminateProcessTree } from "./process.mjs";
+import { prepareSpawnCommand, terminateProcessTree } from "./process.mjs";
 import { getCodexPassthroughArgs } from "./args.mjs";
 
 const PLUGIN_MANIFEST_URL = new URL("../../.claude-plugin/plugin.json", import.meta.url);
@@ -190,11 +190,12 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
   async initialize() {
     const childEnv = this.options.env ?? process.env;
     const passthroughArgs = getCodexPassthroughArgs(childEnv);
-    this.proc = spawn("codex", [...passthroughArgs, "app-server"], {
+    const invocation = prepareSpawnCommand("codex", [...passthroughArgs, "app-server"], { env: childEnv });
+    this.proc = spawn(invocation.command, invocation.args, {
       cwd: this.cwd,
       env: childEnv,
       stdio: ["pipe", "pipe", "pipe"],
-      shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
+      shell: invocation.shell,
       windowsHide: true
     });
 
@@ -248,9 +249,8 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
       this.proc.stdin.end();
       setTimeout(() => {
         if (this.proc && !this.proc.killed && this.proc.exitCode === null) {
-          // On Windows with shell: true, the direct child is cmd.exe.
-          // Use terminateProcessTree to kill the entire tree including
-          // the grandchild node process.
+          // On Windows the direct child may be a shell used to launch a command
+          // shim. Terminate the full tree, including the Codex grandchild.
           if (process.platform === "win32") {
             try {
               terminateProcessTree(this.proc.pid);

--- a/plugins/codex/scripts/lib/args.mjs
+++ b/plugins/codex/scripts/lib/args.mjs
@@ -73,6 +73,25 @@ export function parseArgs(argv, config = {}) {
   return { options, positionals };
 }
 
+export const CODEX_PLUGIN_ARGS_ENV = "CODEX_PLUGIN_CC_ARGS";
+
+/**
+ * Reads extra codex CLI arguments from the CODEX_PLUGIN_CC_ARGS environment
+ * variable and returns them as an argv array. These are prepended to every
+ * codex invocation (e.g. `codex -c model_provider=my-provider app-server`),
+ * letting users force global config overrides without editing config.toml.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {string[]}
+ */
+export function getCodexPassthroughArgs(env = process.env) {
+  const raw = env?.[CODEX_PLUGIN_ARGS_ENV];
+  if (typeof raw !== "string" || !raw.trim()) {
+    return [];
+  }
+  return splitRawArgumentString(raw);
+}
+
 export function splitRawArgumentString(raw) {
   const tokens = [];
   let current = "";

--- a/plugins/codex/scripts/lib/args.mjs
+++ b/plugins/codex/scripts/lib/args.mjs
@@ -92,11 +92,17 @@ export function getCodexPassthroughArgs(env = process.env) {
   return splitRawArgumentString(raw);
 }
 
+// Inside double quotes a backslash is only special before these characters
+// (POSIX); before anything else it stays literal, so `"C:\work\repo"` is kept
+// intact while `"a\"b"` still escapes the inner quote.
+const DOUBLE_QUOTE_ESCAPABLE = new Set(["\"", "\\", "$", "`"]);
+
 export function splitRawArgumentString(raw) {
   const tokens = [];
   let current = "";
   let quote = null;
   let escaping = false;
+  let doubleQuoteEscaping = false;
 
   for (const character of raw) {
     if (escaping) {
@@ -105,17 +111,37 @@ export function splitRawArgumentString(raw) {
       continue;
     }
 
-    if (character === "\\") {
-      escaping = true;
-      continue;
-    }
-
-    if (quote) {
-      if (character === quote) {
+    // Inside single quotes everything is literal (POSIX semantics), including
+    // backslashes — so a Windows path like 'C:\work\repo' survives intact.
+    if (quote === "'") {
+      if (character === "'") {
         quote = null;
       } else {
         current += character;
       }
+      continue;
+    }
+
+    if (quote === "\"") {
+      if (doubleQuoteEscaping) {
+        current += DOUBLE_QUOTE_ESCAPABLE.has(character) ? character : `\\${character}`;
+        doubleQuoteEscaping = false;
+        continue;
+      }
+      if (character === "\\") {
+        doubleQuoteEscaping = true;
+        continue;
+      }
+      if (character === "\"") {
+        quote = null;
+      } else {
+        current += character;
+      }
+      continue;
+    }
+
+    if (character === "\\") {
+      escaping = true;
       continue;
     }
 
@@ -133,6 +159,10 @@ export function splitRawArgumentString(raw) {
     }
 
     current += character;
+  }
+
+  if (doubleQuoteEscaping) {
+    current += "\\";
   }
 
   if (escaping) {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -43,6 +43,7 @@ import { readJsonFile } from "./fs.mjs";
 import { BROKER_BUSY_RPC_CODE, BROKER_ENDPOINT_ENV, CodexAppServerClient } from "./app-server.mjs";
 import { loadBrokerSession } from "./broker-lifecycle.mjs";
 import { binaryAvailable } from "./process.mjs";
+import { getCodexPassthroughArgs } from "./args.mjs";
 
 const SERVICE_NAME = "claude_code_codex_plugin";
 const TASK_THREAD_PREFIX = "Codex Companion Task";
@@ -884,12 +885,13 @@ async function getCodexAuthStatusFromClient(client, cwd) {
 }
 
 export function getCodexAvailability(cwd) {
-  const versionStatus = binaryAvailable("codex", ["--version"], { cwd });
+  const passthroughArgs = getCodexPassthroughArgs();
+  const versionStatus = binaryAvailable("codex", [...passthroughArgs, "--version"], { cwd });
   if (!versionStatus.available) {
     return versionStatus;
   }
 
-  const appServerStatus = binaryAvailable("codex", ["app-server", "--help"], { cwd });
+  const appServerStatus = binaryAvailable("codex", [...passthroughArgs, "app-server", "--help"], { cwd });
   if (!appServerStatus.available) {
     return {
       available: false,

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -1,15 +1,71 @@
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
+const WINDOWS_CMD_META_CHARACTERS = /([()\][%!^"`<>&|;, *?])/g;
+
+function readEnvValue(env, name) {
+  const matchingKey = Object.keys(env ?? {}).find((key) => key.toUpperCase() === name.toUpperCase());
+  return matchingKey ? env[matchingKey] : undefined;
+}
+
+function quotePosixShellArgument(argument) {
+  return `'${String(argument).replaceAll("'", `'\\''`)}'`;
+}
+
+function quoteCmdShellCommand(command) {
+  return String(command).replace(WINDOWS_CMD_META_CHARACTERS, "^$1");
+}
+
+function quoteCmdShellArgument(argument) {
+  let quoted = String(argument);
+
+  // Preserve quotes and trailing backslashes when cmd.exe hands this argument
+  // to the target process, then protect cmd metacharacters from interpretation.
+  quoted = quoted.replace(/(\\*)"/g, (_match, backslashes) => `${backslashes}${backslashes}\\"`);
+  quoted = quoted.replace(/(\\+)$/, "$1$1");
+  quoted = `"${quoted}"`;
+  return quoted.replace(WINDOWS_CMD_META_CHARACTERS, "^$1");
+}
+
+function isCmdShell(shell) {
+  return shell === true || /(?:^|[\\/])cmd(?:\.exe)?$/i.test(String(shell));
+}
+
+/**
+ * Builds a spawn invocation that preserves argv boundaries when Windows needs
+ * a shell to launch command shims such as codex.cmd and npm.cmd.
+ */
+export function prepareSpawnCommand(command, args = [], options = {}) {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") {
+    return { command, args: [...args], shell: false };
+  }
+
+  const env = options.env ?? process.env;
+  const configuredShell = options.shell ?? readEnvValue(env, "SHELL") ?? readEnvValue(process.env, "SHELL") ?? true;
+  if (!configuredShell) {
+    return { command, args: [...args], shell: false };
+  }
+
+  const commandLine = isCmdShell(configuredShell)
+    ? [quoteCmdShellCommand(command), ...args.map(quoteCmdShellArgument)].join(" ")
+    : [command, ...args].map(quotePosixShellArgument).join(" ");
+
+  // Pass a single, fully quoted command string. Node otherwise joins a command
+  // and args with spaces before handing them to the shell, losing argv bounds.
+  return { command: commandLine, args: [], shell: configuredShell };
+}
+
 export function runCommand(command, args = [], options = {}) {
-  const result = spawnSync(command, args, {
+  const invocation = prepareSpawnCommand(command, args, { env: options.env });
+  const result = spawnSync(invocation.command, invocation.args, {
     cwd: options.cwd,
     env: options.env,
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
     stdio: options.stdio ?? "pipe",
-    shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
+    shell: invocation.shell,
     windowsHide: true
   });
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -31,6 +31,26 @@ function isCmdShell(shell) {
   return shell === true || /(?:^|[\\/])cmd(?:\.exe)?$/i.test(String(shell));
 }
 
+function preparePowerShellShimCommand(command, args) {
+  const payload = Buffer.from(JSON.stringify({ command, args }), "utf8").toString("base64");
+  const script = [
+    `$json = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${payload}'))`,
+    "$spec = $json | ConvertFrom-Json",
+    "$name = [string]$spec.command",
+    "$launcher = Get-Command ($name + '.exe') -CommandType Application -ErrorAction SilentlyContinue",
+    "if (-not $launcher) { $launcher = Get-Command ($name + '.ps1') -CommandType ExternalScript -ErrorAction Stop }",
+    "$launchArgs = @($spec.args)",
+    "& $launcher.Source @launchArgs",
+    "exit $LASTEXITCODE"
+  ].join("; ");
+
+  return {
+    command: "powershell.exe",
+    args: ["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
+    shell: false
+  };
+}
+
 /**
  * Builds a spawn invocation that preserves argv boundaries when Windows needs
  * a shell to launch command shims such as codex.cmd and npm.cmd.
@@ -45,6 +65,14 @@ export function prepareSpawnCommand(command, args = [], options = {}) {
   const configuredShell = options.shell ?? readEnvValue(env, "SHELL") ?? readEnvValue(process.env, "SHELL") ?? true;
   if (!configuredShell) {
     return { command, args: [...args], shell: false };
+  }
+
+  // cmd.exe expands %NAME% before it processes caret escapes, so percent signs
+  // cannot be safely embedded in its command string. Standard npm installs
+  // provide a PowerShell shim alongside the .cmd shim; send argv as base64 JSON
+  // and splat the decoded values so no user content is parsed as shell source.
+  if (isCmdShell(configuredShell) && [command, ...args].some((value) => String(value).includes("%"))) {
+    return preparePowerShellShimCommand(command, args);
   }
 
   const commandLine = isCmdShell(configuredShell)

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -31,7 +31,11 @@ function isCmdShell(shell) {
   return shell === true || /(?:^|[\\/])cmd(?:\.exe)?$/i.test(String(shell));
 }
 
-function preparePowerShellShimCommand(command, args) {
+function isPowerShell(shell) {
+  return /(?:^|[\\/])(?:powershell|pwsh)(?:\.exe)?$/i.test(String(shell));
+}
+
+function preparePowerShellShimCommand(command, args, shell = "powershell.exe") {
   const payload = Buffer.from(JSON.stringify({ command, args }), "utf8").toString("base64");
   const script = [
     `$json = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${payload}'))`,
@@ -45,7 +49,7 @@ function preparePowerShellShimCommand(command, args) {
   ].join("; ");
 
   return {
-    command: "powershell.exe",
+    command: shell,
     args: ["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script],
     shell: false
   };
@@ -65,6 +69,10 @@ export function prepareSpawnCommand(command, args = [], options = {}) {
   const configuredShell = options.shell ?? readEnvValue(env, "SHELL") ?? readEnvValue(process.env, "SHELL") ?? true;
   if (!configuredShell) {
     return { command, args: [...args], shell: false };
+  }
+
+  if (isPowerShell(configuredShell)) {
+    return preparePowerShellShimCommand(command, args, configuredShell);
   }
 
   // cmd.exe expands %NAME% before it processes caret escapes, so percent signs

--- a/tests/args.test.mjs
+++ b/tests/args.test.mjs
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { CODEX_PLUGIN_ARGS_ENV, getCodexPassthroughArgs } from "../plugins/codex/scripts/lib/args.mjs";
+
+test("getCodexPassthroughArgs returns [] when the env var is unset", () => {
+  assert.deepEqual(getCodexPassthroughArgs({}), []);
+});
+
+test("getCodexPassthroughArgs returns [] for blank values", () => {
+  assert.deepEqual(getCodexPassthroughArgs({ [CODEX_PLUGIN_ARGS_ENV]: "   " }), []);
+});
+
+test("getCodexPassthroughArgs tokenizes a simple config override", () => {
+  assert.deepEqual(getCodexPassthroughArgs({ [CODEX_PLUGIN_ARGS_ENV]: "-c model_provider=my-provider" }), [
+    "-c",
+    "model_provider=my-provider"
+  ]);
+});
+
+test("getCodexPassthroughArgs honors quotes and multiple flags", () => {
+  assert.deepEqual(
+    getCodexPassthroughArgs({ [CODEX_PLUGIN_ARGS_ENV]: `-c model_provider=my-provider -c 'base_url=https://x/v1'` }),
+    ["-c", "model_provider=my-provider", "-c", "base_url=https://x/v1"]
+  );
+});

--- a/tests/args.test.mjs
+++ b/tests/args.test.mjs
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { CODEX_PLUGIN_ARGS_ENV, getCodexPassthroughArgs } from "../plugins/codex/scripts/lib/args.mjs";
+import {
+  CODEX_PLUGIN_ARGS_ENV,
+  getCodexPassthroughArgs,
+  splitRawArgumentString
+} from "../plugins/codex/scripts/lib/args.mjs";
 
 test("getCodexPassthroughArgs returns [] when the env var is unset", () => {
   assert.deepEqual(getCodexPassthroughArgs({}), []);
@@ -23,4 +27,32 @@ test("getCodexPassthroughArgs honors quotes and multiple flags", () => {
     getCodexPassthroughArgs({ [CODEX_PLUGIN_ARGS_ENV]: `-c model_provider=my-provider -c 'base_url=https://x/v1'` }),
     ["-c", "model_provider=my-provider", "-c", "base_url=https://x/v1"]
   );
+});
+
+test("getCodexPassthroughArgs keeps backslashes literal inside single quotes", () => {
+  assert.deepEqual(getCodexPassthroughArgs({ [CODEX_PLUGIN_ARGS_ENV]: `--add-dir 'C:\\work\\repo'` }), [
+    "--add-dir",
+    "C:\\work\\repo"
+  ]);
+});
+
+test("splitRawArgumentString: single quotes preserve backslashes, double quotes still escape", () => {
+  assert.deepEqual(splitRawArgumentString(`'C:\\work\\repo'`), ["C:\\work\\repo"]);
+  assert.deepEqual(splitRawArgumentString(`"a\\"b"`), [`a"b`]);
+  assert.deepEqual(splitRawArgumentString(`foo\\ bar`), ["foo bar"]);
+});
+
+test("splitRawArgumentString: double quotes keep backslashes before ordinary chars (POSIX)", () => {
+  // `\w` and `\r` are not escapable inside double quotes, so the backslash stays.
+  assert.deepEqual(splitRawArgumentString(`"C:\\work\\repo"`), ["C:\\work\\repo"]);
+  // `\\` collapses to a single backslash; `\$` and `` \` `` drop the backslash.
+  assert.deepEqual(splitRawArgumentString(`"a\\\\b"`), ["a\\b"]);
+  assert.deepEqual(splitRawArgumentString(`"price \\$5"`), ["price $5"]);
+});
+
+test("getCodexPassthroughArgs keeps backslashes literal inside double quotes", () => {
+  assert.deepEqual(getCodexPassthroughArgs({ [CODEX_PLUGIN_ARGS_ENV]: `--add-dir "C:\\work\\repo"` }), [
+    "--add-dir",
+    "C:\\work\\repo"
+  ]);
 });

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -247,12 +247,30 @@ function taskPayload(prompt, resume) {
   return "Handled the requested task.\\nTask prompt accepted.";
 }
 
-const args = process.argv.slice(2);
-if (args[0] === "--version") {
+const rawArgs = process.argv.slice(2);
+// Extract positionals, skipping any leading global flags (e.g. \`-c key=value\`)
+// that the plugin may prepend from CODEX_PLUGIN_CC_ARGS.
+function extractPositionals(tokens) {
+  const positionals = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (token === "-c" || token === "--config") {
+      i++;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      continue;
+    }
+    positionals.push(token);
+  }
+  return positionals;
+}
+const args = extractPositionals(rawArgs);
+if (rawArgs.includes("--version")) {
   console.log("codex-cli test");
   process.exit(0);
 }
-if (args[0] === "app-server" && args[1] === "--help") {
+if (args[0] === "app-server" && rawArgs.includes("--help")) {
   console.log("fake app-server help");
   process.exit(0);
 }
@@ -272,6 +290,7 @@ if (args[0] !== "app-server") {
 }
 const bootState = loadState();
 bootState.appServerStarts = (bootState.appServerStarts || 0) + 1;
+bootState.lastBootArgs = rawArgs;
 saveState(bootState);
 
 const rl = readline.createInterface({ input: process.stdin });

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -1,7 +1,35 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+import { prepareSpawnCommand, terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+
+test("prepareSpawnCommand preserves Windows cmd argument boundaries", () => {
+  const invocation = prepareSpawnCommand(
+    "codex",
+    ["-c", "key=value with spaces", "-c", "url=https://example.test?a=1&b=2"],
+    { platform: "win32", shell: true }
+  );
+
+  assert.deepEqual(invocation, {
+    command:
+      'codex ^"-c^" ^"key=value^ with^ spaces^" ^"-c^" ^"url=https://example.test^?a=1^&b=2^"',
+    args: [],
+    shell: true
+  });
+});
+
+test("prepareSpawnCommand preserves Windows Git Bash argument boundaries", () => {
+  const invocation = prepareSpawnCommand("codex", ["-c", "key=value with spaces", "it's literal"], {
+    platform: "win32",
+    shell: "C:\\Program Files\\Git\\bin\\bash.exe"
+  });
+
+  assert.deepEqual(invocation, {
+    command: `'codex' '-c' 'key=value with spaces' 'it'\\''s literal'`,
+    args: [],
+    shell: "C:\\Program Files\\Git\\bin\\bash.exe"
+  });
+});
 
 test("terminateProcessTree uses taskkill on Windows", () => {
   let captured = null;

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -43,6 +43,20 @@ test("prepareSpawnCommand keeps percent signs out of cmd.exe source", () => {
   assert.deepEqual(JSON.parse(Buffer.from(payload, "base64").toString("utf8")), original);
 });
 
+test("prepareSpawnCommand invokes configured PowerShell without POSIX quoting", () => {
+  const shell = "C:\\Program Files\\PowerShell\\7\\pwsh.exe";
+  const original = { command: "codex", args: ["-c", "key=value with spaces", "--version"] };
+  const invocation = prepareSpawnCommand(original.command, original.args, { platform: "win32", shell });
+
+  assert.equal(invocation.command, shell);
+  assert.equal(invocation.shell, false);
+  const script = invocation.args.at(-1);
+  assert.doesNotMatch(script, /'codex'|'--version'/);
+  const payload = script.match(/FromBase64String\('([^']+)'\)/)?.[1];
+  assert.ok(payload);
+  assert.deepEqual(JSON.parse(Buffer.from(payload, "base64").toString("utf8")), original);
+});
+
 test("prepareSpawnCommand preserves Windows Git Bash argument boundaries", () => {
   const invocation = prepareSpawnCommand("codex", ["-c", "key=value with spaces", "it's literal"], {
     platform: "win32",

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -18,6 +18,31 @@ test("prepareSpawnCommand preserves Windows cmd argument boundaries", () => {
   });
 });
 
+test("prepareSpawnCommand keeps percent signs out of cmd.exe source", () => {
+  const original = {
+    command: "codex",
+    args: ["-c", "base_url=https://example.test/%2Ftenant%2F/v1", "-c", "token=%NAME%"]
+  };
+  const invocation = prepareSpawnCommand(original.command, original.args, { platform: "win32", shell: true });
+
+  assert.equal(invocation.command, "powershell.exe");
+  assert.equal(invocation.shell, false);
+  assert.deepEqual(invocation.args.slice(0, -1), [
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-Command"
+  ]);
+
+  const script = invocation.args.at(-1);
+  assert.doesNotMatch(script, /%2F|%NAME%/);
+  const payload = script.match(/FromBase64String\('([^']+)'\)/)?.[1];
+  assert.ok(payload);
+  assert.deepEqual(JSON.parse(Buffer.from(payload, "base64").toString("utf8")), original);
+});
+
 test("prepareSpawnCommand preserves Windows Git Bash argument boundaries", () => {
   const invocation = prepareSpawnCommand("codex", ["-c", "key=value with spaces", "it's literal"], {
     platform: "win32",

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -157,6 +157,30 @@ test("review renders a no-findings result from app-server review/start", () => {
   assert.match(result.stdout, /No material issues found/);
 });
 
+test("CODEX_PLUGIN_CC_ARGS is passed through to the codex app-server launch", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.mkdirSync(path.join(repo, "src"));
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = 1;\n");
+  run("git", ["add", "src/app.js"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = 2;\n");
+
+  const result = run("node", [SCRIPT, "review"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      CODEX_PLUGIN_CC_ARGS: "-c model_provider=my-provider"
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  assert.deepEqual(fakeState.lastBootArgs, ["-c", "model_provider=my-provider", "app-server"]);
+});
+
 test("task runs when the active provider does not require OpenAI login", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -172,7 +172,8 @@ test("CODEX_PLUGIN_CC_ARGS is passed through to the codex app-server launch", ()
     cwd: repo,
     env: {
       ...buildEnv(binDir),
-      CODEX_PLUGIN_CC_ARGS: "-c 'model_provider=my provider' -c 'base_url=https://example.test/v1?a=1&b=2'"
+      CODEX_PLUGIN_CC_ARGS:
+        "-c 'model_provider=my provider' -c 'base_url=https://example.test/%2Ftenant%2F/v1?a=1&b=2'"
     }
   });
 
@@ -182,7 +183,7 @@ test("CODEX_PLUGIN_CC_ARGS is passed through to the codex app-server launch", ()
     "-c",
     "model_provider=my provider",
     "-c",
-    "base_url=https://example.test/v1?a=1&b=2",
+    "base_url=https://example.test/%2Ftenant%2F/v1?a=1&b=2",
     "app-server"
   ]);
 });

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -172,13 +172,19 @@ test("CODEX_PLUGIN_CC_ARGS is passed through to the codex app-server launch", ()
     cwd: repo,
     env: {
       ...buildEnv(binDir),
-      CODEX_PLUGIN_CC_ARGS: "-c model_provider=my-provider"
+      CODEX_PLUGIN_CC_ARGS: "-c 'model_provider=my provider' -c 'base_url=https://example.test/v1?a=1&b=2'"
     }
   });
 
   assert.equal(result.status, 0, result.stderr);
   const fakeState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
-  assert.deepEqual(fakeState.lastBootArgs, ["-c", "model_provider=my-provider", "app-server"]);
+  assert.deepEqual(fakeState.lastBootArgs, [
+    "-c",
+    "model_provider=my provider",
+    "-c",
+    "base_url=https://example.test/v1?a=1&b=2",
+    "app-server"
+  ]);
 });
 
 test("task runs when the active provider does not require OpenAI login", () => {


### PR DESCRIPTION
## What

Adds a `CODEX_PLUGIN_CC_ARGS` environment variable. When set, its value is tokenized (shell-style, reusing the existing `splitRawArgumentString`) and **prepended** to every `codex` invocation the plugin makes:

- the `codex app-server` runtime spawn (`app-server.mjs`), which covers both direct and broker modes
- the availability checks `codex --version` and `codex app-server --help` (`codex.mjs`)

Example:

```bash
export CODEX_PLUGIN_CC_ARGS='-c model_provider=litellm'
# plugin now runs: codex -c model_provider=litellm app-server
```

## Why

Closes #418. Previously only `--model`/`--effort` were forwarded and the app-server was always spawned bare, so there was no way to pass Codex global overrides (custom `model_provider`, `--profile`, arbitrary `-c key=value`) without editing `config.toml`. This makes it opt-in via a single env var, reusing Codex's own config-override surface.

## Changes

- `scripts/lib/args.mjs`: new `getCodexPassthroughArgs(env)` + `CODEX_PLUGIN_ARGS_ENV` constant
- `scripts/lib/app-server.mjs`: prepend args to the `codex app-server` spawn (reads the same env passed to the child)
- `scripts/lib/codex.mjs`: prepend args to the availability checks
- `tests/fake-codex-fixture.mjs`: tolerate leading global flags before the subcommand; record boot argv
- `tests/args.test.mjs` (new): unit tests for the parser
- `tests/runtime.test.mjs`: e2e test asserting the args reach the codex process
- `README.md`: documents the variable, quoting, and the shared-runtime caveat

## Testing

`npm test` — 95/95 passing locally.

## Notes

- Args are prepended (before the subcommand), the canonical position for Codex global flags like `-c` / `--profile`.
- Read when a Codex runtime starts; if a shared runtime is already active for the session, a fresh session is needed for new values to take effect (documented in the README).