### PR TITLE
fix: surface the real task error in the stop-review gate instead of stderr noise

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -661,7 +661,13 @@ async function runForegroundCommand(job, runner, options = {}) {
     stderr: !options.json
   });
   const execution = await runTrackedJob(job, () => runner(progress), { logFile });
-  outputResult(options.json ? execution.payload : execution.rendered, options.json);
+  // Include the human-readable message in JSON output so callers (e.g. the
+  // stop-review gate hook) can surface the real error instead of stderr noise.
+  const jsonPayload =
+    execution.payload && typeof execution.payload === "object" && !Array.isArray(execution.payload)
+      ? { ...execution.payload, rendered: execution.rendered }
+      : execution.payload;
+  outputResult(options.json ? jsonPayload : execution.rendered, options.json);
   if (execution.exitStatus !== 0) {
     process.exitCode = execution.exitStatus;
   }

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -118,7 +118,23 @@ function runStopReview(cwd, input = {}) {
   }
 
   if (result.status !== 0) {
-    const detail = String(result.stderr || result.stdout || "").trim();
+    // Prefer the real error from the companion's JSON stdout: stderr often
+    // contains only Node runtime noise (e.g. DEP0190) that masks the cause.
+    let detail = "";
+    try {
+      const payload = JSON.parse(result.stdout);
+      detail = String(payload?.rendered ?? "").trim();
+    } catch {
+      // stdout was not JSON; fall through to stderr/stdout below.
+    }
+    if (!detail) {
+      const stderrClean = String(result.stderr || "")
+        .split(/\r?\n/)
+        .filter((line) => !/DeprecationWarning|--trace-deprecation/.test(line))
+        .join("\n")
+        .trim();
+      detail = stderrClean || String(result.stdout || "").trim();
+    }
     return {
       ok: false,
       reason: detail


### PR DESCRIPTION
## Problem

When the stop-review gate's companion task fails (`codex-companion.mjs task --json` exits non-zero), the hook reports `result.stderr || result.stdout` as the failure reason:

```js
const detail = String(result.stderr || result.stdout || "").trim();
```

On some setups (observed on Windows + recent Node), the child's stderr contains only Node runtime noise:

```
(node:10964) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
```

Since a non-empty stderr wins over stdout, this deprecation warning **masks the real error**, which is only available as the human-readable message of the failed run. The user sees the gate block with a `DeprecationWarning` as the "reason" and has no idea what actually failed.

Real-world example: the actual failure was a Codex usage-limit error (`You've hit your usage limit... try again at Aug 5th`), but the hook surfaced only the DEP0190 line. Diagnosing it required digging into the job log files under the plugin state directory.

## Fix

Two small, backward-compatible changes:

1. **`codex-companion.mjs`** — `runForegroundCommand` now includes the human-readable `rendered` message in the `--json` payload (additive field; existing consumers that parse `rawOutput`, `status`, etc. are unaffected).

2. **`stop-review-gate-hook.mjs`** — on non-zero exit, the hook now resolves the failure detail in order of usefulness:
   1. `payload.rendered` parsed from the JSON stdout (the real error),
   2. stderr with `DeprecationWarning` noise lines filtered out,
   3. raw stdout as a last resort.

## Before / after

Before:

```
The stop-time Codex review task failed: (node:19580) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true...
```

After:

```
The stop-time Codex review task failed: You've hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), or try again at Aug 5th, 2026 3:58 AM.
```

Verified end-to-end on Windows 11 / Node against a live failing Codex run (usage-limit error): the gate now blocks with the actual cause in `reason`, exit code 0, valid decision JSON. `node --test` suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
