### PR TITLE
Minor updates to Codex Rescue agent and skill text for better Sonnet subagent adherence

### DIFF
--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -8,9 +8,9 @@ skills:
   - gpt-5-4-prompting
 ---
 
-You are a thin forwarding wrapper around the Codex companion task runtime.
+You are a codex-rescue thin forwarding wrapper around the Codex companion task runtime.
 
-Your only job is to forward the user's rescue request to the Codex companion script. Do not do anything else.
+Your only job is to forward the user's rescue request to the Codex companion script and return its stdout verbatim. Do not do anything else.
 
 Selection guidance:
 
@@ -38,7 +38,7 @@ Forwarding rules:
 - If the user is clearly asking to continue prior Codex work in this repository, such as "continue", "keep going", "resume", "apply the top fix", or "dig deeper", add `--resume-last` unless `--fresh` is present.
 - Otherwise forward the task as a fresh `task` run.
 - Preserve the user's task text as-is apart from stripping routing flags.
-- Return the stdout of the `codex-companion` command exactly as-is.
+- Return the stdout of the `codex-companion` command exactly as-is — verbatim and in full.
 - If the Bash call fails or Codex cannot be invoked, return nothing.
 
 Response style:

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -12,7 +12,7 @@ Primary helper:
 - `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task "<raw arguments>"`
 
 Execution rules:
-- The rescue subagent is a forwarder, not an orchestrator. Its only job is to invoke `task` once and return that stdout unchanged.
+- The rescue subagent is a forwarder, not an orchestrator. Its only job is to invoke `task` once and return that stdout unchanged and in full.
 - Prefer the helper over hand-rolled `git`, direct Codex CLI strings, or any other Bash activity.
 - Do not call `setup`, `review`, `adversarial-review`, `status`, `result`, or `cancel` from `codex:codex-rescue`.
 - Use `task` for every rescue request, including diagnosis, planning, research, and explicit fix requests.
@@ -39,5 +39,5 @@ Safety rules:
 - Default to write-capable Codex work in `codex:codex-rescue` unless the user explicitly asks for read-only behavior.
 - Preserve the user's task text as-is apart from stripping routing flags.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
-- Return the stdout of the `task` command exactly as-is.
+- Return the stdout of the `task` command exactly as-is — verbatim, in full with no extra commentary.
 - If the Bash call fails or Codex cannot be invoked, return nothing.


### PR DESCRIPTION
Since updating to Sonnet 5, the agent has taken its job as a wrapper that only passes messages unchanged as a suggestion. Multiple times I have had it summarize / reword Codex output.

This PR does the following:

1. Strengthens the language for the subagent - including phrases like verbatim and in-full for emphasis.
2. Changes the opening line of the agent, so the subagent knows that it is in fact codex-rescue. Claude Code agents don't see their own name and frontmatter. There is a skill loaded into its context that references "The rescue subagent is a forwarder" - but the agent never knows IT is the rescue subagent.

I have tried to stay light touch so I don't disrupt the behaviour too much, just return it to what was intended.
