### PR TITLE
fix: accept max and ultra reasoning efforts for task --effort

### DIFF
--- a/plugins/codex/commands/rescue.md
+++ b/plugins/codex/commands/rescue.md
@@ -1,6 +1,6 @@
 ---
 description: Delegate investigation, an explicit fix request, or follow-up rescue work to the Codex rescue subagent
-argument-hint: "[--background|--wait] [--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [what Codex should investigate, solve, or continue]"
+argument-hint: "[--background|--wait] [--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh|max|ultra>] [what Codex should investigate, solve, or continue]"
 allowed-tools: Bash(node:*), AskUserQuestion, Agent
 ---
 

--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -70,8 +70,26 @@ async function main() {
   let activeStreamSocket = null;
   let activeStreamThreadIds = null;
   const sockets = new Set();
+  // Requests on one socket can overlap (a client may stop waiting for a slow request
+  // and issue the next one), so request ownership must be refcounted: releasing the
+  // slot on the FIRST completion would drop notifications for the still-running
+  // request and let another socket bypass serialization mid-flight.
+  const inflightRequests = new Map();
+
+  function releaseRequestSlot(socket) {
+    const remaining = (inflightRequests.get(socket) ?? 1) - 1;
+    if (remaining > 0) {
+      inflightRequests.set(socket, remaining);
+      return;
+    }
+    inflightRequests.delete(socket);
+    if (activeRequestSocket === socket) {
+      activeRequestSocket = null;
+    }
+  }
 
   function clearSocketOwnership(socket) {
+    inflightRequests.delete(socket);
     if (activeRequestSocket === socket) {
       activeRequestSocket = null;
     }
@@ -196,6 +214,7 @@ async function main() {
 
         const isStreaming = STREAMING_METHODS.has(message.method);
         activeRequestSocket = socket;
+        inflightRequests.set(socket, (inflightRequests.get(socket) ?? 0) + 1);
 
         try {
           const result = await appClient.request(message.method, message.params ?? {});
@@ -204,17 +223,13 @@ async function main() {
             activeStreamSocket = socket;
             activeStreamThreadIds = buildStreamThreadIds(message.method, message.params ?? {}, result);
           }
-          if (activeRequestSocket === socket) {
-            activeRequestSocket = null;
-          }
+          releaseRequestSlot(socket);
         } catch (error) {
           send(socket, {
             id: message.id,
             error: buildJsonRpcError(error.rpcCode ?? -32000, error.message)
           });
-          if (activeRequestSocket === socket) {
-            activeRequestSocket = null;
-          }
+          releaseRequestSlot(socket);
           // Deliberately keep activeStreamSocket: a failed NON-streaming request must not
           // strip stream ownership from an in-flight turn on the same socket, or its
           // turn/completed notifications are dropped and the client hangs forever.

--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -215,9 +215,9 @@ async function main() {
           if (activeRequestSocket === socket) {
             activeRequestSocket = null;
           }
-          if (activeStreamSocket === socket && !isStreaming) {
-            activeStreamSocket = null;
-          }
+          // Deliberately keep activeStreamSocket: a failed NON-streaming request must not
+          // strip stream ownership from an in-flight turn on the same socket, or its
+          // turn/completed notifications are dropped and the client hangs forever.
         }
       }
     });

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -68,7 +68,7 @@ const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json");
 const DEFAULT_STATUS_WAIT_TIMEOUT_MS = 240000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
-const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
+const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
 const MODEL_ALIASES = new Map([["spark", "gpt-5.3-codex-spark"]]);
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
 
@@ -79,7 +79,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh|max|ultra>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
@@ -121,7 +121,7 @@ function normalizeReasoningEffort(effort) {
   }
   if (!VALID_REASONING_EFFORTS.has(normalized)) {
     throw new Error(
-      `Unsupported reasoning effort "${effort}". Use one of: none, minimal, low, medium, high, xhigh.`
+      `Unsupported reasoning effort "${effort}". Use one of: ${[...VALID_REASONING_EFFORTS].join(", ")}.`
     );
   }
   return normalized;

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -1121,11 +1121,6 @@ async function fetchModelCatalog(client) {
   }
 }
 
-function catalogDefaultModel(entries) {
-  const entry = Array.isArray(entries) ? entries.find((item) => item && item.isDefault) : null;
-  return entry ? entry.id ?? entry.model ?? null : null;
-}
-
 function assertCatalogSupportsEffort(entries, resolvedModel, effort, onProgress) {
   if (!entries) {
     emitEffortValidationSkip(onProgress, effort, "model catalog unavailable or malformed");
@@ -1164,7 +1159,12 @@ export async function runAppServerTurn(cwd, options = {}) {
 
   return withAppServer(cwd, async (client) => {
     let threadId;
-    const catalogEntries = options.effort ? await fetchModelCatalog(client) : null;
+    // Validate only an explicit --model/--effort pair. Without --model the target is
+    // whatever the server resolves (the config.toml default on fresh dispatches, the
+    // thread's own model on resume) — the catalog's global isDefault entry is NOT that
+    // model, so guessing here falsely rejects documented flows.
+    const shouldValidateEffort = Boolean(options.effort) && Boolean(options.model);
+    const catalogEntries = shouldValidateEffort ? await fetchModelCatalog(client) : null;
 
     if (options.resumeThreadId) {
       emitProgress(options.onProgress, `Resuming thread ${options.resumeThreadId}.`, "starting");
@@ -1174,13 +1174,12 @@ export async function runAppServerTurn(cwd, options = {}) {
         ephemeral: false
       });
       threadId = response.thread.id;
-      if (options.effort) {
-        assertCatalogSupportsEffort(catalogEntries, response.model ?? null, options.effort, options.onProgress);
+      if (shouldValidateEffort) {
+        assertCatalogSupportsEffort(catalogEntries, response.model ?? options.model, options.effort, options.onProgress);
       }
     } else {
-      if (options.effort) {
-        const targetModel = options.model ?? catalogDefaultModel(catalogEntries);
-        assertCatalogSupportsEffort(catalogEntries, targetModel, options.effort, options.onProgress);
+      if (shouldValidateEffort) {
+        assertCatalogSupportsEffort(catalogEntries, options.model, options.effort, options.onProgress);
       }
       emitProgress(options.onProgress, "Starting Codex task thread.", "starting");
       const response = await startThread(client, cwd, {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -1094,44 +1094,50 @@ export async function importExternalAgentSession(cwd, options = {}) {
 
 const MODEL_LIST_TIMEOUT_MS = 3000;
 
-async function validateReasoningEffortForModel(client, resolvedModel, effort, onProgress) {
-  const skip = (reason) => {
-    emitProgress(
-      onProgress,
-      `Warning: skipping reasoning-effort validation (${reason}); dispatching effort "${effort}" as requested.`,
-      "starting"
-    );
-  };
+function emitEffortValidationSkip(onProgress, effort, reason) {
+  emitProgress(
+    onProgress,
+    `Warning: skipping reasoning-effort validation (${reason}); dispatching effort "${effort}" as requested.`,
+    "starting"
+  );
+}
 
+async function fetchModelCatalog(client) {
   const requestPromise = client.request("model/list", {});
   requestPromise.catch(() => {});
   let timer;
-  let response = null;
   try {
-    response = await Promise.race([
+    const response = await Promise.race([
       requestPromise,
       new Promise((resolve) => {
         timer = setTimeout(() => resolve(null), MODEL_LIST_TIMEOUT_MS);
       })
     ]);
+    return Array.isArray(response?.data) ? response.data : null;
   } catch {
-    response = null;
+    return null;
   } finally {
     clearTimeout(timer);
   }
+}
 
-  const entries = Array.isArray(response?.data) ? response.data : null;
+function catalogDefaultModel(entries) {
+  const entry = Array.isArray(entries) ? entries.find((item) => item && item.isDefault) : null;
+  return entry ? entry.id ?? entry.model ?? null : null;
+}
+
+function assertCatalogSupportsEffort(entries, resolvedModel, effort, onProgress) {
   if (!entries) {
-    skip("model catalog unavailable or malformed");
+    emitEffortValidationSkip(onProgress, effort, "model catalog unavailable or malformed");
     return;
   }
   if (!resolvedModel) {
-    skip("app-server did not report a resolved model");
+    emitEffortValidationSkip(onProgress, effort, "could not resolve the target model");
     return;
   }
   const entry = entries.find((item) => item && (item.id === resolvedModel || item.model === resolvedModel));
   if (!entry) {
-    skip(`model "${resolvedModel}" is not in the model catalog`);
+    emitEffortValidationSkip(onProgress, effort, `model "${resolvedModel}" is not in the model catalog`);
     return;
   }
   const supported = Array.isArray(entry.supportedReasoningEfforts)
@@ -1140,7 +1146,7 @@ async function validateReasoningEffortForModel(client, resolvedModel, effort, on
         .filter((value) => typeof value === "string" && value)
     : [];
   if (supported.length === 0) {
-    skip(`model "${resolvedModel}" reports no reasoning-effort catalog`);
+    emitEffortValidationSkip(onProgress, effort, `model "${resolvedModel}" reports no reasoning-effort catalog`);
     return;
   }
   if (!supported.includes(effort)) {
@@ -1158,7 +1164,7 @@ export async function runAppServerTurn(cwd, options = {}) {
 
   return withAppServer(cwd, async (client) => {
     let threadId;
-    let resolvedModel = null;
+    const catalogEntries = options.effort ? await fetchModelCatalog(client) : null;
 
     if (options.resumeThreadId) {
       emitProgress(options.onProgress, `Resuming thread ${options.resumeThreadId}.`, "starting");
@@ -1168,8 +1174,14 @@ export async function runAppServerTurn(cwd, options = {}) {
         ephemeral: false
       });
       threadId = response.thread.id;
-      resolvedModel = response.model ?? null;
+      if (options.effort) {
+        assertCatalogSupportsEffort(catalogEntries, response.model ?? null, options.effort, options.onProgress);
+      }
     } else {
+      if (options.effort) {
+        const targetModel = options.model ?? catalogDefaultModel(catalogEntries);
+        assertCatalogSupportsEffort(catalogEntries, targetModel, options.effort, options.onProgress);
+      }
       emitProgress(options.onProgress, "Starting Codex task thread.", "starting");
       const response = await startThread(client, cwd, {
         model: options.model,
@@ -1178,7 +1190,6 @@ export async function runAppServerTurn(cwd, options = {}) {
         threadName: options.persistThread ? options.threadName : options.threadName ?? null
       });
       threadId = response.thread.id;
-      resolvedModel = response.model ?? null;
     }
 
     emitProgress(options.onProgress, `Thread ready (${threadId}).`, "starting", {
@@ -1188,10 +1199,6 @@ export async function runAppServerTurn(cwd, options = {}) {
     const prompt = options.prompt?.trim() || options.defaultPrompt || "";
     if (!prompt) {
       throw new Error("A prompt is required for this Codex run.");
-    }
-
-    if (options.effort) {
-      await validateReasoningEffortForModel(client, resolvedModel, options.effort, options.onProgress);
     }
 
     const turnState = await captureTurn(

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -1093,6 +1093,7 @@ export async function importExternalAgentSession(cwd, options = {}) {
 }
 
 const MODEL_LIST_TIMEOUT_MS = 3000;
+const MODEL_LIST_MAX_PAGES = 5;
 
 function emitEffortValidationSkip(onProgress, effort, reason) {
   emitProgress(
@@ -1103,22 +1104,44 @@ function emitEffortValidationSkip(onProgress, effort, reason) {
 }
 
 async function fetchModelCatalog(client) {
-  const requestPromise = client.request("model/list", {});
-  requestPromise.catch(() => {});
-  let timer;
-  try {
-    const response = await Promise.race([
-      requestPromise,
-      new Promise((resolve) => {
-        timer = setTimeout(() => resolve(null), MODEL_LIST_TIMEOUT_MS);
-      })
-    ]);
-    return Array.isArray(response?.data) ? response.data : null;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
+  // includeHidden: the default model/list only returns picker-visible models, so a
+  // hidden model passed via --model would otherwise dodge validation. The catalog is
+  // paginated; follow nextCursor under ONE shared deadline. A partial catalog can only
+  // cause a fail-open skip for models on unfetched pages — never a false rejection.
+  const deadline = Date.now() + MODEL_LIST_TIMEOUT_MS;
+  const entries = [];
+  let cursor = null;
+  for (let page = 0; page < MODEL_LIST_MAX_PAGES; page += 1) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      break;
+    }
+    const requestPromise = client.request("model/list", cursor ? { includeHidden: true, cursor } : { includeHidden: true });
+    requestPromise.catch(() => {});
+    let timer;
+    let response = null;
+    try {
+      response = await Promise.race([
+        requestPromise,
+        new Promise((resolve) => {
+          timer = setTimeout(() => resolve(null), remaining);
+        })
+      ]);
+    } catch {
+      response = null;
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!response || !Array.isArray(response.data)) {
+      break;
+    }
+    entries.push(...response.data);
+    cursor = response.nextCursor ?? null;
+    if (!cursor) {
+      break;
+    }
   }
+  return entries.length > 0 ? entries : null;
 }
 
 function assertCatalogSupportsEffort(entries, resolvedModel, effort, onProgress) {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -1092,6 +1092,64 @@ export async function importExternalAgentSession(cwd, options = {}) {
   });
 }
 
+const MODEL_LIST_TIMEOUT_MS = 3000;
+
+async function validateReasoningEffortForModel(client, resolvedModel, effort, onProgress) {
+  const skip = (reason) => {
+    emitProgress(
+      onProgress,
+      `Warning: skipping reasoning-effort validation (${reason}); dispatching effort "${effort}" as requested.`,
+      "starting"
+    );
+  };
+
+  const requestPromise = client.request("model/list", {});
+  requestPromise.catch(() => {});
+  let timer;
+  let response = null;
+  try {
+    response = await Promise.race([
+      requestPromise,
+      new Promise((resolve) => {
+        timer = setTimeout(() => resolve(null), MODEL_LIST_TIMEOUT_MS);
+      })
+    ]);
+  } catch {
+    response = null;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const entries = Array.isArray(response?.data) ? response.data : null;
+  if (!entries) {
+    skip("model catalog unavailable or malformed");
+    return;
+  }
+  if (!resolvedModel) {
+    skip("app-server did not report a resolved model");
+    return;
+  }
+  const entry = entries.find((item) => item && (item.id === resolvedModel || item.model === resolvedModel));
+  if (!entry) {
+    skip(`model "${resolvedModel}" is not in the model catalog`);
+    return;
+  }
+  const supported = Array.isArray(entry.supportedReasoningEfforts)
+    ? entry.supportedReasoningEfforts
+        .map((item) => item?.reasoningEffort)
+        .filter((value) => typeof value === "string" && value)
+    : [];
+  if (supported.length === 0) {
+    skip(`model "${resolvedModel}" reports no reasoning-effort catalog`);
+    return;
+  }
+  if (!supported.includes(effort)) {
+    throw new Error(
+      `Model "${resolvedModel}" does not support reasoning effort "${effort}". Supported: ${supported.join(", ")}.`
+    );
+  }
+}
+
 export async function runAppServerTurn(cwd, options = {}) {
   const availability = getCodexAvailability(cwd);
   if (!availability.available) {
@@ -1100,6 +1158,7 @@ export async function runAppServerTurn(cwd, options = {}) {
 
   return withAppServer(cwd, async (client) => {
     let threadId;
+    let resolvedModel = null;
 
     if (options.resumeThreadId) {
       emitProgress(options.onProgress, `Resuming thread ${options.resumeThreadId}.`, "starting");
@@ -1109,6 +1168,7 @@ export async function runAppServerTurn(cwd, options = {}) {
         ephemeral: false
       });
       threadId = response.thread.id;
+      resolvedModel = response.model ?? null;
     } else {
       emitProgress(options.onProgress, "Starting Codex task thread.", "starting");
       const response = await startThread(client, cwd, {
@@ -1118,6 +1178,7 @@ export async function runAppServerTurn(cwd, options = {}) {
         threadName: options.persistThread ? options.threadName : options.threadName ?? null
       });
       threadId = response.thread.id;
+      resolvedModel = response.model ?? null;
     }
 
     emitProgress(options.onProgress, `Thread ready (${threadId}).`, "starting", {
@@ -1127,6 +1188,10 @@ export async function runAppServerTurn(cwd, options = {}) {
     const prompt = options.prompt?.trim() || options.defaultPrompt || "";
     if (!prompt) {
       throw new Error("A prompt is required for this Codex run.");
+    }
+
+    if (options.effort) {
+      await validateReasoningEffortForModel(client, resolvedModel, options.effort, options.onProgress);
     }
 
     const turnState = await captureTurn(

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -1167,6 +1167,13 @@ export async function runAppServerTurn(cwd, options = {}) {
     const catalogEntries = shouldValidateEffort ? await fetchModelCatalog(client) : null;
 
     if (options.resumeThreadId) {
+      // Validate the model that turn/start will actually receive, before thread/resume
+      // has any side effect. The resume response's model is NOT that model (it reports
+      // the config default / prior thread state), so checking it can both falsely reject
+      // a valid requested pair and approve an unsupported one.
+      if (shouldValidateEffort) {
+        assertCatalogSupportsEffort(catalogEntries, options.model, options.effort, options.onProgress);
+      }
       emitProgress(options.onProgress, `Resuming thread ${options.resumeThreadId}.`, "starting");
       const response = await resumeThread(client, options.resumeThreadId, cwd, {
         model: options.model,
@@ -1174,9 +1181,6 @@ export async function runAppServerTurn(cwd, options = {}) {
         ephemeral: false
       });
       threadId = response.thread.id;
-      if (shouldValidateEffort) {
-        assertCatalogSupportsEffort(catalogEntries, response.model ?? options.model, options.effort, options.onProgress);
-      }
     } else {
       if (shouldValidateEffort) {
         assertCatalogSupportsEffort(catalogEntries, options.model, options.effort, options.onProgress);

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -32,7 +32,7 @@ Command selection:
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.
 - `--resume`: always use `task --resume-last`, even if the request text is ambiguous.
 - `--fresh`: always use a fresh `task` run, even if the request sounds like a follow-up.
-- `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`.
+- `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`. Supported tiers vary by model (for example `max`/`ultra` are 5.6-family tiers); a pair the live model catalog rejects fails before dispatch with that model's supported list.
 - `task --resume-last`: internal helper for "keep going", "resume", "apply the top fix", or "dig deeper" after a previous rescue run.
 
 Safety rules:

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -32,7 +32,7 @@ Command selection:
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.
 - `--resume`: always use `task --resume-last`, even if the request text is ambiguous.
 - `--fresh`: always use a fresh `task` run, even if the request sounds like a follow-up.
-- `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`. Supported tiers vary by model (for example `max`/`ultra` are 5.6-family tiers); a pair the live model catalog rejects fails before dispatch with that model's supported list.
+- `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`. Supported tiers vary by model (for example `max`/`ultra` are 5.6-family tiers); a pair the live model catalog rejects fails before dispatch with that model's supported list. `none` and `minimal` are legacy values that current catalogs do not list for any model — combined with an explicit `--model` they will be rejected the same way.
 - `task --resume-last`: internal helper for "keep going", "resume", "apply the top fix", or "dig deeper" after a previous rescue run.
 
 Safety rules:

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -32,7 +32,7 @@ Command selection:
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.
 - `--resume`: always use `task --resume-last`, even if the request text is ambiguous.
 - `--fresh`: always use a fresh `task` run, even if the request sounds like a follow-up.
-- `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`.
+- `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`.
 - `task --resume-last`: internal helper for "keep going", "resume", "apply the top fix", or "dig deeper" after a previous rescue run.
 
 Safety rules:

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -104,7 +104,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /--background\|--wait/);
   assert.match(rescue, /--resume\|--fresh/);
   assert.match(rescue, /--model <model\|spark>/);
-  assert.match(rescue, /--effort <none\|minimal\|low\|medium\|high\|xhigh>/);
+  assert.match(rescue, /--effort <none\|minimal\|low\|medium\|high\|xhigh\|max\|ultra>/);
   assert.match(rescue, /task-resume-candidate --json/);
   assert.match(rescue, /AskUserQuestion/);
   assert.match(rescue, /Continue current Codex thread/);
@@ -150,7 +150,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /Map `spark` to `--model gpt-5\.3-codex-spark`/i);
   assert.match(runtimeSkill, /If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only/i);
   assert.match(runtimeSkill, /Strip it before calling `task`/i);
-  assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`/i);
+  assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`/i);
   assert.match(runtimeSkill, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
   assert.match(readme, /`codex:codex-rescue` subagent/i);

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -152,6 +152,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /Strip it before calling `task`/i);
   assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`/i);
   assert.match(runtimeSkill, /Supported tiers vary by model/i);
+  assert.match(runtimeSkill, /`none` and `minimal` are legacy values/i);
   assert.match(runtimeSkill, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
   assert.match(readme, /`codex:codex-rescue` subagent/i);

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -151,6 +151,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only/i);
   assert.match(runtimeSkill, /Strip it before calling `task`/i);
   assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`/i);
+  assert.match(runtimeSkill, /Supported tiers vary by model/i);
   assert.match(runtimeSkill, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
   assert.match(readme, /`codex:codex-rescue` subagent/i);

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -372,6 +372,19 @@ rl.on("line", (line) => {
           send({ id: message.id, result: { data: "not-a-catalog" } });
           break;
         }
+        if (BEHAVIOR === "model-list-paginated") {
+          const pageEffort = (reasoningEffort) => ({ reasoningEffort, description: reasoningEffort });
+          if (message.params && message.params.cursor === "page-2") {
+            send({ id: message.id, result: { data: [
+              { id: "gpt-5.4-mini", model: "gpt-5.4-mini", hidden: true, isDefault: false, defaultReasoningEffort: "medium", supportedReasoningEfforts: ["low", "medium", "high", "xhigh"].map(pageEffort) }
+            ], nextCursor: null } });
+            break;
+          }
+          send({ id: message.id, result: { data: [
+            { id: "gpt-5.6-sol", model: "gpt-5.6-sol", isDefault: true, defaultReasoningEffort: "medium", supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"].map(pageEffort) }
+          ], nextCursor: "page-2" } });
+          break;
+        }
         const catalogEffort = (reasoningEffort) => ({ reasoningEffort, description: reasoningEffort });
         send({ id: message.id, result: { data: [
           { id: "gpt-5.6-sol", model: "gpt-5.6-sol", isDefault: false, defaultReasoningEffort: "medium", supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"].map(catalogEffort) },

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -351,6 +351,24 @@ rl.on("line", (line) => {
         break;
       }
 
+      case "model/list": {
+        if (BEHAVIOR === "model-list-unsupported") {
+          send({ id: message.id, error: { code: -32601, message: "Unsupported method: model/list" } });
+          break;
+        }
+        if (BEHAVIOR === "model-list-malformed") {
+          send({ id: message.id, result: { data: "not-a-catalog" } });
+          break;
+        }
+        const catalogEffort = (reasoningEffort) => ({ reasoningEffort, description: reasoningEffort });
+        send({ id: message.id, result: { data: [
+          { id: "gpt-5.6-sol", model: "gpt-5.6-sol", isDefault: false, defaultReasoningEffort: "medium", supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"].map(catalogEffort) },
+          { id: "gpt-5.4", model: "gpt-5.4", isDefault: true, defaultReasoningEffort: "medium", supportedReasoningEfforts: ["low", "medium", "high", "xhigh"].map(catalogEffort) },
+          { id: "gpt-5.4-mini", model: "gpt-5.4-mini", isDefault: false, defaultReasoningEffort: "medium", supportedReasoningEfforts: ["low", "medium", "high", "xhigh"].map(catalogEffort) }
+        ] } });
+        break;
+      }
+
       case "externalAgentConfig/import": {
         if (BEHAVIOR === "external-import-unsupported") {
           send({ id: message.id, error: { code: -32601, message: "Unsupported method: externalAgentConfig/import" } });

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -356,6 +356,12 @@ rl.on("line", (line) => {
           send({ id: message.id, error: { code: -32601, message: "Unsupported method: model/list" } });
           break;
         }
+        if (BEHAVIOR === "model-list-slow-error") {
+          setTimeout(() => {
+            send({ id: message.id, error: { code: -32000, message: "model catalog backend timed out" } });
+          }, 3500);
+          break;
+        }
         if (BEHAVIOR === "model-list-malformed") {
           send({ id: message.id, result: { data: "not-a-catalog" } });
           break;
@@ -620,6 +626,9 @@ rl.on("line", (line) => {
 	          interruptibleTurns.set(turnId, { threadId: thread.id, timer });
 	        } else if (BEHAVIOR === "slow-task") {
 	          emitTurnCompletedLater(thread.id, turnId, items, 400);
+	        } else if (BEHAVIOR === "model-list-slow-error") {
+	          send({ method: "turn/started", params: { threadId: thread.id, turn: buildTurn(turnId) } });
+	          emitTurnCompletedLater(thread.id, turnId, items, 1800);
 	        } else {
 	          emitTurnCompleted(thread.id, turnId, items);
 	        }

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -341,6 +341,12 @@ rl.on("line", (line) => {
       }
 
       case "thread/resume": {
+        if (BEHAVIOR === "resume-reports-different-model") {
+          const resumed = ensureThread(state, message.params.threadId);
+          const reported = message.params.model === "gpt-5.4-mini" ? "gpt-5.6-sol" : "gpt-5.4-mini";
+          send({ id: message.id, result: { thread: buildThread(resumed), model: reported, modelProvider: "openai", serviceTier: null, cwd: resumed.cwd, approvalPolicy: "never", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
+          break;
+        }
         if (requiresExperimental("persistExtendedHistory", message, state) || requiresExperimental("persistFullHistory", message, state)) {
           throw new Error("thread/resume.persistFullHistory requires experimentalApi capability");
         }
@@ -356,7 +362,7 @@ rl.on("line", (line) => {
           send({ id: message.id, error: { code: -32601, message: "Unsupported method: model/list" } });
           break;
         }
-        if (BEHAVIOR === "model-list-slow-error") {
+        if (BEHAVIOR === "model-list-slow-error" || BEHAVIOR === "model-list-slow-error-during-request") {
           setTimeout(() => {
             send({ id: message.id, error: { code: -32000, message: "model catalog backend timed out" } });
           }, 3500);
@@ -476,6 +482,22 @@ rl.on("line", (line) => {
 	          prompt
 	        };
 	        saveState(state);
+	        if (BEHAVIOR === "model-list-slow-error-during-request") {
+	          // Keep turn/start pending long enough for the delayed model/list error to land
+	          // mid-flight, then flush the response and every turn event as ONE stdout write
+	          // (one chunk), so the notifications are processed before the microtask that
+	          // resumes the broker's awaited turn/start request.
+	          setTimeout(() => {
+	            const burst = [
+	              { id: message.id, result: { turn: buildTurn(turnId) } },
+	              { method: "turn/started", params: { threadId: thread.id, turn: buildTurn(turnId) } },
+	              { method: "item/completed", params: { threadId: thread.id, turnId, item: { type: "agentMessage", id: "msg_" + turnId, text: taskPayload(prompt, false), phase: "final_answer" } } },
+	              { method: "turn/completed", params: { threadId: thread.id, turn: buildTurn(turnId, "completed") } }
+	            ];
+	            process.stdout.write(burst.map((entry) => JSON.stringify(entry)).join("\\n") + "\\n");
+	          }, 800);
+	          break;
+	        }
 	        send({ id: message.id, result: { turn: buildTurn(turnId) } });
 
         const payload = message.params.outputSchema && message.params.outputSchema.properties && message.params.outputSchema.properties.verdict

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -18,6 +18,7 @@ export function run(command, args, options = {}) {
     env: options.env,
     encoding: "utf8",
     input: options.input,
+    timeout: options.timeout,
     shell: options.shell ?? (process.platform === "win32" && !path.isAbsolute(command)),
     windowsHide: true
   });

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -848,7 +848,7 @@ test("task rejects an effort the resolved model does not support before starting
   }
 });
 
-test("task validates an effort-only dispatch against the resolved default model", () => {
+test("task forwards an effort-only dispatch without validating against a guessed default model", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
   const statePath = path.join(binDir, "fake-codex-state.json");
@@ -858,18 +858,15 @@ test("task validates an effort-only dispatch against the resolved default model"
   run("git", ["add", "README.md"], { cwd: repo });
   run("git", ["commit", "-m", "init"], { cwd: repo });
 
-  const result = run("node", [SCRIPT, "task", "--effort", "ultra", "diagnose the failing test"], {
+  const result = run("node", [SCRIPT, "task", "--fresh", "--effort", "ultra", "diagnose the failing test"], {
     cwd: repo,
     env: buildEnv(binDir)
   });
 
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /Model "gpt-5\.4" does not support reasoning effort "ultra"/);
-  if (fs.existsSync(statePath)) {
-    const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
-    assert.equal(fakeState.lastTurnStart ?? null, null);
-    assert.equal((fakeState.threads ?? []).length, 0, "no thread may be created for a rejected pair");
-  }
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.effort, "ultra");
+  assert.equal(fakeState.lastTurnStart.model, null, "no guessed model may be injected into turn/start");
 });
 
 test("task fails open with a warning when the model catalog is unavailable", () => {
@@ -909,6 +906,54 @@ test("task fails open with a warning when the model catalog is malformed", () =>
   });
 
   assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout + result.stderr, /skipping reasoning-effort validation/);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.effort, "ultra");
+});
+
+test("task --resume-last keeps an explicit effort without validating against the config default", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const firstRun = run("node", [SCRIPT, "task", "--fresh", "--model", "gpt-5.6-sol", "--effort", "ultra", "start the migration"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+  assert.equal(firstRun.status, 0, firstRun.stderr);
+
+  const resume = run("node", [SCRIPT, "task", "--resume-last", "--effort", "ultra", "keep going"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(resume.status, 0, resume.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.effort, "ultra");
+});
+
+test("a slow-failing model/list does not kill the turn's event stream on the broker transport", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir, "model-list-slow-error");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "--fresh", "--model", "gpt-5.6-sol", "--effort", "ultra", "diagnose the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir),
+    timeout: 30000
+  });
+
+  assert.equal(result.status, 0, `companion did not complete (stream ownership lost?): ${result.stderr}`);
   assert.match(result.stdout + result.stderr, /skipping reasoning-effort validation/);
   const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
   assert.equal(fakeState.lastTurnStart.effort, "ultra");

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -844,6 +844,7 @@ test("task rejects an effort the resolved model does not support before starting
   if (fs.existsSync(statePath)) {
     const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
     assert.equal(fakeState.lastTurnStart ?? null, null);
+    assert.equal((fakeState.threads ?? []).length, 0, "no thread may be created for a rejected pair");
   }
 });
 
@@ -867,6 +868,7 @@ test("task validates an effort-only dispatch against the resolved default model"
   if (fs.existsSync(statePath)) {
     const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
     assert.equal(fakeState.lastTurnStart ?? null, null);
+    assert.equal((fakeState.threads ?? []).length, 0, "no thread may be created for a rejected pair");
   }
 });
 

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -976,6 +976,32 @@ test("resume validates the requested model, not the model reported by thread/res
   assert.equal(fakeState.lastTurnStart.effort, "ultra");
 });
 
+test("effort validation finds models on later catalog pages before dispatching", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir, "model-list-paginated");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  // gpt-5.4-mini only appears on the second catalog page; skipping pagination would
+  // fail open and dispatch the unsupported pair instead of rejecting it.
+  const result = run("node", [SCRIPT, "task", "--model", "gpt-5.4-mini", "--effort", "ultra", "diagnose the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Model "gpt-5\.4-mini" does not support reasoning effort "ultra"/);
+  if (fs.existsSync(statePath)) {
+    const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    assert.equal(fakeState.lastTurnStart ?? null, null);
+    assert.equal((fakeState.threads ?? []).length, 0, "no thread may be created for a rejected pair");
+  }
+});
+
 test("a model/list settling during an in-flight request does not drop turn events or broker serialization", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -795,13 +795,14 @@ test("task accepts max and ultra reasoning efforts and forwards them to turn/sta
   run("git", ["commit", "-m", "init"], { cwd: repo });
 
   for (const effort of ["max", "ultra"]) {
-    const result = run("node", [SCRIPT, "task", "--fresh", "--effort", effort, "diagnose the failing test"], {
+    const result = run("node", [SCRIPT, "task", "--fresh", "--model", "gpt-5.6-sol", "--effort", effort, "diagnose the failing test"], {
       cwd: repo,
       env: buildEnv(binDir)
     });
 
     assert.equal(result.status, 0, result.stderr);
     const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    assert.equal(fakeState.lastTurnStart.model, "gpt-5.6-sol");
     assert.equal(fakeState.lastTurnStart.effort, effort);
   }
 });
@@ -820,6 +821,117 @@ test("task rejects an unknown reasoning effort before starting a job", () => {
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /Unsupported reasoning effort "hyperdrive"/);
   assert.match(result.stderr, /max, ultra/);
+});
+
+test("task rejects an effort the resolved model does not support before starting a turn", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "--model", "gpt-5.4-mini", "--effort", "ultra", "diagnose the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Model "gpt-5\.4-mini" does not support reasoning effort "ultra"/);
+  assert.match(result.stderr, /low, medium, high, xhigh/);
+  if (fs.existsSync(statePath)) {
+    const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    assert.equal(fakeState.lastTurnStart ?? null, null);
+  }
+});
+
+test("task validates an effort-only dispatch against the resolved default model", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "--effort", "ultra", "diagnose the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Model "gpt-5\.4" does not support reasoning effort "ultra"/);
+  if (fs.existsSync(statePath)) {
+    const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    assert.equal(fakeState.lastTurnStart ?? null, null);
+  }
+});
+
+test("task fails open with a warning when the model catalog is unavailable", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir, "model-list-unsupported");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "--model", "gpt-5.4-mini", "--effort", "ultra", "diagnose the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout + result.stderr, /skipping reasoning-effort validation/);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.effort, "ultra");
+});
+
+test("task fails open with a warning when the model catalog is malformed", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir, "model-list-malformed");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "--model", "gpt-5.4-mini", "--effort", "ultra", "diagnose the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout + result.stderr, /skipping reasoning-effort validation/);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.effort, "ultra");
+});
+
+test("task warns and proceeds when the resolved model is not in the catalog", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "--model", "spark", "--effort", "ultra", "diagnose the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout + result.stderr, /is not in the model catalog/);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.model, "gpt-5.3-codex-spark");
+  assert.equal(fakeState.lastTurnStart.effort, "ultra");
 });
 
 test("task logs reasoning summaries and assistant messages to the job log", () => {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -784,6 +784,44 @@ test("task forwards model selection and reasoning effort to app-server turn/star
   assert.equal(fakeState.lastTurnStart.effort, "low");
 });
 
+test("task accepts max and ultra reasoning efforts and forwards them to turn/start", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  for (const effort of ["max", "ultra"]) {
+    const result = run("node", [SCRIPT, "task", "--fresh", "--effort", effort, "diagnose the failing test"], {
+      cwd: repo,
+      env: buildEnv(binDir)
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    assert.equal(fakeState.lastTurnStart.effort, effort);
+  }
+});
+
+test("task rejects an unknown reasoning effort before starting a job", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  const result = run("node", [SCRIPT, "task", "--effort", "hyperdrive", "diagnose the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unsupported reasoning effort "hyperdrive"/);
+  assert.match(result.stderr, /max, ultra/);
+});
+
 test("task logs reasoning summaries and assistant messages to the job log", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -937,6 +937,67 @@ test("task --resume-last keeps an explicit effort without validating against the
   assert.equal(fakeState.lastTurnStart.effort, "ultra");
 });
 
+test("resume validates the requested model, not the model reported by thread/resume", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir, "resume-reports-different-model");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const firstRun = run("node", [SCRIPT, "task", "--fresh", "--model", "gpt-5.6-sol", "--effort", "ultra", "start the migration"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+  assert.equal(firstRun.status, 0, firstRun.stderr);
+
+  // thread/resume reports gpt-5.6-sol here; the requested gpt-5.4-mini is what
+  // turn/start would receive, so the pair must be rejected before any resume.
+  const reject = run("node", [SCRIPT, "task", "--resume-last", "--model", "gpt-5.4-mini", "--effort", "ultra", "keep going"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+  assert.notEqual(reject.status, 0);
+  assert.match(reject.stderr, /Model "gpt-5\.4-mini" does not support reasoning effort "ultra"/);
+  let fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.match(fakeState.lastTurnStart.prompt, /start the migration/, "rejected resume must not start a turn");
+
+  // thread/resume reports gpt-5.4-mini here; the requested gpt-5.6-sol supports
+  // ultra, so the resume must proceed instead of being falsely rejected.
+  const approve = run("node", [SCRIPT, "task", "--resume-last", "--model", "gpt-5.6-sol", "--effort", "ultra", "keep going"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+  assert.equal(approve.status, 0, approve.stderr);
+  fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.model, "gpt-5.6-sol");
+  assert.equal(fakeState.lastTurnStart.effort, "ultra");
+});
+
+test("a model/list settling during an in-flight request does not drop turn events or broker serialization", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir, "model-list-slow-error-during-request");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "--fresh", "--model", "gpt-5.6-sol", "--effort", "ultra", "diagnose the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir),
+    timeout: 30000
+  });
+
+  assert.equal(result.status, 0, `companion did not complete (request slot lost?): ${result.stderr}`);
+  assert.match(result.stdout + result.stderr, /skipping reasoning-effort validation/);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.effort, "ultra");
+});
+
 test("a slow-failing model/list does not kill the turn's event stream on the broker transport", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
## Problem

`task --effort max` / `--effort ultra` were rejected by a hardcoded allowlist even though `codex debug models` (codex-cli 0.142.x) lists both as supported reasoning levels for 5.6-family models. Users could not request the top tiers through the plugin at all; the only workaround was `model_reasoning_effort` in `~/.codex/config.toml` with `--effort` omitted. Same drift as #99 (`xhigh`).

Dispatching an unsupported pair is worse than a parse error: the app-server accepts `turn/start` and then hangs with zero events (openai/codex#31552) — so validation, not just allowlist extension, is required.

## What this PR does (7 commits, each with red-first regression tests)

1. **Accept `max`/`ultra`** in the allowlist; error message derives from the set so it can't drift again; usage/docs updated.
2. **Catalog validation for explicit `--model`+`--effort` pairs**, before any thread is created: bounded (3s) `model/list` with `includeHidden: true` + `nextCursor` pagination (live default hides models — verified: 6/7 returned without it). Unsupported pairs fail fast with that model's real tiers: `Model "gpt-5.4-mini" does not support reasoning effort "ultra". Supported: low, medium, high, xhigh.`
3. **Fail-open by design**: catalog unavailable/malformed/partial, unknown models (e.g. `spark` alias), effort-only dispatches, and resumes without `--model` all pass through with a warning — the config default / thread model is resolved server-side and `thread/start`/`thread/resume` responses report the config default, not the target (verified against the live server), so guessing would falsely reject documented flows. A partial catalog can only skip, never falsely reject.
4. **Two broker concurrency fixes** the validation work exposed (both reproduced with probes, both covered by chunk-precise regression tests):
   - a failed non-streaming request no longer strips stream ownership from an in-flight turn (dropped `turn/completed` → permanent hang);
   - request ownership is refcounted per socket, so a late `model/list` completion can no longer release the slot mid-`turn/start` (same-chunk notifications were dropped pre-microtask → hang; a second socket could bypass cross-session serialization; a dropped `turn/started` broke cancel).
5. **Resume validates the requested model** (the one `turn/start` receives), before `thread/resume` side effects.
6. Docs: tiers vary by model; `none`/`minimal` are legacy values current catalogs don't list and are rejected with an explicit `--model`.

## Testing

`npm test`: **103/103** (clean env). Every behavioral fix has a regression test proven red on its parent commit. Live checks on codex-cli 0.142.4: mini+ultra fails in ~4s with the actionable message (previously: silent indefinite hang); sol+max/ultra dispatch correctly.

All automated review threads are resolved (5 fixed, 1 declined with live-protocol evidence in-thread); latest Codex review of `b8134d7` reports no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)