### PR TITLE
Add task --resume-thread <id> for explicit thread resume

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -79,7 +79,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--resume-thread <id>|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
@@ -464,11 +464,11 @@ async function executeTaskRun(request) {
 
   const taskMetadata = buildTaskRunMetadata({
     prompt: request.prompt,
-    resumeLast: request.resumeLast
+    resumeLast: Boolean(request.resumeLast || request.resumeThreadId)
   });
 
-  let resumeThreadId = null;
-  if (request.resumeLast) {
+  let resumeThreadId = request.resumeThreadId ?? null;
+  if (!resumeThreadId && request.resumeLast) {
     const latestThread = await resolveLatestTrackedTaskThread(workspaceRoot, {
       excludeJobId: request.jobId
     });
@@ -601,7 +601,7 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, resumeThreadId, jobId }) {
   return {
     cwd,
     model,
@@ -609,6 +609,7 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     prompt,
     write,
     resumeLast,
+    resumeThreadId: resumeThreadId ?? null,
     jobId
   };
 }
@@ -649,9 +650,9 @@ function readTaskPrompt(cwd, options, positionals) {
   return positionalPrompt || readStdinIfPiped();
 }
 
-function requireTaskRequest(prompt, resumeLast) {
-  if (!prompt && !resumeLast) {
-    throw new Error("Provide a prompt, a prompt file, piped stdin, or use --resume-last.");
+function requireTaskRequest(prompt, resume) {
+  if (!prompt && !resume) {
+    throw new Error("Provide a prompt, a prompt file, piped stdin, or use --resume-last/--resume-thread.");
   }
 }
 
@@ -761,7 +762,7 @@ async function handleReview(argv) {
 
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["model", "effort", "cwd", "prompt-file"],
+    valueOptions: ["model", "effort", "cwd", "prompt-file", "resume-thread"],
     booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
     aliasMap: {
       m: "model"
@@ -775,19 +776,23 @@ async function handleTask(argv) {
   const prompt = readTaskPrompt(cwd, options, positionals);
 
   const resumeLast = Boolean(options["resume-last"] || options.resume);
+  const resumeThreadId = options["resume-thread"] || null;
   const fresh = Boolean(options.fresh);
   if (resumeLast && fresh) {
     throw new Error("Choose either --resume/--resume-last or --fresh.");
   }
+  if (resumeThreadId && (resumeLast || fresh)) {
+    throw new Error("Choose either --resume-thread or --resume/--resume-last/--fresh.");
+  }
   const write = Boolean(options.write);
   const taskMetadata = buildTaskRunMetadata({
     prompt,
-    resumeLast
+    resumeLast: resumeLast || Boolean(resumeThreadId)
   });
 
   if (options.background) {
     ensureCodexAvailable(cwd);
-    requireTaskRequest(prompt, resumeLast);
+    requireTaskRequest(prompt, resumeLast || Boolean(resumeThreadId));
 
     const job = buildTaskJob(workspaceRoot, taskMetadata, write);
     const request = buildTaskRequest({
@@ -797,6 +802,7 @@ async function handleTask(argv) {
       prompt,
       write,
       resumeLast,
+      resumeThreadId,
       jobId: job.id
     });
     const { payload } = enqueueBackgroundTask(cwd, job, request);
@@ -815,6 +821,7 @@ async function handleTask(argv) {
         prompt,
         write,
         resumeLast,
+        resumeThreadId,
         jobId: job.id,
         onProgress: progress
       }),

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -503,6 +503,58 @@ test("task --resume-last resumes the latest persisted task thread", () => {
   assert.equal(result.stdout, "Resumed the prior run.\nFollow-up prompt accepted.\n");
 });
 
+test("task --resume-thread resumes the specified thread", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const firstRun = run("node", [SCRIPT, "task", "--json", "initial task"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+  assert.equal(firstRun.status, 0, firstRun.stderr);
+  const firstPayload = JSON.parse(firstRun.stdout);
+  assert.ok(firstPayload.threadId, "first run should report a threadId");
+
+  const result = run(
+    "node",
+    [SCRIPT, "task", "--resume-thread", firstPayload.threadId, "--json", "follow up"],
+    {
+      cwd: repo,
+      env: buildEnv(binDir)
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.threadId, firstPayload.threadId);
+  assert.equal(payload.rawOutput, "Resumed the prior run.\nFollow-up prompt accepted.");
+});
+
+test("task --resume-thread rejects --resume-last and --fresh", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  for (const conflicting of ["--resume-last", "--fresh"]) {
+    const result = run(
+      "node",
+      [SCRIPT, "task", "--resume-thread", "thr_explicit", conflicting, "follow up"],
+      {
+        cwd: repo,
+        env: buildEnv(binDir)
+      }
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Choose either --resume-thread/);
+  }
+});
+
 test("task-resume-candidate returns the latest rescue thread from the current session", () => {
   const workspace = makeTempDir();
   const stateDir = resolveStateDir(workspace);


### PR DESCRIPTION
## Summary

Adds `task --resume-thread <id>` so callers can resume an **explicit** Codex thread instead of the newest tracked one.

`--resume` / `--resume-last` picks the most recent tracked task thread, which is ambiguous for orchestrators driving several concurrent Codex jobs in one repository: which thread gets resumed depends on job-store state and session scoping rather than the caller's intent. The app-server layer already supports targeting a thread (`runAppServerTurn`'s `resumeThreadId`); this exposes it on the `task` subcommand so a caller that recorded a `threadId` from a previous run (`task --json`) can continue that exact conversation deterministically.

## Changes

- `task --resume-thread <id>` resumes the given thread (foreground and `--background`; the worker path serializes `resumeThreadId` through the stored request).
- Conflicts with `--resume` / `--resume-last` / `--fresh` are rejected with a clear error.
- A prompt remains optional, matching `--resume-last` semantics (the default continue-prompt is used when none is given).

## Tests

- `task --resume-thread resumes the specified thread` — round 1 `task --json` captures a `threadId`, round 2 resumes it and asserts the same thread + continued output.
- `task --resume-thread rejects --resume-last and --fresh`.
- Full existing suite green (`npm test`): 93 passing.

## Motivation

We drive Codex as a multi-round peer reviewer from Claude Code. Round 1 records the `threadId` from `task --json`; subsequent rounds need to resume *that* thread. Today the only CLI path is `--resume-last`, which is a heuristic; under any concurrency it can resume the wrong conversation. This flag makes the common "continue the thread I just started" case explicit and deterministic, using machinery the app-server already exposes.
