### PR TITLE
fix: cancel dead pids on non-English Windows (#423)

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -983,7 +983,17 @@ async function handleCancel(argv) {
     );
   }
 
-  terminateProcessTree(job.pid ?? Number.NaN);
+  // Termination failures must not leave the job stuck as "running": the user is
+  // abandoning this job, so persist the cancelled state even if the (possibly
+  // already-dead) worker cannot be terminated.
+  try {
+    terminateProcessTree(job.pid ?? Number.NaN);
+  } catch (error) {
+    appendLogLine(
+      job.logFile,
+      `Process termination failed during cancel${error?.message ? `: ${error.message}` : "."}`
+    );
+  }
   appendLogLine(job.logFile, "Cancelled by user.");
 
   const completedAt = nowIso();

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -1,13 +1,22 @@
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
+function resolveShellOption(shell) {
+  // Normalize null/undefined to the platform default so callers can pass
+  // through optional values without tripping spawnSync's ERR_INVALID_ARG_TYPE.
+  if (shell === undefined || shell === null) {
+    return process.platform === "win32" ? process.env.SHELL || true : false;
+  }
+  if (typeof shell !== "boolean" && typeof shell !== "string") {
+    throw new TypeError(
+      `runCommand "shell" option must be a boolean or string, received ${typeof shell}`
+    );
+  }
+  return shell;
+}
+
 export function runCommand(command, args = [], options = {}) {
-  const shell =
-    options.shell !== undefined
-      ? options.shell
-      : process.platform === "win32"
-        ? process.env.SHELL || true
-        : false;
+  const shell = resolveShellOption(options.shell);
   const result = spawnSync(command, args, {
     cwd: options.cwd,
     env: options.env,

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -2,6 +2,12 @@ import { spawnSync } from "node:child_process";
 import process from "node:process";
 
 export function runCommand(command, args = [], options = {}) {
+  const shell =
+    options.shell !== undefined
+      ? options.shell
+      : process.platform === "win32"
+        ? process.env.SHELL || true
+        : false;
   const result = spawnSync(command, args, {
     cwd: options.cwd,
     env: options.env,
@@ -9,7 +15,7 @@ export function runCommand(command, args = [], options = {}) {
     input: options.input,
     maxBuffer: options.maxBuffer,
     stdio: options.stdio ?? "pipe",
-    shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
+    shell,
     windowsHide: true
   });
 
@@ -64,13 +70,23 @@ export function terminateProcessTree(pid, options = {}) {
   const killImpl = options.killImpl ?? process.kill.bind(process);
 
   if (platform === "win32") {
+    // taskkill needs no shell; forcing shell:false avoids MSYS/Git-Bash argument
+    // conversion mangling "/PID" into a path, and sidesteps the DEP0190 warning.
     const result = runCommandImpl("taskkill", ["/PID", String(pid), "/T", "/F"], {
       cwd: options.cwd,
-      env: options.env
+      env: options.env,
+      shell: false
     });
 
     if (!result.error && result.status === 0) {
       return { attempted: true, delivered: true, method: "taskkill", result };
+    }
+
+    // taskkill exits 128 when the target process does not exist. Its stderr is
+    // localized (and becomes mojibake when a non-UTF-8 console codepage is
+    // decoded as utf8), so the exit code is the only locale-independent signal.
+    if (!result.error && result.status === 128) {
+      return { attempted: true, delivered: false, method: "taskkill", result };
     }
 
     const combinedOutput = `${result.stderr}\n${result.stdout}`.trim();

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -53,3 +53,47 @@ test("terminateProcessTree treats missing Windows processes as already stopped",
   assert.equal(outcome.result.status, 128);
   assert.match(outcome.result.stdout, /not found/i);
 });
+
+test("terminateProcessTree treats exit 128 as not-found even with localized/mojibake output", () => {
+  // cp950 rendering of a localized "process not found" message decoded as utf8.
+  const outcome = terminateProcessTree(36564, {
+    platform: "win32",
+    runCommandImpl(command, args) {
+      return {
+        command,
+        args,
+        status: 128,
+        signal: null,
+        stdout: "",
+        stderr: "\uFFFD\uFFFD: \uFFFD\uFFFD\uFFFD\uFFFD\uFFFD",
+        error: null
+      };
+    }
+  });
+
+  assert.equal(outcome.attempted, true);
+  assert.equal(outcome.delivered, false);
+  assert.equal(outcome.method, "taskkill");
+  assert.equal(outcome.result.status, 128);
+});
+
+test("terminateProcessTree invokes taskkill without a shell", () => {
+  let capturedOptions = null;
+  terminateProcessTree(1234, {
+    platform: "win32",
+    runCommandImpl(command, args, options) {
+      capturedOptions = options;
+      return {
+        command,
+        args,
+        status: 0,
+        signal: null,
+        stdout: "",
+        stderr: "",
+        error: null
+      };
+    }
+  });
+
+  assert.equal(capturedOptions.shell, false);
+});


### PR DESCRIPTION
Fixes #423

## Problem

On non-English Windows, cancelling a background task whose worker has already died leaves the job stuck as `"running"` forever (and blocks `--resume-last`).

`terminateProcessTree()` runs `taskkill /PID <pid> /T /F`. When the process is already gone, `taskkill` exits `128` with a **localized** stderr (e.g. zh-TW `錯誤: 找不到處理程序`). Two things then go wrong:

1. `looksLikeMissingProcessMessage()` only matches English strings, so the localized message never matches and the win32 branch falls through to `throw`.
2. `runCommand()` decodes output as `utf8`, but `taskkill` emits the console codepage (cp950, etc.), so the text is mojibake (`U+FFFD` runs) and could never be matched anyway. The exit code is the only locale-independent signal.

Because `handleCancel()` calls `terminateProcessTree()` **before** persisting the cancelled state, that throw turns a routine "already dead" case into a permanently stuck job.

## Changes

- **Treat `taskkill` exit code `128` as process-not-found** in the win32 branch of `terminateProcessTree()`. The message check remains as a fallback.
- **Invoke `taskkill` with `shell: false`** so `SHELL` pointing at Git Bash no longer mangles `/PID` via MSYS path conversion, and to avoid the `DEP0190` deprecation warning. `runCommand()` now accepts a `shell` override.
- **Persist the cancelled state even if `terminateProcessTree()` throws** (try/catch + log in `handleCancel()`), so abandoning a job can never leave the state machine stuck.
- **Tests** for the exit-128/mojibake case and the `shell: false` invocation.

## Testing

`node --test tests/process.test.mjs` — all pass, including the two new cases:

```
✔ terminateProcessTree treats exit 128 as not-found even with localized/mojibake output
✔ terminateProcessTree invokes taskkill without a shell
```

Credit to the detailed root-cause analysis in #423.
