### PR TITLE
fix: multi-session broker and state lifecycle bugs

### DIFF
--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -100,6 +100,7 @@ async function main() {
   }
 
   async function shutdown(server) {
+    intentionalShutdown = true;
     for (const socket of sockets) {
       socket.end();
     }
@@ -114,6 +115,25 @@ async function main() {
   }
 
   appClient.setNotificationHandler(routeNotification);
+
+  // If the child app-server dies, do not linger: a broker without its child
+  // still answers initialize probes locally, so reuse checks pass and the
+  // next real turn fails with "connection closed" (see #402).
+  // Tear down instead so probes fail honestly (ECONNREFUSED/ENOENT), which
+  // the client's direct-retry path already handles.
+  let serverStarted = false;
+  let intentionalShutdown = false;
+  appClient.exitPromise.then(async () => {
+    if (!serverStarted || intentionalShutdown) {
+      return;
+    }
+    try {
+      await shutdown(server);
+    } catch {
+      // Best effort — exiting is the important part.
+    }
+    process.exit(1);
+  });
 
   const server = net.createServer((socket) => {
     sockets.add(socket);
@@ -244,6 +264,7 @@ async function main() {
   });
 
   server.listen(listenTarget.path);
+  serverStarted = true;
 }
 
 main().catch((error) => {

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -67,6 +67,7 @@ class AppServerClientBase {
     this.notificationHandler = null;
     this.lineBuffer = "";
     this.transport = "unknown";
+    this.applicationRequestSent = false;
 
     this.exitPromise = new Promise((resolve) => {
       this.resolveExit = resolve;
@@ -86,6 +87,9 @@ class AppServerClientBase {
   request(method, params) {
     if (this.closed) {
       throw new Error("codex app-server client is closed.");
+    }
+    if (method !== "initialize") {
+      this.applicationRequestSent = true;
     }
 
     const id = this.nextId;

--- a/plugins/codex/scripts/lib/broker-lifecycle.mjs
+++ b/plugins/codex/scripts/lib/broker-lifecycle.mjs
@@ -89,7 +89,13 @@ export function loadBrokerSession(cwd) {
 export function saveBrokerSession(cwd, session) {
   const stateDir = resolveStateDir(cwd);
   fs.mkdirSync(stateDir, { recursive: true });
-  fs.writeFileSync(resolveBrokerStateFile(cwd), `${JSON.stringify(session, null, 2)}\n`, "utf8");
+  // Atomic write (tmp + rename), matching saveState: a concurrent reader in
+  // another session must never parse a half-written broker.json, conclude
+  // "no broker", and spawn a duplicate.
+  const stateFile = resolveBrokerStateFile(cwd);
+  const tmpFile = `${stateFile}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpFile, `${JSON.stringify(session, null, 2)}\n`, "utf8");
+  fs.renameSync(tmpFile, stateFile);
 }
 
 export function clearBrokerSession(cwd) {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -619,9 +619,18 @@ async function withAppServer(cwd, fn) {
     return result;
   } catch (error) {
     const brokerRequested = client?.transport === "broker" || Boolean(process.env[BROKER_ENDPOINT_ENV]);
+    // "connection closed" is the shape of a broker whose child app-server
+    // died between turns (#402): no rpcCode, no errno — just the handleExit
+    // message. Treat it as a broker failure worth a direct retry.
+    const brokerConnectionClosed =
+      brokerRequested &&
+      error?.rpcCode === undefined &&
+      error?.code === undefined &&
+      /connection closed/i.test(error?.message ?? "");
     const shouldRetryDirect =
       (client?.transport === "broker" && error?.rpcCode === BROKER_BUSY_RPC_CODE) ||
-      (brokerRequested && (error?.code === "ENOENT" || error?.code === "ECONNREFUSED"));
+      (brokerRequested && (error?.code === "ENOENT" || error?.code === "ECONNREFUSED")) ||
+      brokerConnectionClosed;
 
     if (client) {
       await client.close().catch(() => {});

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -619,14 +619,16 @@ async function withAppServer(cwd, fn) {
     return result;
   } catch (error) {
     const brokerRequested = client?.transport === "broker" || Boolean(process.env[BROKER_ENDPOINT_ENV]);
-    // "connection closed" is the shape of a broker whose child app-server
-    // died between turns (#402): no rpcCode, no errno — just the handleExit
-    // message. Treat it as a broker failure worth a direct retry.
+    // "connection closed" can be a broker whose child app-server died, but
+    // once an application request has been sent the broker may already have
+    // forwarded side-effecting work. Only retry if nothing beyond initialize
+    // was attempted on this connection.
     const brokerConnectionClosed =
       brokerRequested &&
       error?.rpcCode === undefined &&
       error?.code === undefined &&
-      /connection closed/i.test(error?.message ?? "");
+      /connection closed/i.test(error?.message ?? "") &&
+      !client?.applicationRequestSent;
     const shouldRetryDirect =
       (client?.transport === "broker" && error?.rpcCode === BROKER_BUSY_RPC_CODE) ||
       (brokerRequested && (error?.code === "ENOENT" || error?.code === "ECONNREFUSED")) ||

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -55,7 +55,10 @@ function looksLikeMissingProcessMessage(text) {
 }
 
 export function terminateProcessTree(pid, options = {}) {
-  if (!Number.isFinite(pid)) {
+  // pid 0 signals the caller's own process group and pid <= -1 signals
+  // arbitrary groups — either can take down the invoking process tree
+  // (e.g. a test runner). Only ever target a concrete child pid.
+  if (!Number.isInteger(pid) || pid <= 1) {
     return { attempted: false, delivered: false, method: null };
   }
 

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -77,10 +77,21 @@ export function loadState(cwd) {
   }
 }
 
+function isActiveJob(job) {
+  return job?.status === "queued" || job?.status === "running";
+}
+
 function pruneJobs(jobs) {
-  return [...jobs]
+  // Never evict an active (queued/running) job: it may belong to another
+  // session or a live background worker, and dropping its record hides it
+  // from the broker-ownership gate (letting a SessionEnd tear the broker
+  // down under it). Cap only the terminal history.
+  const active = jobs.filter(isActiveJob);
+  const terminal = [...jobs]
+    .filter((job) => !isActiveJob(job))
     .sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")))
-    .slice(0, MAX_JOBS);
+    .slice(0, Math.max(0, MAX_JOBS - active.length));
+  return [...active, ...terminal];
 }
 
 function removeFileIfExists(filePath) {
@@ -107,11 +118,23 @@ export function saveState(cwd, state) {
     if (retainedIds.has(job.id)) {
       continue;
     }
+    // Only GC files for jobs that are already terminal. If a job absent from
+    // this (possibly stale) snapshot is still active on disk, it belongs to a
+    // concurrent writer — deleting its .json/.log would strand a live worker.
+    if (isActiveJob(job)) {
+      continue;
+    }
     removeJobFile(resolveJobFile(cwd, job.id));
     removeFileIfExists(job.logFile);
   }
 
-  fs.writeFileSync(resolveStateFile(cwd), `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
+  // Write atomically (tmp + rename) so concurrent readers — e.g. another
+  // session's SessionEnd hook deciding whether the shared broker is still
+  // in use — never observe a partially-written state file.
+  const stateFile = resolveStateFile(cwd);
+  const tmpFile = `${stateFile}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpFile, `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
+  fs.renameSync(tmpFile, stateFile);
   return nextState;
 }
 
@@ -188,4 +211,17 @@ export function resolveJobLogFile(cwd, jobId) {
 export function resolveJobFile(cwd, jobId) {
   ensureStateDir(cwd);
   return path.join(resolveJobsDir(cwd), `${jobId}.json`);
+}
+
+// Delete a job's on-disk artifacts (.json + .log). For callers that are
+// *intentionally* removing a specific job they own — e.g. SessionEnd cleaning
+// up its own killed jobs — since saveState's GC now refuses to unlink files
+// for active jobs (to protect concurrent sessions), the deliberate owner must
+// clean up its own artifacts explicitly.
+export function removeJobArtifacts(cwd, job) {
+  if (!job?.id) {
+    return;
+  }
+  removeJobFile(resolveJobFile(cwd, job.id));
+  removeFileIfExists(job.logFile);
 }

--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -13,7 +13,7 @@ import {
   sendBrokerShutdown,
   teardownBrokerSession
 } from "./lib/broker-lifecycle.mjs";
-import { loadState, resolveStateFile, saveState } from "./lib/state.mjs";
+import { loadState, removeJobArtifacts, resolveStateFile, saveState } from "./lib/state.mjs";
 import { TRANSCRIPT_PATH_ENV } from "./lib/claude-session-transfer.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
 
@@ -58,19 +58,59 @@ function cleanupSessionJobs(cwd, sessionId) {
 
   for (const job of removedJobs) {
     const stillRunning = job.status === "queued" || job.status === "running";
-    if (!stillRunning) {
-      continue;
+    if (stillRunning) {
+      try {
+        terminateProcessTree(job.pid ?? Number.NaN);
+      } catch {
+        // Ignore teardown failures during session shutdown.
+      }
     }
-    try {
-      terminateProcessTree(job.pid ?? Number.NaN);
-    } catch {
-      // Ignore teardown failures during session shutdown.
-    }
+    // We own these jobs and are deliberately removing them. saveState's GC
+    // now protects active jobs' files (for other sessions' sake), so delete
+    // our own artifacts explicitly — otherwise killed jobs leak .json/.log.
+    removeJobArtifacts(workspaceRoot, job);
   }
 
   saveState(workspaceRoot, {
     ...state,
     jobs: state.jobs.filter((job) => job.sessionId !== sessionId)
+  });
+}
+
+function isQueuedOrRunning(job) {
+  return job?.status === "queued" || job?.status === "running";
+}
+
+function hasOtherActiveSessionJobs(cwd, sessionId) {
+  if (!cwd) {
+    return false;
+  }
+
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateFile = resolveStateFile(workspaceRoot);
+  if (!fs.existsSync(stateFile)) {
+    return false;
+  }
+
+  // Read the state file directly rather than via loadState(), which maps
+  // read/parse failures to an empty default. An unreadable state file means
+  // we cannot prove sole ownership of the broker — fail closed and skip
+  // teardown rather than risk killing another session's live work.
+  let state;
+  try {
+    state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+  } catch {
+    return true;
+  }
+  const jobs = Array.isArray(state?.jobs) ? state.jobs : [];
+  return jobs.some((job) => {
+    if (!isQueuedOrRunning(job)) {
+      return false;
+    }
+    if (!sessionId || !job.sessionId) {
+      return true;
+    }
+    return job.sessionId !== sessionId;
   });
 }
 
@@ -96,12 +136,17 @@ async function handleSessionEnd(input) {
   const logFile = brokerSession?.logFile ?? null;
   const sessionDir = brokerSession?.sessionDir ?? null;
   const pid = brokerSession?.pid ?? null;
+  const sessionId = input.session_id || process.env[SESSION_ID_ENV] || null;
+
+  cleanupSessionJobs(cwd, sessionId);
+  if (hasOtherActiveSessionJobs(cwd, sessionId)) {
+    return;
+  }
 
   if (brokerEndpoint) {
     await sendBrokerShutdown(brokerEndpoint);
   }
 
-  cleanupSessionJobs(cwd, input.session_id || process.env[SESSION_ID_ENV]);
   teardownBrokerSession({
     endpoint: brokerEndpoint,
     pidFile,

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -3,9 +3,69 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { spawnSync } from "node:child_process";
+import { after } from "node:test";
+
+import {
+  clearBrokerSession,
+  loadBrokerSession,
+  sendBrokerShutdown,
+  teardownBrokerSession
+} from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+
+const TEST_TEMP_PREFIX = "codex-plugin-test-";
+const tempDirs = new Set();
+
+function isTestTempDir(dir) {
+  return path.basename(dir).startsWith(TEST_TEMP_PREFIX);
+}
+
+async function teardownTempBroker(cwd) {
+  const brokerSession = loadBrokerSession(cwd);
+  if (!brokerSession) {
+    return;
+  }
+
+  const endpoint = brokerSession.endpoint ?? null;
+  if (endpoint) {
+    // A wedged endpoint (accepts, never responds) must not hang the global
+    // cleanup hook and strand every later-registered broker.
+    await Promise.race([
+      sendBrokerShutdown(endpoint).catch(() => {}),
+      new Promise((resolve) => {
+        const timer = setTimeout(resolve, 5000);
+        timer.unref?.();
+      })
+    ]);
+  }
+
+  teardownBrokerSession({
+    endpoint,
+    pidFile: brokerSession.pidFile ?? null,
+    logFile: brokerSession.logFile ?? null,
+    sessionDir: brokerSession.sessionDir ?? null,
+    pid: brokerSession.pid ?? null,
+    killProcess: terminateProcessTree
+  });
+  clearBrokerSession(cwd);
+}
+
+export async function cleanupRegisteredTempBrokers() {
+  for (const dir of tempDirs) {
+    await teardownTempBroker(dir);
+  }
+}
+
+after(async () => {
+  await cleanupRegisteredTempBrokers();
+});
 
 export function makeTempDir(prefix = "codex-plugin-test-") {
-  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  if (isTestTempDir(dir)) {
+    tempDirs.add(dir);
+  }
+  return dir;
 }
 
 export function writeExecutable(filePath, source) {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -845,6 +845,116 @@ test("task forwards model selection and reasoning effort to app-server turn/star
   assert.equal(fakeState.lastTurnStart.effort, "low");
 });
 
+test("task does not retry direct after broker connection closes during an in-flight turn", async (t) => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const fakeStatePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const brokerDir = fs.realpathSync(createBrokerSessionDir("cxc-test-"));
+  const endpoint = createBrokerEndpoint(brokerDir);
+  const socketPath = endpoint.startsWith("unix:") ? endpoint.slice(5) : endpoint;
+  const methodsLog = path.join(brokerDir, "received-methods.log");
+  const stubLog = path.join(brokerDir, "stub.log");
+  const stubScript = `
+    const net = require("node:net");
+    const fs = require("node:fs");
+    const [sock, log] = process.argv.slice(1);
+    const server = net.createServer((socket) => {
+      socket.setEncoding("utf8");
+      let buffered = "";
+      socket.on("data", (chunk) => {
+        buffered += chunk;
+        let idx;
+        while ((idx = buffered.indexOf("\\n")) !== -1) {
+          const line = buffered.slice(0, idx);
+          buffered = buffered.slice(idx + 1);
+          if (!line.trim()) continue;
+          let message;
+          try { message = JSON.parse(line); } catch { continue; }
+          if (message.method) fs.appendFileSync(log, message.method + "\\n");
+          if (message.method === "initialize") {
+            socket.write(JSON.stringify({ id: message.id, result: { userAgent: "test-broker" } }) + "\\n");
+            continue;
+          }
+          if (message.method === "initialized") {
+            continue;
+          }
+          if (message.method === "thread/start") {
+            socket.write(JSON.stringify({ id: message.id, result: { thread: { id: "thr-broker" } } }) + "\\n");
+            continue;
+          }
+          if (message.method === "thread/name/set") {
+            socket.write(JSON.stringify({ id: message.id, result: {} }) + "\\n");
+            continue;
+          }
+          if (message.method === "turn/start") {
+            socket.destroy();
+            server.close(() => process.exit(0));
+          }
+        }
+      });
+    });
+    server.on("error", (error) => {
+      fs.appendFileSync(log + ".error", error.stack || String(error));
+      process.exit(1);
+    });
+    server.listen(sock);
+  `;
+  const stubFd = fs.openSync(stubLog, "a");
+  const brokerProcess = spawn(process.execPath, ["-e", stubScript, socketPath, methodsLog], {
+    cwd: repo,
+    detached: true,
+    stdio: ["ignore", stubFd, stubFd]
+  });
+  fs.closeSync(stubFd);
+  let brokerExit = null;
+  brokerProcess.on("exit", (code, signal) => {
+    brokerExit = { code, signal };
+  });
+  brokerProcess.unref();
+  t.after(() => {
+    try {
+      process.kill(brokerProcess.pid, "SIGKILL");
+    } catch {
+      // Ignore missing process.
+    }
+    fs.rmSync(brokerDir, { recursive: true, force: true });
+  });
+  await waitFor(() => {
+    if (fs.existsSync(socketPath)) {
+      return true;
+    }
+    if (brokerExit) {
+      const stderr = fs.existsSync(stubLog) ? fs.readFileSync(stubLog, "utf8") : "";
+      const startupError = fs.existsSync(`${methodsLog}.error`) ? fs.readFileSync(`${methodsLog}.error`, "utf8") : "";
+      throw new Error(`Stub broker exited before listening: ${JSON.stringify(brokerExit)}\n${stderr}${startupError}`);
+    }
+    return false;
+  });
+
+  const result = run("node", [SCRIPT, "task", "do not duplicate this turn"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      CODEX_COMPANION_APP_SERVER_ENDPOINT: endpoint
+    }
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /connection closed/i);
+  const methods = fs.readFileSync(methodsLog, "utf8").split("\n").filter(Boolean);
+  assert.deepEqual(methods, ["initialize", "initialized", "thread/start", "thread/name/set", "turn/start"]);
+  if (fs.existsSync(fakeStatePath)) {
+    const fakeState = JSON.parse(fs.readFileSync(fakeStatePath, "utf8"));
+    assert.equal(fakeState.appServerStarts ?? 0, 0);
+  }
+});
+
 test("task logs reasoning summaries and assistant messages to the job log", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -7,7 +7,8 @@ import { fileURLToPath } from "node:url";
 
 import { buildEnv, installFakeCodex } from "./fake-codex-fixture.mjs";
 import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
-import { loadBrokerSession, saveBrokerSession } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { createBrokerSessionDir, loadBrokerSession, saveBrokerSession } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { createBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-endpoint.mjs";
 import { resolveStateDir } from "../plugins/codex/scripts/lib/state.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -28,12 +29,40 @@ async function waitFor(predicate, { timeoutMs = 5000, intervalMs = 50 } = {}) {
   throw new Error("Timed out waiting for condition.");
 }
 
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+function withEnvVar(name, value, callback) {
+  const previous = process.env[name];
+  if (value == null) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+  try {
+    return callback();
+  } finally {
+    if (previous == null) {
+      delete process.env[name];
+    } else {
+      process.env[name] = previous;
+    }
+  }
+}
+
 test("setup reports ready when fake codex is installed and authenticated", () => {
   const binDir = makeTempDir();
   installFakeCodex(binDir);
 
+  const workspace = makeTempDir();
   const result = run("node", [SCRIPT, "setup", "--json"], {
-    cwd: ROOT,
+    cwd: workspace,
     env: buildEnv(binDir)
   });
 
@@ -45,12 +74,13 @@ test("setup reports ready when fake codex is installed and authenticated", () =>
 });
 
 test("setup is ready without npm when Codex is already installed and authenticated", () => {
+  const workspace = makeTempDir();
   const binDir = makeTempDir();
   installFakeCodex(binDir);
   fs.symlinkSync(process.execPath, path.join(binDir, "node"));
 
   const result = run("node", [SCRIPT, "setup", "--json"], {
-    cwd: ROOT,
+    cwd: workspace,
     env: {
       ...process.env,
       PATH: binDir
@@ -66,11 +96,12 @@ test("setup is ready without npm when Codex is already installed and authenticat
 });
 
 test("setup trusts app-server API key auth even when login status alone would fail", () => {
+  const workspace = makeTempDir();
   const binDir = makeTempDir();
   installFakeCodex(binDir, "api-key-account-only");
 
   const result = run("node", [SCRIPT, "setup", "--json"], {
-    cwd: ROOT,
+    cwd: workspace,
     env: buildEnv(binDir)
   });
 
@@ -84,11 +115,12 @@ test("setup trusts app-server API key auth even when login status alone would fa
 });
 
 test("setup is ready when the active provider does not require OpenAI login", () => {
+  const workspace = makeTempDir();
   const binDir = makeTempDir();
   installFakeCodex(binDir, "provider-no-auth");
 
   const result = run("node", [SCRIPT, "setup", "--json"], {
-    cwd: ROOT,
+    cwd: workspace,
     env: buildEnv(binDir)
   });
 
@@ -102,11 +134,12 @@ test("setup is ready when the active provider does not require OpenAI login", ()
 });
 
 test("setup treats custom providers with app-server-ready config as ready", () => {
+  const workspace = makeTempDir();
   const binDir = makeTempDir();
   installFakeCodex(binDir, "env-key-provider");
 
   const result = run("node", [SCRIPT, "setup", "--json"], {
-    cwd: ROOT,
+    cwd: workspace,
     env: buildEnv(binDir)
   });
 
@@ -120,11 +153,12 @@ test("setup treats custom providers with app-server-ready config as ready", () =
 });
 
 test("setup reports not ready when app-server config read fails", () => {
+  const workspace = makeTempDir();
   const binDir = makeTempDir();
   installFakeCodex(binDir, "config-read-fails");
 
   const result = run("node", [SCRIPT, "setup", "--json"], {
-    cwd: ROOT,
+    cwd: workspace,
     env: buildEnv(binDir)
   });
 
@@ -134,6 +168,33 @@ test("setup reports not ready when app-server config read fails", () => {
   assert.equal(payload.auth.loggedIn, false);
   assert.equal(payload.auth.source, "app-server");
   assert.match(payload.auth.detail, /config\/read failed for cwd/);
+});
+
+test("setup tests ignore a live broker for the repo cwd when run in a temp workspace", () => {
+  const workspace = makeTempDir();
+  const pluginDataDir = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+
+  withEnvVar("CLAUDE_PLUGIN_DATA", pluginDataDir, () => {
+    saveBrokerSession(ROOT, {
+      endpoint: "unix:/tmp/codex-plugin-test-live-root-broker.sock"
+    });
+  });
+
+  const result = run("node", [SCRIPT, "setup", "--json"], {
+    cwd: workspace,
+    env: {
+      ...buildEnv(binDir),
+      CLAUDE_PLUGIN_DATA: pluginDataDir
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.ready, true);
+  assert.equal(payload.sessionRuntime.mode, "direct");
+  assert.equal(payload.auth.loggedIn, true);
 });
 
 test("review renders a no-findings result from app-server review/start", () => {
@@ -1921,6 +1982,199 @@ test("session end fully cleans up jobs for the ending session", async (t) => {
   assert.deepEqual(state.jobs.map((job) => job.id), ["review-other"]);
   const otherJob = state.jobs[0];
   assert.equal(otherJob.logFile, otherSessionLog);
+});
+
+test("session end preserves shared broker while another session has active jobs", async (t) => {
+  const repo = makeTempDir();
+  const stateDir = resolveStateDir(repo);
+  const jobsDir = path.join(stateDir, "jobs");
+  fs.mkdirSync(jobsDir, { recursive: true });
+
+  const currentLog = path.join(jobsDir, "task-current.log");
+  const completedLog = path.join(jobsDir, "task-current-completed.log");
+  const otherLog = path.join(jobsDir, "task-other.log");
+  const currentJobFile = path.join(jobsDir, "task-current.json");
+  const completedJobFile = path.join(jobsDir, "task-current-completed.json");
+  const otherJobFile = path.join(jobsDir, "task-other.json");
+  for (const filePath of [currentLog, completedLog, otherLog]) {
+    fs.writeFileSync(filePath, "log\n", "utf8");
+  }
+  for (const filePath of [currentJobFile, completedJobFile, otherJobFile]) {
+    fs.writeFileSync(filePath, JSON.stringify({ id: path.basename(filePath, ".json") }, null, 2), "utf8");
+  }
+
+  fs.writeFileSync(
+    path.join(stateDir, "state.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        config: { stopReviewGate: false },
+        jobs: [
+          {
+            id: "task-current",
+            status: "queued",
+            sessionId: "sess-current",
+            logFile: currentLog,
+            createdAt: "2026-03-18T15:30:00.000Z",
+            updatedAt: "2026-03-18T15:31:00.000Z"
+          },
+          {
+            id: "task-current-completed",
+            status: "completed",
+            sessionId: "sess-current",
+            logFile: completedLog,
+            createdAt: "2026-03-18T15:32:00.000Z",
+            updatedAt: "2026-03-18T15:33:00.000Z"
+          },
+          {
+            id: "task-other",
+            status: "running",
+            sessionId: "sess-other",
+            logFile: otherLog,
+            createdAt: "2026-03-18T15:34:00.000Z",
+            updatedAt: "2026-03-18T15:35:00.000Z"
+          }
+        ]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  const brokerDir = createBrokerSessionDir("cxc-test-");
+  const endpoint = createBrokerEndpoint(brokerDir);
+  const socketPath = endpoint.startsWith("unix:") ? endpoint.slice(5) : endpoint;
+  const pidFile = path.join(brokerDir, "broker.pid");
+  const logFile = path.join(brokerDir, "broker.log");
+  const methodsLog = path.join(brokerDir, "received-methods.log");
+
+  // A REAL listening broker in a separate process — the test driver calls the
+  // SessionEnd hook via spawnSync (blocking), so an in-process socket server
+  // would deadlock: it could never accept the subprocess's connection. The
+  // stub records every JSON-RPC method it receives to a file and exits on
+  // broker/shutdown, so a hook that sends shutdown while another session has
+  // active jobs is caught, not silently tolerated by an unmanned socket.
+  const stubScript = `
+    const net = require("node:net");
+    const fs = require("node:fs");
+    const [sock, log] = process.argv.slice(1);
+    const server = net.createServer((socket) => {
+      socket.setEncoding("utf8");
+      let buffered = "";
+      socket.on("data", (chunk) => {
+        buffered += chunk;
+        let idx;
+        while ((idx = buffered.indexOf("\\n")) !== -1) {
+          const line = buffered.slice(0, idx);
+          buffered = buffered.slice(idx + 1);
+          if (!line.trim()) continue;
+          let message;
+          try { message = JSON.parse(line); } catch { continue; }
+          if (message.method) fs.appendFileSync(log, message.method + "\\n");
+          if (message.id !== undefined) socket.write(JSON.stringify({ id: message.id, result: {} }) + "\\n");
+          if (message.method === "broker/shutdown") { server.close(); process.exit(0); }
+        }
+      });
+    });
+    server.listen(sock);
+  `;
+  const brokerProcess = spawn(process.execPath, ["-e", stubScript, socketPath, methodsLog], {
+    cwd: repo,
+    detached: true,
+    stdio: "ignore"
+  });
+  brokerProcess.unref();
+  await waitFor(() => fs.existsSync(socketPath));
+  fs.writeFileSync(pidFile, `${brokerProcess.pid}\n`, "utf8");
+  fs.writeFileSync(logFile, "broker\n", "utf8");
+  saveBrokerSession(repo, {
+    endpoint,
+    pidFile,
+    logFile,
+    sessionDir: brokerDir,
+    pid: brokerProcess.pid
+  });
+
+  const receivedMethods = () =>
+    fs.existsSync(methodsLog)
+      ? fs.readFileSync(methodsLog, "utf8").split("\n").filter(Boolean)
+      : [];
+
+  t.after(() => {
+    try {
+      process.kill(brokerProcess.pid, "SIGKILL");
+    } catch {
+      // Ignore missing process.
+    }
+    fs.rmSync(brokerDir, { recursive: true, force: true });
+  });
+
+  const firstEnd = run("node", [SESSION_HOOK, "SessionEnd"], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      CODEX_COMPANION_SESSION_ID: "sess-current"
+    },
+    input: JSON.stringify({
+      hook_event_name: "SessionEnd",
+      session_id: "sess-current",
+      cwd: repo
+    })
+  });
+  assert.equal(firstEnd.status, 0, firstEnd.stderr);
+  assert.ok(loadBrokerSession(repo));
+  assert.equal(isProcessAlive(brokerProcess.pid), true);
+  assert.equal(
+    receivedMethods().includes("broker/shutdown"),
+    false,
+    "broker/shutdown must not be sent while another session has active jobs"
+  );
+  assert.equal(fs.existsSync(currentLog), false);
+  assert.equal(fs.existsSync(completedLog), false);
+  assert.equal(fs.existsSync(currentJobFile), false);
+  assert.equal(fs.existsSync(completedJobFile), false);
+  assert.equal(fs.existsSync(otherLog), true);
+  assert.equal(fs.existsSync(otherJobFile), true);
+
+  let state = JSON.parse(fs.readFileSync(path.join(stateDir, "state.json"), "utf8"));
+  assert.deepEqual(state.jobs.map((job) => job.id), ["task-other"]);
+  assert.equal(state.jobs[0].status, "running");
+
+  state.jobs[0] = {
+    ...state.jobs[0],
+    status: "completed",
+    updatedAt: "2026-03-18T15:36:00.000Z"
+  };
+  fs.writeFileSync(path.join(stateDir, "state.json"), `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+  const lastEnd = run("node", [SESSION_HOOK, "SessionEnd"], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      CODEX_COMPANION_SESSION_ID: "sess-other"
+    },
+    input: JSON.stringify({
+      hook_event_name: "SessionEnd",
+      session_id: "sess-other",
+      cwd: repo
+    })
+  });
+  assert.equal(lastEnd.status, 0, lastEnd.stderr);
+  assert.equal(loadBrokerSession(repo), null);
+  assert.ok(
+    receivedMethods().includes("broker/shutdown"),
+    "the last session out must actually request broker shutdown"
+  );
+  assert.equal(fs.existsSync(otherLog), false);
+  assert.equal(fs.existsSync(otherJobFile), false);
+  assert.equal(fs.existsSync(pidFile), false);
+  assert.equal(fs.existsSync(logFile), false);
+
+  await waitFor(() => !isProcessAlive(brokerProcess.pid));
+
+  state = JSON.parse(fs.readFileSync(path.join(stateDir, "state.json"), "utf8"));
+  assert.deepEqual(state.jobs, []);
 });
 
 test("stop hook runs a stop-time review task and blocks on findings when the review gate is enabled", () => {


### PR DESCRIPTION
> **Authored by Claude (Opus 4.8) + Codex (gpt-5.5)** — written and reviewed collaboratively across several passes.

Fixes a family of bugs that appear when more than one Claude Code session shares
a project directory. The broker and state files are keyed by cwd, so sessions
coordinate through shared processes and files — with no coordination primitive.

## What this fixes

1. **SessionEnd tore down a broker other sessions were using.** Any session
   ending shut down the cwd-shared broker with no ownership check, killing other
   sessions' running jobs and leaving records stuck at `"running"`. Teardown is
   now skipped while another session has active jobs; SessionEnd reads job state
   directly (fails closed if unreadable) and removes only its own artifacts.
2. **The broker kept answering after its child app-server died (#402).** Health
   probes passed locally, so the next turn failed with a bare `connection closed`
   in a pass/fail/pass/fail pattern. The broker now exits when its child exits,
   and the client treats `connection closed` as a broker failure worth a retry.
3. **The test suite leaked ~25–30 broker processes per run, and setup tests read
   live workspace state** (a live repo-root broker failed five unrelated tests).
   Fixed with a global broker-cleanup hook and temp-cwd isolation.
4. **Concurrency-safety hardening:** state writes no longer delete a
   queued/running job's files, `broker.json` is written atomically, and
   `terminateProcessTree` no longer group-kills `pid <= 1`.

This ships the safe, self-contained fixes. It does **not** attempt the larger
refactor the pattern calls for (a state-transaction lock and a broker-acquisition
lease) — that's a design change better done as its own PR. The analysis below
explains why.

## Tests

`node --test tests/*.test.mjs` → **92/92**, verified across repeated sequential
runs. (Earlier intermittent hangs were host contention from running multiple
suites at once, not a code issue.) Follow-ups, not in this PR: dedicated
regression tests for the #402 retry path and the `pid <= 1` guard.

Related: #380, #402, #286, #416.

---

<details>
<summary><b>The core problem</b> — why 19 findings, one cause</summary>

`codex-plugin-cc` coordinates several independent OS processes — interactive
sessions, detached background workers, and lifecycle hooks — through shared JSON
files (`state.json`, `broker.json`) and one broker process, all keyed by the
working directory. Nothing serialises them: there is no cross-process lock,
compare-and-swap, or liveness check anywhere in the tree, so every mutation is an
unguarded read-modify-write or check-then-act done as if a single owner held the
files. The `tmp+rename` writes keep individual writes from tearing but never make
the compound operations atomic — which is why the same defect surfaces
repeatedly: concurrent processes clobber each other's records, spawn duplicate
brokers, and delete files or kill pids out from under a peer still using them.

An eight-surface audit (each finding checked by a separate verifier) confirmed 19
multi-session races. They collapse to a few root causes:

| Cluster | Root cause | Findings |
|--------|-----------|:--------:|
| **A. Unlocked `state.json`** | `load → mutate → save` is not atomic across processes, and `saveState` then deletes job files absent from a possibly-stale snapshot | **8** |
| **B. No broker ownership** | cold-start spawn is check-then-act with no lock; `broker.json` written non-atomically | **4** |
| **C. `BROKER_BUSY` handling** | write tasks retry direct (two agents on one tree); setup/auth reports a busy broker as logged-out | **3** |
| **D. PID trusted without identity** | stored pids group-killed with no liveness/identity check (PID reuse) | **2** |
| **E. Cancel clobber** | cancel overwrites a job that finished mid-cancel | **1** |
| **F. Jobless-broker ownership** | teardown gate counts only tracked jobs | **1** |

Clusters A and B are twelve of the nineteen, and most come down to one thing:
no lock on a shared file.

</details>

<details>
<summary><b>The bugs in the source</b> — pre-fix code, pinned permalinks</summary>

**1. SessionEnd shut the broker down unconditionally** — no check for other
sessions or their jobs:

📍 [`plugins/codex/scripts/session-lifecycle-hook.mjs:101-114 @ 86ea7dd`](https://github.com/sublimator/codex-plugin-cc/blob/86ea7dd6cd57b847b55cda2efcecb0e23fcd31ca/plugins/codex/scripts/session-lifecycle-hook.mjs#L101-L114)
```javascript
 101   if (brokerEndpoint) {
 102     await sendBrokerShutdown(brokerEndpoint);
 103   }
 104 
 105   cleanupSessionJobs(cwd, input.session_id || process.env[SESSION_ID_ENV]);
 106   teardownBrokerSession({
 107     endpoint: brokerEndpoint,
 108     pidFile,
 109     logFile,
 110     sessionDir,
 111     pid,
 112     killProcess: terminateProcessTree
 113   });
 114   clearBrokerSession(cwd);
```

**3. Setup tests ran in the real repo root**, so a live broker for the repo made
them read live state:

📍 [`tests/runtime.test.mjs:36-45 @ 86ea7dd`](https://github.com/sublimator/codex-plugin-cc/blob/86ea7dd6cd57b847b55cda2efcecb0e23fcd31ca/tests/runtime.test.mjs#L36-L45)
```javascript
  36   const result = run("node", [SCRIPT, "setup", "--json"], {
  37     cwd: ROOT,
  38     env: buildEnv(binDir)
  39   });
  40 
  41   assert.equal(result.status, 0);
  42   const payload = JSON.parse(result.stdout);
  43   assert.equal(payload.ready, true);
  44   assert.match(payload.codex.detail, /advanced runtime available/);
  45   assert.equal(payload.sessionRuntime.mode, "direct");
```

The test harness reaped a throwaway `sleep` process but never the brokers it
spawned:

📍 [`tests/runtime.test.mjs:1560-1570 @ 86ea7dd`](https://github.com/sublimator/codex-plugin-cc/blob/86ea7dd6cd57b847b55cda2efcecb0e23fcd31ca/tests/runtime.test.mjs#L1560-L1570)
```javascript
1560   t.after(() => {
1561     try {
1562       process.kill(-sleeper.pid, "SIGTERM");
1563     } catch {
1564       try {
1565         process.kill(sleeper.pid, "SIGTERM");
1566       } catch {
1567         // Ignore missing process.
1568       }
1569     }
1570   });
```

Full worked write-ups for all four bugs — with more extracts — are in the
[dossier](https://github.com/sublimator/codex-plugin-cc/blob/14da37e30dceef71b9c31905347a7dad807a6e26/dossier/broker-lifecycle.md)
on the `analysis/broker-lifecycle` branch.

</details>

<details>
<summary><b>What the fixes reach, and the refactor they don't</b></summary>

The race and the damage are separable, and the damage is the simpler thing to
fix. This PR targets the destruction, not the race:

- `broker.json` atomic write (was missing; `state.json` already had it).
- A GC guard so `saveState`/`pruneJobs` never delete a queued/running job's
  files — a concurrent worker's output survives a stale write.
- The `pid > 1` group-kill guard, the #402 broker self-teardown, and the
  SessionEnd ownership gate.

The seam the simple fix can't reach: `saveState` still writes the caller's whole
job array, so a stale write can drop another session's job *record* (its files
now survive, but the ownership gate can't see it) or resurrect a finished job as
`running`. Closing that needs the lock, or a merge that knows the caller's
intent. That's the refactor, out of scope here:

1. **A locked state transaction** around `load → mutate → save`, with
   `cleanupSessionJobs` reading fresh state — closes cluster A.
2. **The same lock around broker acquisition** (one lease, no duplicate
   cold-start brokers) — closes cluster B.
3. **Treat `BROKER_BUSY` as serialisation, not transport failure** for write
   tasks — a protocol decision, closes finding 5.
4. PID identity before group-kill, compare-and-set on cancel, broker-side
   shutdown awareness — the tail.

Items 1–2 are the lock and cover about half; 3–4 are separate mechanisms. One
design change plus a few independent fixes — fewer moving parts than nineteen
tickets, but more than one lever.

</details>