### PR TITLE
fix: use a deterministic Windows shell for broker spawns (#236)

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -191,7 +191,15 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
       cwd: this.cwd,
       env: this.options.env ?? process.env,
       stdio: ["pipe", "pipe", "pipe"],
-      shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
+      // Always use the deterministic Windows shell (cmd.exe) to wrap this spawn, never
+      // process.env.SHELL. This wrapper only resolves the codex executable (npm installs
+      // ship a .cmd shim that CreateProcess cannot exec directly); it has no bearing on
+      // what shell Codex uses internally for its own command-execution tool, since SHELL
+      // is passed through via `env` above regardless of this option. Trusting an arbitrary
+      // user-configured SHELL here (git-bash, WSL's bash.exe shim, an unresolvable literal
+      // path, etc.) to wrap a JSON-RPC stdio pipe is unpredictable and can hang the
+      // handshake indefinitely with no surfaced error (#236). See also #138/#178.
+      shell: process.platform === "win32",
       windowsHide: true
     });
 

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -14,7 +14,7 @@ import { spawn } from "node:child_process";
 import readline from "node:readline";
 import { parseBrokerEndpoint } from "./broker-endpoint.mjs";
 import { ensureBrokerSession, loadBrokerSession } from "./broker-lifecycle.mjs";
-import { terminateProcessTree } from "./process.mjs";
+import { resolveWindowsShell, terminateProcessTree } from "./process.mjs";
 
 const PLUGIN_MANIFEST_URL = new URL("../../.claude-plugin/plugin.json", import.meta.url);
 const PLUGIN_MANIFEST = JSON.parse(fs.readFileSync(PLUGIN_MANIFEST_URL, "utf8"));
@@ -191,15 +191,18 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
       cwd: this.cwd,
       env: this.options.env ?? process.env,
       stdio: ["pipe", "pipe", "pipe"],
-      // Always use the deterministic Windows shell (cmd.exe) to wrap this spawn, never
-      // process.env.SHELL. This wrapper only resolves the codex executable (npm installs
-      // ship a .cmd shim that CreateProcess cannot exec directly); it has no bearing on
-      // what shell Codex uses internally for its own command-execution tool, since SHELL
-      // is passed through via `env` above regardless of this option. Trusting an arbitrary
-      // user-configured SHELL here (git-bash, WSL's bash.exe shim, an unresolvable literal
-      // path, etc.) to wrap a JSON-RPC stdio pipe is unpredictable and can hang the
-      // handshake indefinitely with no surfaced error (#236). See also #138/#178.
-      shell: process.platform === "win32",
+      // Always use the deterministic Windows shell (System32\cmd.exe, resolved via
+      // resolveWindowsShell) to wrap this spawn, never process.env.SHELL or
+      // process.env.ComSpec (plain `shell: true` falls back to the latter). This wrapper
+      // only resolves the codex executable (npm installs ship a .cmd shim that
+      // CreateProcess cannot exec directly); it has no bearing on what shell Codex uses
+      // internally for its own command-execution tool, since SHELL is passed through via
+      // `env` above regardless of this option. Trusting an arbitrary user-configured
+      // SHELL or ComSpec here (git-bash, WSL's bash.exe shim, an unresolvable literal
+      // path, a non-cmd.exe ComSpec, etc.) to wrap a JSON-RPC stdio pipe is unpredictable
+      // and can hang the handshake indefinitely with no surfaced error (#236). See also
+      // #138/#178.
+      shell: process.platform === "win32" ? resolveWindowsShell() : false,
       windowsHide: true
     });
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -9,7 +9,10 @@ export function runCommand(command, args = [], options = {}) {
     input: options.input,
     maxBuffer: options.maxBuffer,
     stdio: options.stdio ?? "pipe",
-    shell: options.shell ?? (process.platform === "win32" ? (process.env.SHELL || true) : false),
+    // See app-server.mjs for why this stays off process.env.SHELL: an arbitrary
+    // user-configured shell is not a safe or predictable wrapper for spawning
+    // subprocesses on Windows (#236).
+    shell: options.shell ?? process.platform === "win32",
     windowsHide: true
   });
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -1,5 +1,19 @@
 import { spawnSync } from "node:child_process";
+import path from "node:path";
 import process from "node:process";
+
+// Resolve the Windows command interpreter deterministically. Passing `shell: true` on
+// Windows would otherwise let Node fall back to process.env.ComSpec, and this project
+// intentionally never consults process.env.SHELL either -- both are arbitrary,
+// user-configurable env vars that are not a safe or predictable wrapper for spawning a
+// subprocess on Windows (#236: a nonstandard SHELL or ComSpec can silently break the
+// spawn wrapper for a JSON-RPC stdio pipe). SystemRoot is set by the OS itself, so
+// resolving System32\cmd.exe through it keeps this wrapper deterministic regardless of
+// either env var. See app-server.mjs for the codex app-server spawn that shares this.
+export function resolveWindowsShell() {
+  const systemRoot = process.env.SystemRoot || "C:\\Windows";
+  return path.join(systemRoot, "System32", "cmd.exe");
+}
 
 export function runCommand(command, args = [], options = {}) {
   const result = spawnSync(command, args, {
@@ -9,10 +23,7 @@ export function runCommand(command, args = [], options = {}) {
     input: options.input,
     maxBuffer: options.maxBuffer,
     stdio: options.stdio ?? "pipe",
-    // See app-server.mjs for why this stays off process.env.SHELL: an arbitrary
-    // user-configured shell is not a safe or predictable wrapper for spawning
-    // subprocesses on Windows (#236).
-    shell: options.shell ?? process.platform === "win32",
+    shell: options.shell ?? (process.platform === "win32" ? resolveWindowsShell() : false),
     windowsHide: true
   });
 


### PR DESCRIPTION
## Problem

Fixes #236 (broker hangs at "Initializing..." on Windows).

`app-server.mjs` spawns `codex app-server` with `shell: process.env.SHELL || true` on win32 (and `lib/process.mjs` `runCommand` has the same pattern). An arbitrary, unvalidated `SHELL` (git-bash, a WSL shim, an untranslated POSIX literal like `/usr/bin/bash`) then wraps the JSON-RPC stdio pipe. Depending on the value this yields ENOENT or a wrapped pipe, and it silently breaks `terminateProcessTree`, whose cleanup logic assumes the direct child is cmd.exe.

### Regression chain
- #55 introduced `shell: process.platform === "win32"` (deterministic) to fix ENOENT on npm `.cmd` shims.
- #178 (for #138) changed it to `process.env.SHELL || true`. The outer spawn `shell` option only resolves the codex executable; it has no bearing on the shell Codex uses internally for its command tool (`SHELL` already flows through `env` passthrough), so #138's actual concern was unaffected by this option — but the change exposed the wrapper to arbitrary `SHELL` values.
- During review of this fix, we found `shell: true` is itself not deterministic: Node resolves it via `process.env.ComSpec`, so a nonstandard ComSpec (PowerShell, git-bash) reproduces the hang through a second env var.

## Fix (2 commits)
1. Stop honoring `SHELL` for the spawn wrapper (revert to platform-boolean).
2. Harden to a fully deterministic shell: new `resolveWindowsShell()` returns `%SystemRoot%\System32\cmd.exe` (SystemRoot is kernel-set, not a dev-tooling convention like SHELL/ComSpec). Explicit `options.shell` overrides in `runCommand` are preserved; non-win32 behavior unchanged. `SHELL` still reaches Codex via env passthrough, so internal shell selection (#138) is unaffected.

## Verification
- Windows 11, codex-cli 0.144.0: multi-variant spawn repro (`SHELL` unset / POSIX literal / translated path) demonstrated the failure modes before the fix.
- Test suite: the previously failing `cancel sends turn interrupt to the shared app-server before killing a brokered task` (taskkill/terminateProcessTree path) flips to passing; no other test status changes.
- Live headless round trip through the production broker path: `ensureBrokerSession` -> broker -> `codex app-server` -> initialize -> thread/start -> turn/start -> turn/completed -> clean shutdown, no orphaned processes.