### PR TITLE
Report missing Claude projects directory

### DIFF
--- a/plugins/codex/scripts/lib/claude-session-transfer.mjs
+++ b/plugins/codex/scripts/lib/claude-session-transfer.mjs
@@ -29,13 +29,19 @@ export function resolveClaudeSessionPath(cwd, options = {}) {
   }
 
   let source;
-  let projects;
   try {
     source = fs.realpathSync(sourcePath);
-    projects = fs.realpathSync(CLAUDE_PROJECTS_DIR);
   } catch {
     throw new Error(`Claude session file not found: ${sourcePath}`);
   }
+
+  let projects;
+  try {
+    projects = fs.realpathSync(CLAUDE_PROJECTS_DIR);
+  } catch {
+    throw new Error(`Claude projects directory not found: ${CLAUDE_PROJECTS_DIR}`);
+  }
+
   const relative = path.relative(projects, source);
   if (relative === "" || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
     throw new Error(`Codex can import Claude sessions only from ${CLAUDE_PROJECTS_DIR}: ${source}`);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -327,6 +327,23 @@ test("transfer rejects sources outside the Claude projects directory", () => {
   assert.match(result.stderr, /only from .*\.claude.*projects/);
 });
 
+test("transfer distinguishes a missing Claude projects directory from a missing source", () => {
+  const home = makeTempDir();
+  const repo = path.join(home, "repo");
+  const sourcePath = path.join(home, "session.jsonl");
+  fs.mkdirSync(repo, { recursive: true });
+  fs.writeFileSync(sourcePath, "{}\n", "utf8");
+
+  const result = run("node", [SCRIPT, "transfer", "--source", sourcePath], {
+    cwd: repo,
+    env: { ...process.env, HOME: home }
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Claude projects directory not found:/);
+  assert.doesNotMatch(result.stderr, /Claude session file not found:/);
+});
+
 test("task reports the actual Codex auth error when the run is rejected", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
Transfer reports a valid session file as missing when the Claude projects directory itself does not exist.

## Observable sequence

- Provide `/codex:transfer` with an existing JSONL source file.
- Run it with a home directory that has no `.claude/projects` directory.
- Expected: report that the Claude projects directory is missing.
- Actual: report `Claude session file not found` for the existing source.

## Root cause and fix

One `try/catch` wrapped both `realpathSync` calls, so either failure was attributed to the source file. Resolve the source and projects directory separately and report the failing path accurately.

A regression test constructs an existing source with a missing projects directory and checks both the positive and negative error assertions.

## Validation

- Focused regression: 1 passed
- Full suite: 92 passed
- `git diff --check`: clean

## Actual screenshots

**Before — existing source incorrectly reported missing**

![Focused transfer regression showing the misleading source-file error before the fix](https://github.com/user-attachments/assets/7573b787-2ce6-4139-b10f-9471fdca6f3c)

**After — identical reproduction reports the correct condition**

![Focused transfer regression passing after the projects-directory error is distinguished](https://github.com/user-attachments/assets/280044cb-b382-4bab-9b05-023c658d77e5)
