### PR TITLE
Terminate broker when its app-server child exits (fixes wedged/zombie broker hangs)

### DIFF
--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -99,7 +99,12 @@ async function main() {
     }
   }
 
+  let terminating = false;
   async function shutdown(server) {
+    if (terminating) {
+      return;
+    }
+    terminating = true;
     for (const socket of sockets) {
       socket.end();
     }
@@ -241,6 +246,20 @@ async function main() {
   process.on("SIGINT", async () => {
     await shutdown(server);
     process.exit(0);
+  });
+
+  // The broker proxies every request to the single app-server child spawned
+  // above. If that child exits, appClient can no longer serve: request() writes
+  // to a closed stdin and its promise never resolves, so a caller hangs forever
+  // (a submitted turn/task sits at "starting" and is never answered). The broker
+  // stays up as a zombie because its listening socket still accepts connections,
+  // so ensureBrokerSession() keeps reusing it. Terminate when the child exits so
+  // the stale socket/pid-file are removed and the next connect spawns a fresh,
+  // working broker.
+  appClient.exitPromise.then(() => {
+    if (!terminating) {
+      shutdown(server).finally(() => process.exit(1));
+    }
   });
 
   server.listen(listenTarget.path);


### PR DESCRIPTION
## Problem

The app-server broker (`scripts/app-server-broker.mjs`) spawns exactly one `codex app-server` child at startup and proxies every request to it. If that child exits at any point, the broker becomes a **zombie that accepts connections but can never serve a request again**:

- `AppServerClientBase.handleExit()` rejects in-flight requests but does not set `closed`, and nothing respawns the child.
- The next `request()` therefore passes the `if (this.closed)` guard, registers a pending promise, and writes to the dead child's stdin — the promise **never resolves**.
- So `await appClient.request(...)` in the broker's data handler hangs forever, the client sees its submitted `turn/start` / `review/start` sit at "starting" indefinitely, and it is eventually reported lost.
- Because the broker's listening socket is still up, `ensureBrokerSession()` (whose readiness check is a bare socket connect) keeps **reusing the same wedged broker**, so every subsequent Codex review/task from that workspace wedges the same way until the broker is killed manually.

We observed this repeatedly on a busy multi-session machine: brokers whose app-server child had died (e.g. reaped by an unrelated process sweeper, OOM, or a crash) lingered for many hours with zero children, and every Codex review routed to them hung.

## Fix

Register a handler on `appClient.exitPromise` that shuts the broker down and exits (code 1) as soon as the app-server child is gone. This removes the stale unix socket + pid-file, so the next `ensureBrokerSession()` sees a dead endpoint and spawns a fresh, working broker instead of binding the zombie. A `terminating` flag guards against racing an intentional shutdown (`broker/shutdown`, `SIGTERM`/`SIGINT`).

Net effect: a broker whose backing app-server dies now fails closed and self-heals on next use, instead of silently swallowing every future request.

## Testing

- `node --check` passes.
- Spawned a broker from the patched script, killed its `codex app-server` child, and confirmed the broker process exits and its socket is removed (vs. the unpatched build, where the broker stays up childless and the next request hangs).
- Verified the guard prevents a double-shutdown on the normal `broker/shutdown` path.

Small, self-contained change; no interface or behavior change on the healthy path.
