### PR TITLE
fix: treat signal-terminated subprocesses as failures in runCommand

### DIFF
--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -16,7 +16,10 @@ export function runCommand(command, args = [], options = {}) {
   return {
     command,
     args,
-    status: result.status ?? 0,
+    // A process killed by a signal reports status === null. Treat that as a
+    // failure (not success) so runCommandChecked/binaryAvailable don't silently
+    // accept truncated output; the signal itself is preserved below.
+    status: result.status ?? (result.signal ? 1 : 0),
     signal: result.signal ?? null,
     stdout: result.stdout ?? "",
     stderr: result.stderr ?? "",

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -1,7 +1,48 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+import {
+  formatCommandFailure,
+  runCommand,
+  runCommandChecked,
+  terminateProcessTree
+} from "../plugins/codex/scripts/lib/process.mjs";
+
+test("runCommand reports a signal-terminated process as a non-zero failure", () => {
+  const result = runCommand(process.execPath, ["-e", "process.kill(process.pid, 'SIGKILL')"]);
+  assert.notEqual(result.status, 0);
+  assert.equal(result.signal, "SIGKILL");
+});
+
+test("runCommandChecked throws when the child is killed by a signal", () => {
+  assert.throws(
+    () => runCommandChecked(process.execPath, ["-e", "process.kill(process.pid, 'SIGKILL')"]),
+    /signal=SIGKILL/
+  );
+});
+
+test("runCommand still reports a clean exit as status 0", () => {
+  const result = runCommand(process.execPath, ["-e", "process.exit(0)"]);
+  assert.equal(result.status, 0);
+  assert.equal(result.signal, null);
+});
+
+test("runCommand preserves a non-zero exit code", () => {
+  const result = runCommand(process.execPath, ["-e", "process.exit(3)"]);
+  assert.equal(result.status, 3);
+});
+
+test("formatCommandFailure surfaces the signal for a signal-killed command", () => {
+  const failure = formatCommandFailure({
+    command: "git",
+    args: ["status"],
+    status: 1,
+    signal: "SIGKILL",
+    stdout: "",
+    stderr: ""
+  });
+  assert.match(failure, /signal=SIGKILL/);
+});
 
 test("terminateProcessTree uses taskkill on Windows", () => {
   let captured = null;


### PR DESCRIPTION
## Problem
  `spawnSync` returns `status === null` when a child process is terminated by a signal (e.g. SIGKILL from the OOM killer, or a manual kill). `runCommand` coerced that to `0` with `result.status ?? 0`, so `runCommandChecked` (`status !== 0`) and `binaryAvailable` treated the killed process as a **success** callers then proceeded with truncated or empty stdout as if the command had completed normally (e.g. a `git diff` that was killed mid-run would look empty/clean).

  The existing `if (result.signal)` branch in `formatCommandFailure` shows this was meant to be reported as a failure, but the coercion made that path unreachable for the checked helpers.

  ## Fix
  Map a signal death to a non-zero status: `result.status ?? (result.signal ? 1 : 0)`. Only the signal case changes; the `signal` field is still exposed separately and surfaced by `formatCommandFailure` (`signal=SIGKILL`).

  ## Tests
  Added cases to `tests/process.test.mjs`: real SIGKILL child reports non-zero status + preserved signal, `runCommandChecked` throws with `signal=SIGKILL`, clean exit still `0`, non-zero exit preserved, and `formatCommandFailure` surfaces the signal. Full suite: 95 pass / 0 fail. `tsc -p tsconfig.app-server.json` passes.

  ## Conflicts
  No overlap with the other open `process.mjs` PRs — #415 doesn't touch this file, and #424 only changes the `shell:` line and `terminateProcessTree` (this PR changes `runCommand`'s  `status` mapping). taskkill's numeric exit codes (128/0) are unaffected.
