### PR TITLE
Fix background job zombie entries and enhance --fresh clearing

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -27,6 +27,7 @@ import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "
 import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
 import {
+  clearTerminalJobs,
   generateJobId,
   getConfig,
   listJobs,
@@ -778,6 +779,9 @@ async function handleTask(argv) {
   const fresh = Boolean(options.fresh);
   if (resumeLast && fresh) {
     throw new Error("Choose either --resume/--resume-last or --fresh.");
+  }
+  if (fresh) {
+    clearTerminalJobs(cwd);
   }
   const write = Boolean(options.write);
   const taskMetadata = buildTaskRunMetadata({

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -149,8 +149,9 @@ export function upsertJob(cwd, jobPatch) {
 export function listJobs(cwd) {
   const state = loadState(cwd);
   const now = Date.now();
+  const terminalStatuses = ["completed", "failed", "cancelled", "stopped"];
   const nextJobs = state.jobs.filter((job) => {
-    if (job.status !== "running" && job.updatedAt) {
+    if (terminalStatuses.includes(job.status) && job.updatedAt) {
       const updatedTime = Date.parse(job.updatedAt);
       if (Number.isFinite(updatedTime) && now - updatedTime > 30 * 60 * 1000) {
         return false;
@@ -167,7 +168,8 @@ export function listJobs(cwd) {
 
 export function clearTerminalJobs(cwd) {
   const state = loadState(cwd);
-  const nextJobs = state.jobs.filter((job) => job.status === "running");
+  const terminalStatuses = ["completed", "failed", "cancelled", "stopped"];
+  const nextJobs = state.jobs.filter((job) => !terminalStatuses.includes(job.status));
   if (nextJobs.length !== state.jobs.length) {
     state.jobs = nextJobs;
     saveState(cwd, state);

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -147,7 +147,32 @@ export function upsertJob(cwd, jobPatch) {
 }
 
 export function listJobs(cwd) {
-  return loadState(cwd).jobs;
+  const state = loadState(cwd);
+  const now = Date.now();
+  const nextJobs = state.jobs.filter((job) => {
+    if (job.status !== "running" && job.updatedAt) {
+      const updatedTime = Date.parse(job.updatedAt);
+      if (Number.isFinite(updatedTime) && now - updatedTime > 30 * 60 * 1000) {
+        return false;
+      }
+    }
+    return true;
+  });
+  if (nextJobs.length !== state.jobs.length) {
+    state.jobs = nextJobs;
+    saveState(cwd, state);
+  }
+  return nextJobs;
+}
+
+export function clearTerminalJobs(cwd) {
+  const state = loadState(cwd);
+  const nextJobs = state.jobs.filter((job) => job.status === "running");
+  if (nextJobs.length !== state.jobs.length) {
+    state.jobs = nextJobs;
+    saveState(cwd, state);
+  }
+  return nextJobs;
 }
 
 export function setConfig(cwd, key, value) {

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -120,6 +120,12 @@ test("listJobs automatically garbage collects completed/failed jobs older than 3
       createdAt: new Date(now - 40 * 60 * 1000).toISOString()
     },
     {
+      id: "job-queued-old",
+      status: "queued",
+      updatedAt: new Date(now - 40 * 60 * 1000).toISOString(),
+      createdAt: new Date(now - 40 * 60 * 1000).toISOString()
+    },
+    {
       id: "job-completed-old",
       status: "completed",
       updatedAt: new Date(now - 40 * 60 * 1000).toISOString(),
@@ -144,16 +150,18 @@ test("listJobs automatically garbage collects completed/failed jobs older than 3
     jobs
   });
 
-  // Old completed job should be GC'ed, old running job and fresh completed job should remain.
+  // Old completed job should be GC'ed, old running/queued and fresh completed jobs should remain.
   const activeJobs = listJobs(workspace);
-  assert.equal(activeJobs.length, 2);
+  assert.equal(activeJobs.length, 3);
   assert.equal(activeJobs.some((j) => j.id === "job-running-old"), true);
+  assert.equal(activeJobs.some((j) => j.id === "job-queued-old"), true);
   assert.equal(activeJobs.some((j) => j.id === "job-completed-fresh"), true);
   assert.equal(activeJobs.some((j) => j.id === "job-completed-old"), false);
 
   assert.equal(fs.existsSync(resolveJobFile(workspace, "job-completed-old")), false);
   assert.equal(fs.existsSync(resolveJobFile(workspace, "job-completed-fresh")), true);
   assert.equal(fs.existsSync(resolveJobFile(workspace, "job-running-old")), true);
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-queued-old")), true);
 });
 
 test("clearTerminalJobs removes all completed/failed/stopped jobs but keeps running ones", () => {
@@ -167,6 +175,12 @@ test("clearTerminalJobs removes all completed/failed/stopped jobs but keeps runn
     {
       id: "job-running",
       status: "running",
+      updatedAt: new Date(now).toISOString(),
+      createdAt: new Date(now).toISOString()
+    },
+    {
+      id: "job-queued",
+      status: "queued",
       updatedAt: new Date(now).toISOString(),
       createdAt: new Date(now).toISOString()
     },
@@ -196,10 +210,12 @@ test("clearTerminalJobs removes all completed/failed/stopped jobs but keeps runn
   });
 
   const activeJobs = clearTerminalJobs(workspace);
-  assert.equal(activeJobs.length, 1);
-  assert.equal(activeJobs[0].id, "job-running");
+  assert.equal(activeJobs.length, 2);
+  assert.equal(activeJobs.some((j) => j.id === "job-running"), true);
+  assert.equal(activeJobs.some((j) => j.id === "job-queued"), true);
 
   assert.equal(fs.existsSync(resolveJobFile(workspace, "job-completed")), false);
   assert.equal(fs.existsSync(resolveJobFile(workspace, "job-failed")), false);
   assert.equal(fs.existsSync(resolveJobFile(workspace, "job-running")), true);
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-queued")), true);
 });

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -4,8 +4,8 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { makeTempDir } from "./helpers.mjs";
-import { resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState } from "../plugins/codex/scripts/lib/state.mjs";
+import { makeTempDir, initGitRepo } from "./helpers.mjs";
+import { resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState, listJobs, clearTerminalJobs } from "../plugins/codex/scripts/lib/state.mjs";
 
 test("resolveStateDir uses a temp-backed per-workspace directory", () => {
   const workspace = makeTempDir();
@@ -42,6 +42,7 @@ test("resolveStateDir uses CLAUDE_PLUGIN_DATA when it is provided", () => {
 
 test("saveState prunes dropped job artifacts when indexed jobs exceed the cap", () => {
   const workspace = makeTempDir();
+  initGitRepo(workspace);
   const stateFile = resolveStateFile(workspace);
   fs.mkdirSync(path.dirname(stateFile), { recursive: true });
 
@@ -102,4 +103,103 @@ test("saveState prunes dropped job artifacts when indexed jobs exceed the cap", 
       .flatMap((jobId) => [`${jobId}.json`, `${jobId}.log`])
       .sort()
   );
+});
+
+test("listJobs automatically garbage collects completed/failed jobs older than 30 minutes", () => {
+  const workspace = makeTempDir();
+  initGitRepo(workspace);
+  const stateFile = resolveStateFile(workspace);
+  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+
+  const now = Date.now();
+  const jobs = [
+    {
+      id: "job-running-old",
+      status: "running",
+      updatedAt: new Date(now - 40 * 60 * 1000).toISOString(),
+      createdAt: new Date(now - 40 * 60 * 1000).toISOString()
+    },
+    {
+      id: "job-completed-old",
+      status: "completed",
+      updatedAt: new Date(now - 40 * 60 * 1000).toISOString(),
+      createdAt: new Date(now - 40 * 60 * 1000).toISOString()
+    },
+    {
+      id: "job-completed-fresh",
+      status: "completed",
+      updatedAt: new Date(now - 10 * 60 * 1000).toISOString(),
+      createdAt: new Date(now - 10 * 60 * 1000).toISOString()
+    }
+  ];
+
+  for (const job of jobs) {
+    fs.writeFileSync(resolveJobFile(workspace, job.id), JSON.stringify(job), "utf8");
+    fs.writeFileSync(resolveJobLogFile(workspace, job.id), "log\n", "utf8");
+  }
+
+  saveState(workspace, {
+    version: 1,
+    config: { stopReviewGate: false },
+    jobs
+  });
+
+  // Old completed job should be GC'ed, old running job and fresh completed job should remain.
+  const activeJobs = listJobs(workspace);
+  assert.equal(activeJobs.length, 2);
+  assert.equal(activeJobs.some((j) => j.id === "job-running-old"), true);
+  assert.equal(activeJobs.some((j) => j.id === "job-completed-fresh"), true);
+  assert.equal(activeJobs.some((j) => j.id === "job-completed-old"), false);
+
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-completed-old")), false);
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-completed-fresh")), true);
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-running-old")), true);
+});
+
+test("clearTerminalJobs removes all completed/failed/stopped jobs but keeps running ones", () => {
+  const workspace = makeTempDir();
+  initGitRepo(workspace);
+  const stateFile = resolveStateFile(workspace);
+  fs.mkdirSync(path.dirname(stateFile), { recursive: true });
+
+  const now = Date.now();
+  const jobs = [
+    {
+      id: "job-running",
+      status: "running",
+      updatedAt: new Date(now).toISOString(),
+      createdAt: new Date(now).toISOString()
+    },
+    {
+      id: "job-completed",
+      status: "completed",
+      updatedAt: new Date(now).toISOString(),
+      createdAt: new Date(now).toISOString()
+    },
+    {
+      id: "job-failed",
+      status: "failed",
+      updatedAt: new Date(now).toISOString(),
+      createdAt: new Date(now).toISOString()
+    }
+  ];
+
+  for (const job of jobs) {
+    fs.writeFileSync(resolveJobFile(workspace, job.id), JSON.stringify(job), "utf8");
+    fs.writeFileSync(resolveJobLogFile(workspace, job.id), "log\n", "utf8");
+  }
+
+  saveState(workspace, {
+    version: 1,
+    config: { stopReviewGate: false },
+    jobs
+  });
+
+  const activeJobs = clearTerminalJobs(workspace);
+  assert.equal(activeJobs.length, 1);
+  assert.equal(activeJobs[0].id, "job-running");
+
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-completed")), false);
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-failed")), false);
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-running")), true);
 });


### PR DESCRIPTION
This PR fixes background job state machine retaining zombie entries (Issue #410) in `openai/codex-plugin-cc`:

1. **Auto-Garbage Collection (GC) for Job State (Issue #410)**:
   - **Root Cause**: Previously completed, failed, or stopped jobs were stored in the state database indefinitely, leading to a build-up of stale/zombie entries.
   - **Fix**: Implemented an auto-cleanup process in `listJobs()` (inside `state.mjs`) that automatically filters out completed, failed, or stopped jobs older than 30 minutes. The associated JSON state files and log files on disk are pruned automatically during this process via the existing `saveState` logic.

2. **Enhanced `--fresh` Flag Behavior**:
   - **Root Cause**: The `--fresh` flag did not actively clean up existing terminal-state jobs, meaning stale jobs still interfered or showed up in `/codex:status`.
   - **Fix**: Added a `clearTerminalJobs(cwd)` function to wipe all terminal-state jobs (completed, failed, or stopped) while keeping active/running jobs. This is invoked in `codex-companion.mjs`'s `handleTask` when the `--fresh` option is passed, ensuring a completely clean slate for new runs.

3. **Added Unit Tests**:
   - Added unit test cases in `tests/state.test.mjs` verifying that `listJobs` correctly prunes expired jobs and `clearTerminalJobs` removes only terminal jobs.
   - Fixed a test isolation bug in `tests/state.test.mjs` where multiple test cases resolved to the same temp workspace directory on Windows (due to parent directory traversing for Git repo roots), by calling `initGitRepo(workspace)` on the unique temp workspaces.
