### PR TITLE
fix: hide detached broker window on Windows

### DIFF
--- a/plugins/codex/scripts/lib/broker-lifecycle.mjs
+++ b/plugins/codex/scripts/lib/broker-lifecycle.mjs
@@ -56,12 +56,13 @@ export async function sendBrokerShutdown(endpoint) {
   });
 }
 
-export function spawnBrokerProcess({ scriptPath, cwd, endpoint, pidFile, logFile, env = process.env }) {
+export function spawnBrokerProcess({ scriptPath, cwd, endpoint, pidFile, logFile, env = process.env, spawnImpl = spawn }) {
   const logFd = fs.openSync(logFile, "a");
-  const child = spawn(process.execPath, [scriptPath, "serve", "--endpoint", endpoint, "--cwd", cwd, "--pid-file", pidFile], {
+  const child = spawnImpl(process.execPath, [scriptPath, "serve", "--endpoint", endpoint, "--cwd", cwd, "--pid-file", pidFile], {
     cwd,
     env,
     detached: true,
+    windowsHide: true,
     stdio: ["ignore", logFd, logFd]
   });
   child.unref();

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import process from "node:process";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { getCodexAvailability } from "./lib/codex.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
@@ -95,18 +95,19 @@ function parseStopReviewOutput(rawOutput) {
   };
 }
 
-function runStopReview(cwd, input = {}) {
+export function runStopReview(cwd, input = {}, { spawnSyncImpl = spawnSync } = {}) {
   const scriptPath = path.join(SCRIPT_DIR, "codex-companion.mjs");
   const prompt = buildStopReviewPrompt(input);
   const childEnv = {
     ...process.env,
     ...(input.session_id ? { [SESSION_ID_ENV]: input.session_id } : {})
   };
-  const result = spawnSync(process.execPath, [scriptPath, "task", "--json", prompt], {
+  const result = spawnSyncImpl(process.execPath, [scriptPath, "task", "--json", prompt], {
     cwd,
     env: childEnv,
     encoding: "utf8",
-    timeout: STOP_REVIEW_TIMEOUT_MS
+    timeout: STOP_REVIEW_TIMEOUT_MS,
+    windowsHide: true
   });
 
   if (result.error?.code === "ETIMEDOUT") {
@@ -175,10 +176,16 @@ function main() {
   logNote(runningTaskNote);
 }
 
-try {
-  main();
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`${message}\n`);
-  process.exitCode = 1;
+function isMainModule() {
+  return process.argv[1] ? import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href : false;
+}
+
+if (isMainModule()) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
 }

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import process from "node:process";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 import { getCodexAvailability } from "./lib/codex.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
@@ -176,8 +176,17 @@ function main() {
   logNote(runningTaskNote);
 }
 
-function isMainModule() {
-  return process.argv[1] ? import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href : false;
+export function isMainModule(entryPath = process.argv[1]) {
+  if (!entryPath) {
+    return false;
+  }
+
+  const modulePath = fileURLToPath(import.meta.url);
+  try {
+    return fs.realpathSync.native(modulePath) === fs.realpathSync.native(path.resolve(entryPath));
+  } catch {
+    return modulePath === path.resolve(entryPath);
+  }
 }
 
 if (isMainModule()) {

--- a/tests/broker-lifecycle.test.mjs
+++ b/tests/broker-lifecycle.test.mjs
@@ -1,0 +1,50 @@
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { spawnBrokerProcess } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { makeTempDir } from "./helpers.mjs";
+
+test("spawnBrokerProcess hides detached broker windows on Windows", () => {
+  const cwd = makeTempDir();
+  const logFile = path.join(cwd, "broker.log");
+  const pidFile = path.join(cwd, "broker.pid");
+  let captured = null;
+  let unrefCalled = false;
+
+  const child = spawnBrokerProcess({
+    scriptPath: path.join(cwd, "app-server-broker.mjs"),
+    cwd,
+    endpoint: "unix:/tmp/broker.sock",
+    pidFile,
+    logFile,
+    env: { PATH: "/bin" },
+    spawnImpl(command, args, options) {
+      captured = { command, args, options };
+      return {
+        pid: 1234,
+        unref() {
+          unrefCalled = true;
+        }
+      };
+    }
+  });
+
+  assert.equal(child.pid, 1234);
+  assert.equal(unrefCalled, true);
+  assert.equal(captured.options.cwd, cwd);
+  assert.equal(captured.options.detached, true);
+  assert.equal(captured.options.windowsHide, true);
+  assert.deepEqual(captured.options.env, { PATH: "/bin" });
+  assert.deepEqual(captured.options.stdio.slice(0, 1), ["ignore"]);
+  assert.deepEqual(captured.args, [
+    path.join(cwd, "app-server-broker.mjs"),
+    "serve",
+    "--endpoint",
+    "unix:/tmp/broker.sock",
+    "--cwd",
+    cwd,
+    "--pid-file",
+    pidFile
+  ]);
+});

--- a/tests/stop-review-gate-hook.test.mjs
+++ b/tests/stop-review-gate-hook.test.mjs
@@ -1,0 +1,39 @@
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runStopReview } from "../plugins/codex/scripts/stop-review-gate-hook.mjs";
+import { makeTempDir } from "./helpers.mjs";
+
+test("runStopReview hides stop-gate task windows on Windows", () => {
+  const cwd = makeTempDir();
+  let captured = null;
+
+  const result = runStopReview(
+    cwd,
+    {
+      session_id: "session-123",
+      last_assistant_message: "Looks good."
+    },
+    {
+      spawnSyncImpl(command, args, options) {
+        captured = { command, args, options };
+        return {
+          status: 0,
+          stdout: JSON.stringify({ rawOutput: "ALLOW: no blocking issues" }),
+          stderr: "",
+          error: null
+        };
+      }
+    }
+  );
+
+  assert.equal(result.ok, true);
+  assert.equal(captured.command, process.execPath);
+  assert.deepEqual(captured.args.slice(1, 3), ["task", "--json"]);
+  assert.equal(path.basename(captured.args[0]), "codex-companion.mjs");
+  assert.equal(captured.options.cwd, cwd);
+  assert.equal(captured.options.encoding, "utf8");
+  assert.equal(captured.options.windowsHide, true);
+  assert.equal(captured.options.env.CODEX_COMPANION_SESSION_ID, "session-123");
+});

--- a/tests/stop-review-gate-hook.test.mjs
+++ b/tests/stop-review-gate-hook.test.mjs
@@ -1,9 +1,14 @@
+import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { runStopReview } from "../plugins/codex/scripts/stop-review-gate-hook.mjs";
+import { isMainModule, runStopReview } from "../plugins/codex/scripts/stop-review-gate-hook.mjs";
 import { makeTempDir } from "./helpers.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const STOP_HOOK = path.join(ROOT, "plugins", "codex", "scripts", "stop-review-gate-hook.mjs");
 
 test("runStopReview hides stop-gate task windows on Windows", () => {
   const cwd = makeTempDir();
@@ -36,4 +41,12 @@ test("runStopReview hides stop-gate task windows on Windows", () => {
   assert.equal(captured.options.encoding, "utf8");
   assert.equal(captured.options.windowsHide, true);
   assert.equal(captured.options.env.CODEX_COMPANION_SESSION_ID, "session-123");
+});
+
+test("isMainModule treats a symlinked hook path as the hook entrypoint", () => {
+  const cwd = makeTempDir();
+  const linkedHook = path.join(cwd, "stop-review-gate-hook.mjs");
+  fs.symlinkSync(STOP_HOOK, linkedHook);
+
+  assert.equal(isMainModule(linkedHook), true);
 });


### PR DESCRIPTION
## Summary

- Add `windowsHide: true` to the detached broker spawn path.
- Add a focused unit test covering the broker spawn options.

Fixes #440.

## Test plan

- `node --test tests/broker-lifecycle.test.mjs`
- `git diff --check`
- `npm test`
- `npm run build`