### PR TITLE
fix(tests): keep the suite hermetic inside a live Claude Code session

### DIFF
--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -4,6 +4,18 @@ import path from "node:path";
 import process from "node:process";
 import { spawnSync } from "node:child_process";
 
+// Keep the suite hermetic when it runs from inside a live Claude Code
+// session. Two inherited variables otherwise change behavior:
+// - CLAUDE_PLUGIN_DATA points at the user's real plugin data directory, so
+//   in-process state writes and spawned companions (which inherit it through
+//   buildEnv) leak fixture workspaces and job records into that real
+//   directory. Pin it to a fresh temp root for the whole test process.
+// - CODEX_COMPANION_SESSION_ID makes status/result session-filter jobs that
+//   fixtures seed without a sessionId, hiding them. Session-scoped tests set
+//   the variable explicitly in the env they compose.
+process.env.CLAUDE_PLUGIN_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "codex-plugin-cc-tests-"));
+delete process.env.CODEX_COMPANION_SESSION_ID;
+
 export function makeTempDir(prefix = "codex-plugin-test-") {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -9,11 +9,22 @@ import { resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, s
 
 test("resolveStateDir uses a temp-backed per-workspace directory", () => {
   const workspace = makeTempDir();
-  const stateDir = resolveStateDir(workspace);
+  const previousPluginDataDir = process.env.CLAUDE_PLUGIN_DATA;
+  delete process.env.CLAUDE_PLUGIN_DATA;
 
-  assert.equal(stateDir.startsWith(os.tmpdir()), true);
-  assert.match(path.basename(stateDir), /.+-[a-f0-9]{16}$/);
-  assert.match(stateDir, new RegExp(`^${os.tmpdir().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  try {
+    const stateDir = resolveStateDir(workspace);
+
+    assert.equal(stateDir.startsWith(os.tmpdir()), true);
+    assert.match(path.basename(stateDir), /.+-[a-f0-9]{16}$/);
+    assert.match(stateDir, new RegExp(`^${os.tmpdir().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  } finally {
+    if (previousPluginDataDir === undefined) {
+      delete process.env.CLAUDE_PLUGIN_DATA;
+    } else {
+      process.env.CLAUDE_PLUGIN_DATA = previousPluginDataDir;
+    }
+  }
 });
 
 test("resolveStateDir uses CLAUDE_PLUGIN_DATA when it is provided", () => {


### PR DESCRIPTION
Fixes #455.

## Problem

`npm test` run from inside a live Claude Code session fails 4 tests at HEAD and leaks fixture state into the user's **real** plugin data dir (~150 fake `codex-plugin-test-*` workspaces / ~420 job records per two runs). Two inherited variables cause it:

- `CLAUDE_PLUGIN_DATA` → in-process state writes and spawned companions (`buildEnv` spreads `process.env`) resolve state into the real data dir instead of the temp fallback; the `resolveStateDir` fallback test also fails.
- `CODEX_COMPANION_SESSION_ID` (set by the plugin's own session hook) → `status`/`result` session-filter fixture-seeded jobs that carry no `sessionId`, so those tests render empty output.

Full evidence trail in #455.

## Fix (2 files, tests only)

- `tests/helpers.mjs`: pin `CLAUDE_PLUGIN_DATA` to a fresh `mkdtemp` root for the test process (in-process writers and spawned companions then agree on a temp-backed root, so state handling is still exercised end-to-end), and clear `CODEX_COMPANION_SESSION_ID` — every session-scoped test already sets it explicitly in the env it composes (`sess-current` / `sess-other`).
- `tests/state.test.mjs`: the fallback-path test now saves/deletes/restores `CLAUDE_PLUGIN_DATA` locally, exactly like its `uses CLAUDE_PLUGIN_DATA when provided` sibling already does.

Deliberately did NOT strip `CLAUDE*` wholesale in `buildEnv`: broker-mode tests rely on `CLAUDE_ENV_FILE`, and blanket stripping breaks 4 other tests (verified) while still missing the in-process leak path.

## Testing

- Inside a live Claude Code session (14 `CLAUDE*`/`CODEX*` vars in the env): **87/91 → 91/91**, and the real plugin state dir gains **zero** new entries across the run (was ~75 fake workspaces per run before).
- Under a clean env (`env -i PATH HOME`): 91/91 before and after — no behavior change for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)