### PR TITLE
fix: pass on-request approval policy for write-capable task runs

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -488,6 +488,7 @@ async function executeTaskRun(request) {
     defaultPrompt: resumeThreadId ? DEFAULT_CONTINUE_PROMPT : "",
     model: request.model,
     effort: request.effort,
+    approvalPolicy: request.write ? "on-request" : "never",
     sandbox: request.write ? "workspace-write" : "read-only",
     onProgress: request.onProgress,
     persistThread: true,

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -1105,6 +1105,7 @@ export async function runAppServerTurn(cwd, options = {}) {
       emitProgress(options.onProgress, `Resuming thread ${options.resumeThreadId}.`, "starting");
       const response = await resumeThread(client, options.resumeThreadId, cwd, {
         model: options.model,
+        approvalPolicy: options.approvalPolicy,
         sandbox: options.sandbox,
         ephemeral: false
       });
@@ -1113,6 +1114,7 @@ export async function runAppServerTurn(cwd, options = {}) {
       emitProgress(options.onProgress, "Starting Codex task thread.", "starting");
       const response = await startThread(client, cwd, {
         model: options.model,
+        approvalPolicy: options.approvalPolicy,
         sandbox: options.sandbox,
         ephemeral: options.persistThread ? false : true,
         threadName: options.persistThread ? options.threadName : options.threadName ?? null

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -313,7 +313,16 @@ rl.on("line", (line) => {
           throw new Error("thread/start.persistFullHistory requires experimentalApi capability");
         }
         const thread = nextThread(state, message.params.cwd, message.params.ephemeral);
-        send({ id: message.id, result: { thread: buildThread(thread), model: message.params.model || "gpt-5.4", modelProvider: "openai", serviceTier: null, cwd: thread.cwd, approvalPolicy: "never", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
+        state.lastThreadStart = {
+          threadId: thread.id,
+          cwd: message.params.cwd ?? null,
+          model: message.params.model ?? null,
+          approvalPolicy: message.params.approvalPolicy ?? null,
+          sandbox: message.params.sandbox ?? null,
+          ephemeral: message.params.ephemeral ?? null
+        };
+        saveState(state);
+        send({ id: message.id, result: { thread: buildThread(thread), model: message.params.model || "gpt-5.4", modelProvider: "openai", serviceTier: null, cwd: thread.cwd, approvalPolicy: message.params.approvalPolicy || "never", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
         send({ method: "thread/started", params: { thread: { id: thread.id } } });
         break;
       }
@@ -346,8 +355,15 @@ rl.on("line", (line) => {
         }
         const thread = ensureThread(state, message.params.threadId);
         thread.updatedAt = now();
+        state.lastThreadResume = {
+          threadId: message.params.threadId,
+          cwd: message.params.cwd ?? null,
+          model: message.params.model ?? null,
+          approvalPolicy: message.params.approvalPolicy ?? null,
+          sandbox: message.params.sandbox ?? null
+        };
         saveState(state);
-        send({ id: message.id, result: { thread: buildThread(thread), model: message.params.model || "gpt-5.4", modelProvider: "openai", serviceTier: null, cwd: thread.cwd, approvalPolicy: "never", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
+        send({ id: message.id, result: { thread: buildThread(thread), model: message.params.model || "gpt-5.4", modelProvider: "openai", serviceTier: null, cwd: thread.cwd, approvalPolicy: message.params.approvalPolicy || "never", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
         break;
       }
 

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -701,6 +701,7 @@ test("session start hook exports the Claude session id, transcript path, and plu
 test("write task output focuses on the Codex result without generic follow-up hints", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
   installFakeCodex(binDir);
   initGitRepo(repo);
   fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
@@ -714,6 +715,58 @@ test("write task output focuses on the Codex result without generic follow-up hi
 
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout, "Handled the requested task.\nTask prompt accepted.\n");
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastThreadStart.approvalPolicy, "on-request");
+  assert.equal(fakeState.lastThreadStart.sandbox, "workspace-write");
+});
+
+test("read-only task keeps never approval policy on app-server thread/start", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "inspect the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastThreadStart.approvalPolicy, "never");
+  assert.equal(fakeState.lastThreadStart.sandbox, "read-only");
+});
+
+test("task --resume-last --write forwards write approval policy to app-server thread/resume", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const firstRun = run("node", [SCRIPT, "task", "initial task"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+  assert.equal(firstRun.status, 0, firstRun.stderr);
+
+  const result = run("node", [SCRIPT, "task", "--resume-last", "--write", "follow up"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastThreadResume.threadId, "thr_1");
+  assert.equal(fakeState.lastThreadResume.approvalPolicy, "on-request");
+  assert.equal(fakeState.lastThreadResume.sandbox, "workspace-write");
 });
 
 test("task --resume acts like --resume-last without leaking the flag into the prompt", () => {


### PR DESCRIPTION
## Summary
Write-capable task runs now send `approvalPolicy: "on-request"` to the app server, so `--write` actually gets a writable sandbox. Previously every run sent `never`, and the Codex CLI silently downgrades a `workspace-write` sandbox to effectively read-only under `approval_policy=never`.

## Why this matters

The reporter of #412 isolated this with a plugin-free repro (Windows 11, Codex CLI 0.142.4, plugin 1.0.5):

> `codex exec -s workspace-write -c approval_policy=never` fails to write; `approval_policy=on-request` succeeds with no prompt, because in-sandbox writes never escalate.

The plugin only toggled `sandbox` between `read-only` and `workspace-write` and hardcoded `approvalPolicy: "never"` everywhere, so even a trivial "create test.txt" rescue task failed with a read-only sandbox error. Two threading gaps caused it: `runAppServerTurn` in `plugins/codex/scripts/lib/codex.mjs` built its `startThread`/`resumeThread` options without `approvalPolicy` (so `buildThreadParams`' existing `options.approvalPolicy ?? "never"` could never see a value), and `executeTaskRun` in `codex-companion.mjs` never passed one.

## Changes
- `approvalPolicy` is forwarded through both `runAppServerTurn` branches (start and resume), and `executeTaskRun` sets it from the run mode: `on-request` for `--write` (including `--resume-last` resumes), `never` for read-only runs - reviews and other read-only paths are behaviorally unchanged.

## Testing
`node --test tests/runtime.test.mjs`: new assertions verify the fake app-server records `approvalPolicy: "on-request"` + `sandbox: "workspace-write"` on write runs, `never` + `read-only` on read-only runs, and `on-request` on the `--resume-last --write` resume path. Full suite matches the baseline commit exactly in a clean checkout (the only failures in my environment are three pre-existing status/result tests that also fail on the base commit due to a live shared app-server on this machine).

Fixes #412
