### PR TITLE
docs: fix review gate README anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Check out the Codex docs for more [configuration options](https://developers.ope
 
 ### Moving The Work Over To Codex
 
-Delegated tasks and any [stop gate](#what-does-the-review-gate-do) run can also be directly resumed inside Codex by running `codex resume` either with the specific session ID you received from running `/codex:result` or `/codex:status` or by selecting it from the list.
+Delegated tasks and any [review gate](#enabling-review-gate) run can also be directly resumed inside Codex by running `codex resume` either with the specific session ID you received from running `/codex:result` or `/codex:status` or by selecting it from the list.
 
 This way you can review the Codex work or continue the work there.
 

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -158,6 +158,8 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(readme, /--model gpt-5\.4-mini --effort medium/i);
   assert.match(readme, /`spark`, the plugin maps that to `gpt-5\.3-codex-spark`/i);
   assert.match(readme, /continue a previous Codex task/i);
+  assert.match(readme, /\[review gate\]\(#enabling-review-gate\)/i);
+  assert.doesNotMatch(readme, /#what-does-the-review-gate-do/i);
   assert.match(readme, /### `\/codex:setup`/);
   assert.match(readme, /### `\/codex:review`/);
   assert.match(readme, /### `\/codex:adversarial-review`/);


### PR DESCRIPTION
## Summary
- update the README Codex resume section to link to the existing review gate heading
- add a command-docs regression assertion so the stale anchor does not return

## Verification
- node --test tests/commands.test.mjs
- git diff --check
- node -e README anchor check for #enabling-review-gate

Note: an initial full `npm test` run was stopped after it appeared stuck after test 77; all emitted tests up to that point had passed. The focused docs test above passed after the change.