### PR TITLE
fix: resolve imported transfer threads when the ledger record diverges (#417)

### DIFF
--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -658,16 +658,36 @@ function sourceContentSha256(sourcePath) {
   return crypto.createHash("sha256").update(fs.readFileSync(sourcePath)).digest("hex");
 }
 
-function importedThreadIdForSource(sourcePath) {
-  const ledgerPath = path.join(resolveCodexHome(), "external_agent_session_imports.json");
+function importLedgerPath() {
+  return path.join(resolveCodexHome(), "external_agent_session_imports.json");
+}
+
+function readImportLedgerRecords() {
+  const ledgerPath = importLedgerPath();
   if (!fs.existsSync(ledgerPath)) {
-    return null;
+    return [];
   }
   const ledger = readJsonFile(ledgerPath);
+  return Array.isArray(ledger?.records) ? ledger.records : [];
+}
+
+// Codex canonicalizes the recorded source path itself; on Windows Rust's
+// canonicalization yields verbatim paths (\\?\C:\...) that never compare
+// equal to Node's realpathSync output.
+function normalizeLedgerSourcePath(value) {
+  if (typeof value !== "string" || value === "") {
+    return null;
+  }
+  let normalized = value.startsWith("\\\\?\\") ? value.slice(4) : value;
+  normalized = normalized.replaceAll("\\", "/");
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function importedThreadIdForSource(sourcePath, previousRecords = null) {
+  const records = readImportLedgerRecords();
   const canonicalSource = fs.realpathSync(sourcePath);
   const contentSha256 = sourceContentSha256(canonicalSource);
-  const records = Array.isArray(ledger?.records) ? ledger.records : [];
-  const match = records
+  const strictMatch = records
     .filter(
       (record) =>
         record?.source_path === canonicalSource &&
@@ -675,7 +695,32 @@ function importedThreadIdForSource(sourcePath) {
         typeof record?.imported_thread_id === "string"
     )
     .at(-1);
-  return match?.imported_thread_id ?? null;
+  if (strictMatch) {
+    return strictMatch.imported_thread_id;
+  }
+
+  // Fall back to records Codex appended during this import. The strict match
+  // misses real imports in two known ways: a live Claude transcript keeps
+  // growing while the transfer runs, so the hash computed here trails the
+  // content Codex imported, and Codex may canonicalize the recorded source
+  // path differently than realpathSync does.
+  if (!previousRecords) {
+    return null;
+  }
+  const appended = records
+    .slice(previousRecords.length)
+    .filter((record) => typeof record?.imported_thread_id === "string");
+  const normalizedSource = normalizeLedgerSourcePath(canonicalSource);
+  const pathMatch = appended
+    .filter((record) => normalizeLedgerSourcePath(record?.source_path) === normalizedSource)
+    .at(-1);
+  if (pathMatch) {
+    return pathMatch.imported_thread_id;
+  }
+  if (appended.length === 1) {
+    return appended[0].imported_thread_id;
+  }
+  return null;
 }
 
 function externalAgentSessionMigration(sourcePath, cwd) {
@@ -1066,6 +1111,7 @@ export async function importExternalAgentSession(cwd, options = {}) {
 
   return withDirectAppServer(cwd, async (client) => {
     emitProgress(options.onProgress, "Importing Claude session into Codex.", "transferring");
+    const previousRecords = readImportLedgerRecords();
     try {
       await requestExternalAgentSessionImport(client, externalAgentSessionMigration(options.sourcePath, cwd));
     } catch (error) {
@@ -1077,11 +1123,11 @@ export async function importExternalAgentSession(cwd, options = {}) {
       }
       throw error;
     }
-    const threadId = importedThreadIdForSource(options.sourcePath);
+    const threadId = importedThreadIdForSource(options.sourcePath, previousRecords);
     if (!threadId) {
       const stderr = cleanCodexStderr(client.stderr);
       throw new Error(
-        `Codex reported that the Claude import completed, but did not record an imported thread.${stderr ? `\n${stderr}` : " Check the Codex app-server logs for the underlying import error."}`
+        `Codex reported that the Claude import completed, but did not record an imported thread in ${importLedgerPath()}.${stderr ? `\n${stderr}` : " Check the Codex app-server logs for the underlying import error."}`
       );
     }
     emitProgress(options.onProgress, `Claude session imported (${threadId}).`, "completed", { threadId });

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -395,6 +395,10 @@ rl.on("line", (line) => {
             imported_at: now(),
             source_modified_at: null
           };
+          if (BEHAVIOR === "external-import-divergent-ledger") {
+            record.source_path = "\\\\\\\\?\\\\" + sourcePath.split("/").join("\\\\");
+            record.content_sha256 = crypto.createHash("sha256").update(contents + "appended-after-import\\n").digest("hex");
+          }
           ledger.records.push(record);
           saveState(state);
           saveImportLedger(ledger);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -303,6 +303,42 @@ test("transfer fails visibly when native import completes without a ledger recor
   assert.match(result.stderr, /did not record an imported thread/);
 });
 
+// Regression for #417: real Codex canonicalizes the recorded source_path
+// itself (verbatim \\?\C:\... paths on Windows) and hashes the transcript as
+// it was at import time, while a live Claude session keeps appending to it.
+// The strict path+hash ledger match therefore failed even though the import
+// succeeded. The lookup must fall back to records appended during the import.
+test("transfer resolves the imported thread when the ledger record diverges in path and hash", () => {
+  const home = makeTempDir();
+  const repo = path.join(home, "repo");
+  const binDir = makeTempDir();
+  const projectDir = path.join(home, ".claude", "projects", "-repo");
+  const sourcePath = path.join(projectDir, "session.jsonl");
+  fs.mkdirSync(repo, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+  installFakeCodex(binDir, "external-import-divergent-ledger");
+  initGitRepo(repo);
+  fs.writeFileSync(
+    sourcePath,
+    `${JSON.stringify({ type: "user", cwd: repo, message: { role: "user", content: "Continue this work." } })}\n`,
+    "utf8"
+  );
+
+  const result = run("node", [SCRIPT, "transfer", "--source", sourcePath, "--json"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      HOME: home,
+      CODEX_HOME: path.join(home, ".codex")
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.threadId, "thr_1");
+  assert.equal(payload.resumeCommand, "codex resume thr_1");
+});
+
 test("transfer rejects sources outside the Claude projects directory", () => {
   const home = makeTempDir();
   const repo = path.join(home, "repo");


### PR DESCRIPTION
Fixes #417

## Problem

`/codex:transfer` consistently fails with `Codex reported that the Claude import completed, but did not record an imported thread` — identically for auto-detected and explicit `--source` paths — even though the import actually succeeds on the Codex side.

After the `externalAgentConfig/import` notification fires, `importedThreadIdForSource` looks up the imported thread in `$CODEX_HOME/external_agent_session_imports.json` by **strict equality** on `source_path` (Node `realpathSync` output) **and** a content sha256 **computed at lookup time**. That match misses real imports two ways:

1. **Path canonicalization mismatch (Windows).** Codex canonicalizes the recorded `source_path` itself; Rust's `fs::canonicalize` yields verbatim paths (`\\?\C:\Users\...`) that never compare equal to Node's `realpathSync` output (`C:\Users\...`). The strict path match can never succeed — matching the reporter's Git Bash / Windows 11 environment where both invocations fail byte-for-byte identically.
2. **Live-transcript hash race (all platforms).** Running transfer from inside an active Claude Code session means the transcript `.jsonl` keeps growing (the transfer invocation itself gets logged) between Codex hashing it at import time and the companion hashing it at lookup time — so `content_sha256` diverges and the record is rejected.

Either way the command exits 1 with an opaque error while a perfectly good imported thread sits in the ledger.

## Fix

`importExternalAgentSession` snapshots the ledger before the import; when the strict match misses, the lookup falls back to **records Codex appended during this import**:

- prefer an appended record whose source path matches after normalization (strip the `\\?\` verbatim prefix, unify `\`/`/` separators, case-fold on win32),
- else accept a lone appended record.

The strict path+hash match stays first so Codex-side dedup of an unchanged, already-imported session still resolves without any appended record. The failure error now also names the ledger path it searched instead of only pointing at app-server logs.

## Tests

New fake-codex behavior `external-import-divergent-ledger` simulates real Codex: the ledger record gets a verbatim-prefixed, backslash-separated `source_path` and a hash of content that differs from what the companion reads back (both #417 divergences at once). The new regression test:

- **fails on `main`**: `transfer` exits 1 with `did not record an imported thread`
- **passes with this fix**: resolves `thr_1` and prints the resume command

All 5 transfer tests pass; full suite 91/92 — the one failure (`resolveStateDir uses a temp-backed per-workspace directory`) fails identically on `main` when run inside a live Claude Code session (pre-existing #455, unrelated).

Note: the `[DEP0190]` deprecation warning mentioned in the issue is a separate stderr-noise concern (#452 territory) and is not addressed here.
