### PR TITLE
Document review scope selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ Use it when you want:
 - a review of your current uncommitted changes
 - a review of your branch compared to a base branch like `main`
 
-Use `--base <ref>` for branch review. It also supports `--wait` and `--background`. It is not steerable and does not take custom focus text. Use [`/codex:adversarial-review`](#codexadversarial-review) when you want to challenge a specific decision or risk area.
+Use `--base <ref>` for branch review. Use `--scope auto|working-tree|branch` to control target selection:
+
+- `auto` reviews working tree changes when present, otherwise the branch diff
+- `working-tree` reviews staged, unstaged, and untracked changes
+- `branch` reviews the branch diff against the detected default branch
+
+Passing `--base <ref>` selects branch review against that ref regardless of `--scope`. The command also supports `--wait` and `--background`. It is not steerable and does not take custom focus text. Use [`/codex:adversarial-review`](#codexadversarial-review) when you want to challenge a specific decision or risk area.
 
 Examples:
 


### PR DESCRIPTION
Users cannot see how to select working-tree or branch review scope from the README even though both review commands support it.

## Summary

- Document the `--scope auto|working-tree|branch` option.
- Explain how `auto` chooses a target and what the explicit scopes include.
- Clarify that `--base <ref>` takes precedence and selects branch review.

## Expected and actual

- Expected: the README explains every review-target option exposed by the command frontmatter.
- Actual: it documented `--base`, `--wait`, and `--background`, but omitted `--scope` and its selection behavior.

## Validation

- `node --test tests/commands.test.mjs`: 8 passed
- `node --test tests/*.test.mjs`: 91 passed
- `git diff --check`: clean

## Actual screenshots

**README diff — actual terminal output**

![README review scope documentation diff in the terminal](https://github.com/user-attachments/assets/c6b288d9-a254-4ce6-a948-a69ac4c144bd)

**Focused validation — actual terminal output**

![Focused command documentation tests passing in the terminal](https://github.com/user-attachments/assets/5b3dd6ee-9c6e-462d-8050-e35fdd20f4e7)
