### PR TITLE
Fix false approvals when adversarial review turns fail

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -415,9 +415,15 @@ async function executeReviewRun(request) {
     outputSchema: readOutputSchema(REVIEW_SCHEMA),
     onProgress: request.onProgress
   });
+  const failureMessage =
+    result.error?.message?.trim() ||
+    result.stderr?.trim() ||
+    (result.status === 0
+      ? ""
+      : `Codex turn ended with status ${result.turn?.status ?? result.status} before returning a final review verdict.`);
   const parsed = parseStructuredOutput(result.finalMessage, {
     status: result.status,
-    failureMessage: result.error?.message ?? result.stderr
+    failureMessage
   });
   const payload = {
     review: reviewName,
@@ -430,6 +436,7 @@ async function executeReviewRun(request) {
     },
     codex: {
       status: result.status,
+      error: failureMessage || null,
       stderr: result.stderr,
       stdout: result.finalMessage,
       reasoning: result.reasoningSummary

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -1186,6 +1186,17 @@ export function buildPersistentTaskThreadName(prompt) {
 }
 
 export function parseStructuredOutput(rawOutput, fallback = {}) {
+  if (typeof fallback.status === "number" && fallback.status !== 0) {
+    return {
+      parsed: null,
+      parseError:
+        fallback.failureMessage ??
+        `Codex run failed with status ${fallback.status} before returning a final structured message.`,
+      rawOutput: rawOutput ?? "",
+      ...fallback
+    };
+  }
+
   if (!rawOutput) {
     return {
       parsed: null,

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -210,16 +210,24 @@ export function renderSetupReport(report) {
 
 export function renderReviewResult(parsedResult, meta) {
   if (!parsedResult.parsed) {
+    const runFailed = typeof parsedResult.status === "number" && parsedResult.status !== 0;
     const lines = [
       `# Codex ${meta.reviewLabel}`,
       "",
-      "Codex did not return valid structured JSON.",
+      ...(meta.targetLabel ? [`Target: ${meta.targetLabel}`, ""] : []),
+      runFailed
+        ? "Codex review failed before returning a final verdict."
+        : "Codex did not return valid structured JSON.",
       "",
-      `- Parse error: ${parsedResult.parseError}`
+      `- ${runFailed ? "Runtime error" : "Parse error"}: ${parsedResult.parseError}`
     ];
 
     if (parsedResult.rawOutput) {
-      lines.push("", "Raw final message:", "", "```text", parsedResult.rawOutput, "```");
+      if (runFailed) {
+        lines.push("", "An interim assistant message was discarded because the review turn failed.");
+      } else {
+        lines.push("", "Raw final message:", "", "```text", parsedResult.rawOutput, "```");
+      }
     }
 
     appendReasoningSection(lines, meta.reasoningSummary ?? parsedResult.reasoningSummary);

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -454,6 +454,42 @@ rl.on("line", (line) => {
 	        saveState(state);
 	        send({ id: message.id, result: { turn: buildTurn(turnId) } });
 
+        if (BEHAVIOR === "adversarial-turn-fails-after-progress") {
+          const interimPayload = JSON.stringify({
+            verdict: "approve",
+            summary: "I am splitting the audit into independent review tracks.",
+            findings: [],
+            next_steps: []
+          });
+          send({ method: "turn/started", params: { threadId: thread.id, turn: buildTurn(turnId) } });
+          send({
+            method: "item/completed",
+            params: {
+              threadId: thread.id,
+              turnId,
+              item: { type: "agentMessage", id: "msg_" + turnId, text: interimPayload, phase: "analysis" }
+            }
+          });
+          send({
+            method: "error",
+            params: {
+              threadId: thread.id,
+              turnId,
+              error: { message: "No tool output found for custom tool call call_test." }
+            }
+          });
+          send({
+            method: "turn/completed",
+            params: {
+              threadId: thread.id,
+              turn: buildTurn(turnId, "failed", {
+                message: "No tool output found for custom tool call call_test."
+              })
+            }
+          });
+          break;
+        }
+
         const payload = message.params.outputSchema && message.params.outputSchema.properties && message.params.outputSchema.properties.verdict
           ? structuredReviewPayload(prompt)
           : taskPayload(prompt, thread.name && thread.name.startsWith("Codex Companion Task") && prompt.includes("Continue from the current thread state"));

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -386,6 +386,28 @@ test("adversarial review renders structured findings over app-server turn/start"
   assert.match(result.stdout, /Missing empty-state guard/);
 });
 
+test("adversarial review never approves from an interim message after the turn fails", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "adversarial-turn-fails-after-progress");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "README.md"), "hello again\n");
+
+  const result = run("node", [SCRIPT, "adversarial-review"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout, /review failed before returning a final verdict/i);
+  assert.match(result.stdout, /No tool output found for custom tool call call_test/);
+  assert.match(result.stdout, /interim assistant message was discarded/i);
+  assert.doesNotMatch(result.stdout, /approve|No material findings/i);
+});
+
 test("adversarial review accepts the same base-branch targeting as review", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
## Summary

- fail closed when an adversarial review turn exits nonzero, even if an interim assistant message is valid structured review JSON
- render the runtime failure and discard interim review text from stdout
- persist the runtime error in the tracked review payload
- add an integration regression for an interim `approve` followed by a failed turn

## Reproduction

A real adversarial review emitted schema-valid progress messages with `verdict: approve`, then failed with `No tool output found for custom tool call ...`. The companion marked the job failed internally but parsed and rendered the last progress message as an approval.

## Verification

- `npm run build`
- `npm run check-version`
- `claude plugin validate plugins/codex`
- `node --test --test-reporter=dot tests/*.test.mjs`
- reran the original review input: collaboration tracks ran and the completed turn returned `needs-attention` with six findings
