### PR TITLE
fix(app-server): accept MCP elicitation requests instead of rejecting them (#499)

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -54,7 +54,7 @@ function createProtocolError(message, data) {
   return error;
 }
 
-class AppServerClientBase {
+export class AppServerClientBase {
   constructor(cwd, options = {}) {
     this.cwd = cwd;
     this.options = options;
@@ -154,6 +154,20 @@ class AppServerClientBase {
   }
 
   handleServerRequest(message) {
+    // MCP servers (e.g. ChatGPT connectors surfaced as `codex_apps`) request the
+    // operator's consent via an elicitation, which app-server delivers as a
+    // server->client request. This client runs Codex non-interactively, so there
+    // is no human to answer it; blanket-rejecting every server request with
+    // -32601 makes those tool calls fail ("user rejected MCP tool call") on the
+    // background runner and hang on `codex exec` / `codex mcp-server`. Accept the
+    // elicitation so connectors the operator has already enabled can run.
+    if (message.method === "mcpServer/elicitation/request") {
+      this.sendMessage({
+        id: message.id,
+        result: { action: "accept", content: null, _meta: null }
+      });
+      return;
+    }
     this.sendMessage({
       id: message.id,
       error: buildJsonRpcError(-32601, `Unsupported server request: ${message.method}`)

--- a/tests/app-server.test.mjs
+++ b/tests/app-server.test.mjs
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { AppServerClientBase } from "../plugins/codex/scripts/lib/app-server.mjs";
+
+/** Minimal client that records the JSON-RPC messages it would send. */
+class CapturingClient extends AppServerClientBase {
+  constructor() {
+    super(process.cwd());
+    this.sent = [];
+  }
+  sendMessage(message) {
+    this.sent.push(message);
+  }
+}
+
+test("handleServerRequest accepts MCP elicitation requests instead of rejecting them", () => {
+  const client = new CapturingClient();
+  client.handleServerRequest({
+    id: 7,
+    method: "mcpServer/elicitation/request",
+    params: { threadId: "t1" }
+  });
+  assert.deepEqual(client.sent, [
+    { id: 7, result: { action: "accept", content: null, _meta: null } }
+  ]);
+});
+
+test("handleServerRequest still rejects unknown server requests with -32601", () => {
+  const client = new CapturingClient();
+  client.handleServerRequest({ id: 8, method: "some/unknown/request", params: {} });
+  assert.equal(client.sent.length, 1);
+  assert.equal(client.sent[0].id, 8);
+  assert.equal(client.sent[0].result, undefined);
+  assert.equal(client.sent[0].error.code, -32601);
+});


### PR DESCRIPTION
Fixes #499.

## Problem

`AppServerClientBase.handleServerRequest` rejects **every** server→client request with JSON-RPC `-32601` "Unsupported server request". MCP servers surfaced as `codex_apps` (e.g. ChatGPT connectors) ask for the operator's consent via an `mcpServer/elicitation/request`, which app-server delivers as a server→client request. Because this client runs Codex non-interactively, that request is never answered:

- the background runner returns `user rejected MCP tool call`;
- `codex exec` and `codex mcp-server` **hang** on the unanswered elicitation.

So connector tool calls (DainOS, GitHub, Slack, …) can't run through the plugin at all.

## Fix

Answer `mcpServer/elicitation/request` with `{ action: "accept", content: null, _meta: null }` so connectors the operator has already enabled can run. Unknown server requests still get `-32601`.

The response shape matches the generated app-server protocol (`McpServerElicitationRequestResponse`; `McpServerElicitationAction = "accept" | "decline" | "cancel"`).

## Verification

Ran a read-only connector call (`dainos.describe_schema`) through the plugin's `task` runner — non-interactive, **no** `--dangerously-bypass-approvals-and-sandbox`:

- **Before:** `user rejected MCP tool call`.
- **After:** `codex_apps/dainos.describe_schema completed` and the tool result is returned.

`node --test tests/*.test.mjs` stays green (91 → 93; adds a focused unit test and exports `AppServerClientBase` so it can be constructed in isolation).

## Note

If you'd prefer this gated behind a config/env opt-in rather than always accepting, I'm happy to adjust. Accepting seemed right given the plugin's non-interactive model and that the connector is already operator-enabled, but the choice is yours.

🤖 Authored with Claude Code