### PR TITLE
fix: auto-review write-capable task escalations

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -488,6 +488,8 @@ async function executeTaskRun(request) {
     defaultPrompt: resumeThreadId ? DEFAULT_CONTINUE_PROMPT : "",
     model: request.model,
     effort: request.effort,
+    approvalPolicy: request.write ? "on-request" : "never",
+    approvalsReviewer: request.write ? "auto_review" : undefined,
     sandbox: request.write ? "workspace-write" : "read-only",
     onProgress: request.onProgress,
     persistThread: true,

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -65,6 +65,7 @@ function buildThreadParams(cwd, options = {}) {
     cwd,
     model: options.model ?? null,
     approvalPolicy: options.approvalPolicy ?? "never",
+    approvalsReviewer: options.approvalsReviewer ?? null,
     sandbox: options.sandbox ?? "read-only",
     serviceName: SERVICE_NAME,
     ephemeral: options.ephemeral ?? true
@@ -78,6 +79,7 @@ function buildResumeParams(threadId, cwd, options = {}) {
     cwd,
     model: options.model ?? null,
     approvalPolicy: options.approvalPolicy ?? "never",
+    approvalsReviewer: options.approvalsReviewer ?? null,
     sandbox: options.sandbox ?? "read-only"
   };
 }
@@ -1105,6 +1107,8 @@ export async function runAppServerTurn(cwd, options = {}) {
       emitProgress(options.onProgress, `Resuming thread ${options.resumeThreadId}.`, "starting");
       const response = await resumeThread(client, options.resumeThreadId, cwd, {
         model: options.model,
+        approvalPolicy: options.approvalPolicy,
+        approvalsReviewer: options.approvalsReviewer,
         sandbox: options.sandbox,
         ephemeral: false
       });
@@ -1113,6 +1117,8 @@ export async function runAppServerTurn(cwd, options = {}) {
       emitProgress(options.onProgress, "Starting Codex task thread.", "starting");
       const response = await startThread(client, cwd, {
         model: options.model,
+        approvalPolicy: options.approvalPolicy,
+        approvalsReviewer: options.approvalsReviewer,
         sandbox: options.sandbox,
         ephemeral: options.persistThread ? false : true,
         threadName: options.persistThread ? options.threadName : options.threadName ?? null

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -313,7 +313,17 @@ rl.on("line", (line) => {
           throw new Error("thread/start.persistFullHistory requires experimentalApi capability");
         }
         const thread = nextThread(state, message.params.cwd, message.params.ephemeral);
-        send({ id: message.id, result: { thread: buildThread(thread), model: message.params.model || "gpt-5.4", modelProvider: "openai", serviceTier: null, cwd: thread.cwd, approvalPolicy: "never", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
+        state.lastThreadStart = {
+          threadId: thread.id,
+          cwd: message.params.cwd ?? null,
+          model: message.params.model ?? null,
+          approvalPolicy: message.params.approvalPolicy ?? null,
+          approvalsReviewer: message.params.approvalsReviewer ?? null,
+          sandbox: message.params.sandbox ?? null,
+          ephemeral: message.params.ephemeral ?? null
+        };
+        saveState(state);
+        send({ id: message.id, result: { thread: buildThread(thread), model: message.params.model || "gpt-5.4", modelProvider: "openai", serviceTier: null, cwd: thread.cwd, approvalPolicy: message.params.approvalPolicy || "never", approvalsReviewer: message.params.approvalsReviewer || "user", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
         send({ method: "thread/started", params: { thread: { id: thread.id } } });
         break;
       }
@@ -346,8 +356,16 @@ rl.on("line", (line) => {
         }
         const thread = ensureThread(state, message.params.threadId);
         thread.updatedAt = now();
+        state.lastThreadResume = {
+          threadId: message.params.threadId,
+          cwd: message.params.cwd ?? null,
+          model: message.params.model ?? null,
+          approvalPolicy: message.params.approvalPolicy ?? null,
+          approvalsReviewer: message.params.approvalsReviewer ?? null,
+          sandbox: message.params.sandbox ?? null
+        };
         saveState(state);
-        send({ id: message.id, result: { thread: buildThread(thread), model: message.params.model || "gpt-5.4", modelProvider: "openai", serviceTier: null, cwd: thread.cwd, approvalPolicy: "never", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
+        send({ id: message.id, result: { thread: buildThread(thread), model: message.params.model || "gpt-5.4", modelProvider: "openai", serviceTier: null, cwd: thread.cwd, approvalPolicy: message.params.approvalPolicy || "never", approvalsReviewer: message.params.approvalsReviewer || "user", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
         break;
       }
 

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -701,6 +701,7 @@ test("session start hook exports the Claude session id, transcript path, and plu
 test("write task output focuses on the Codex result without generic follow-up hints", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
   installFakeCodex(binDir);
   initGitRepo(repo);
   fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
@@ -714,6 +715,61 @@ test("write task output focuses on the Codex result without generic follow-up hi
 
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout, "Handled the requested task.\nTask prompt accepted.\n");
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastThreadStart.approvalPolicy, "on-request");
+  assert.equal(fakeState.lastThreadStart.approvalsReviewer, "auto_review");
+  assert.equal(fakeState.lastThreadStart.sandbox, "workspace-write");
+});
+
+test("read-only task keeps never approval policy without auto-review", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "inspect the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastThreadStart.approvalPolicy, "never");
+  assert.equal(fakeState.lastThreadStart.approvalsReviewer, null);
+  assert.equal(fakeState.lastThreadStart.sandbox, "read-only");
+});
+
+test("task --resume-last --write forwards auto-review policy to app-server thread/resume", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const firstRun = run("node", [SCRIPT, "task", "initial task"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+  assert.equal(firstRun.status, 0, firstRun.stderr);
+
+  const result = run("node", [SCRIPT, "task", "--resume-last", "--write", "follow up"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastThreadResume.threadId, "thr_1");
+  assert.equal(fakeState.lastThreadResume.approvalPolicy, "on-request");
+  assert.equal(fakeState.lastThreadResume.approvalsReviewer, "auto_review");
+  assert.equal(fakeState.lastThreadResume.sandbox, "workspace-write");
 });
 
 test("task --resume acts like --resume-last without leaking the flag into the prompt", () => {


### PR DESCRIPTION
## Summary

- send `approvalPolicy: "on-request"`, `approvalsReviewer: "auto_review"`, and `sandbox: "workspace-write"` for write-capable task runs
- forward the same policy through both new and resumed app-server threads
- keep read-only tasks fail-closed with `approvalPolicy: "never"`, no automatic reviewer, and `sandbox: "read-only"`
- record the actual thread start/resume payloads in the fake app server and cover all three paths

## Relationship to #426 and #445

This deliberately builds on @mvanhorn's approved #426. It includes that PR's `approvalPolicy` plumbing and regression coverage, then extends the same path with the `approvalsReviewer` field requested in #445. Credit for the underlying write-policy fix belongs to @mvanhorn.

If maintainers prefer to keep #426 as the landing PR, this delta can be folded into it; this PR is intended as a cooperative extension or replacement, not a competing implementation.

## Security boundary

`auto_review` is an escalation approval gate. It does not select `danger-full-access`, bypass app-server approval handling, or prove that approved writes remain inside the workspace. Read-only delegation remains unchanged.

## Verification

- `node --test --test-name-pattern "write task output focuses|read-only task keeps never|resume-last --write forwards" tests/runtime.test.mjs` — 3/3 passed
- `codex app-server generate-ts --out plugins/codex/.generated/app-server-types` — passed with Codex CLI 0.144.0; generated start/resume types include `approvalsReviewer`
- `npx --no-install tsc -p tsconfig.app-server.json` — passed
- `npm ci --ignore-scripts` — 0 vulnerabilities
- `git diff --check` — passed
- full `tests/runtime.test.mjs` — 58/63 passed; the five failures are unrelated Windows/environment constraints: symlink privilege (1), temp transcripts outside the configured Claude projects root (3), and `taskkill` process termination (1). All changed policy-path tests passed.

Fixes #412
Closes #445