### PR TITLE
Remove shell expansion for git commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Codex plugins to use in Claude Code for delegation and code review.",
-    "version": "1.0.5"
+    "version": "1.0.6"
   },
   "plugins": [
     {
       "name": "codex",
       "description": "Use Codex from Claude Code to review code or delegate tasks.",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "author": {
         "name": "OpenAI"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openai/codex-plugin-cc",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "type": "module",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",

--- a/plugins/codex/.claude-plugin/plugin.json
+++ b/plugins/codex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "OpenAI"

--- a/plugins/codex/scripts/lib/git.mjs
+++ b/plugins/codex/scripts/lib/git.mjs
@@ -8,12 +8,13 @@ const MAX_UNTRACKED_BYTES = 24 * 1024;
 const DEFAULT_INLINE_DIFF_MAX_FILES = 2;
 const DEFAULT_INLINE_DIFF_MAX_BYTES = 256 * 1024;
 
+// Git is directly executable on Windows. Repository-derived arguments must never pass through a shell.
 function git(cwd, args, options = {}) {
-  return runCommand("git", args, { cwd, ...options });
+  return runCommand("git", args, { cwd, ...options, shell: false });
 }
 
 function gitChecked(cwd, args, options = {}) {
-  return runCommandChecked("git", args, { cwd, ...options });
+  return runCommandChecked("git", args, { cwd, ...options, shell: false });
 }
 
 function listUniqueFiles(...groups) {

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -9,7 +9,7 @@ export function runCommand(command, args = [], options = {}) {
     input: options.input,
     maxBuffer: options.maxBuffer,
     stdio: options.stdio ?? "pipe",
-    shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
+    shell: options.shell ?? (process.platform === "win32" ? (process.env.SHELL || true) : false),
     windowsHide: true
   });
 

--- a/tests/git.test.mjs
+++ b/tests/git.test.mjs
@@ -38,6 +38,35 @@ test("resolveReviewTarget falls back to branch diff when repo is clean", () => {
   assert.match(context.content, /Branch Diff/);
 });
 
+test("default branch names with special characters are passed to git literally", () => {
+  const cwd = makeTempDir();
+  const branchName = "main&branch-helper&x";
+  const helperOutputPath = path.join(cwd, "branch-helper-output");
+  initGitRepo(cwd);
+  fs.writeFileSync(path.join(cwd, "branch-helper.cmd"), "@echo branch-helper>branch-helper-output\r\n");
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('base');\n");
+  run("git", ["add", "app.js", "branch-helper.cmd"], { cwd });
+  run("git", ["commit", "-m", "base"], { cwd });
+  run("git", ["branch", "-m", branchName], { cwd, shell: false });
+  run("git", ["update-ref", `refs/remotes/origin/${branchName}`, branchName], { cwd, shell: false });
+  run("git", ["symbolic-ref", "refs/remotes/origin/HEAD", `refs/remotes/origin/${branchName}`], {
+    cwd,
+    shell: false
+  });
+  run("git", ["checkout", "-b", "feature/test"], { cwd });
+  fs.writeFileSync(path.join(cwd, "app.js"), "console.log('feature');\n");
+  run("git", ["add", "app.js"], { cwd });
+  run("git", ["commit", "-m", "feature"], { cwd });
+
+  const target = resolveReviewTarget(cwd, {});
+  const context = collectReviewContext(cwd, target);
+
+  assert.equal(target.mode, "branch");
+  assert.equal(target.baseRef, branchName);
+  assert.match(context.content, /Branch Diff/);
+  assert.equal(fs.existsSync(helperOutputPath), false);
+});
+
 test("resolveReviewTarget honors explicit base overrides", () => {
   const cwd = makeTempDir();
   initGitRepo(cwd);

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -18,7 +18,7 @@ export function run(command, args, options = {}) {
     env: options.env,
     encoding: "utf8",
     input: options.input,
-    shell: process.platform === "win32" && !path.isAbsolute(command),
+    shell: options.shell ?? (process.platform === "win32" && !path.isAbsolute(command)),
     windowsHide: true
   });
 }


### PR DESCRIPTION
## Summary

Ensure Git commands are executed directly on Windows instead of being routed through a shell.

Git reference names can contain characters that Windows shells interpret specially. Passing those references through `shell: true` can therefore change the meaning of an otherwise valid Git command. This change keeps Git arguments as a literal argv array by forcing `shell: false` in the shared Git helpers.

## Historical context

Windows npm installations expose tools such as `npm` and `codex` through `.cmd` shims, which Node cannot launch directly in some configurations.

- [#13](https://github.com/openai/codex-plugin-cc/pull/13) enabled `shell: true` for the shared synchronous command runner so Windows could resolve those shims.
- [#55](https://github.com/openai/codex-plugin-cc/pull/55) added equivalent handling for the Codex app-server process, along with hidden-window and process-tree cleanup behavior.
- [#178](https://github.com/openai/codex-plugin-cc/pull/178) made Windows launches respect `SHELL`, preserving compatibility with Git Bash.

Those changes fixed important Windows behavior, but the shared command runner also handles Git. Unlike `npm` and `codex`, Git is directly executable on Windows and does not need shell-based `.cmd` resolution.

## Changes

- Allow callers of `runCommand` to override its shell setting.
- Force `shell: false` in both Git command helpers.
- Apply the Git override after caller-provided options so it cannot be re-enabled accidentally.
- Add regression coverage for an automatically detected default branch containing shell-special characters.
- Update the test command helper to support an explicit shell setting when constructing the fixture.

The regression test verifies that the branch name is passed to Git literally and that an adjacent command helper is not executed.

## Compatibility

The existing Windows behavior remains unchanged for commands that require it:

- npm and Codex `.cmd` discovery continues to use the configured Windows shell.
- Codex app-server startup continues to respect `SHELL` for Git Bash users.
- Existing Windows process-tree cleanup and hidden-window behavior are unaffected.
- macOS and Linux behavior is unchanged.

This approach avoids restricting valid Git reference names and confines the change to the command path that does not require shell expansion.

## Validation

- `npm test`: **91 tests passed**
- Focused Git tests: **11 tests passed**
- `git diff --check`: clean