### PR TITLE
Fix result lookup for active jobs

### DIFF
--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -256,9 +256,18 @@ export function buildSingleJobSnapshot(cwd, reference, options = {}) {
 export function resolveResultJob(cwd, reference) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const jobs = sortJobsNewestFirst(reference ? listJobs(workspaceRoot) : filterJobsForCurrentSession(listJobs(workspaceRoot)));
+
+  if (reference) {
+    const selected = matchJobReference(jobs, reference);
+    if (selected.status === "queued" || selected.status === "running") {
+      throw new Error(`Job ${selected.id} is still ${selected.status}. Check /codex:status and try again once it finishes.`);
+    }
+    return { workspaceRoot, job: selected };
+  }
+
   const selected = matchJobReference(
     jobs,
-    reference,
+    "",
     (job) => job.status === "completed" || job.status === "failed" || job.status === "cancelled"
   );
 
@@ -266,13 +275,9 @@ export function resolveResultJob(cwd, reference) {
     return { workspaceRoot, job: selected };
   }
 
-  const active = matchJobReference(jobs, reference, (job) => job.status === "queued" || job.status === "running");
+  const active = matchJobReference(jobs, "", (job) => job.status === "queued" || job.status === "running");
   if (active) {
     throw new Error(`Job ${active.id} is still ${active.status}. Check /codex:status and try again once it finishes.`);
-  }
-
-  if (reference) {
-    throw new Error(`No finished job found for "${reference}". Run /codex:status to inspect active jobs.`);
   }
 
   throw new Error("No finished Codex jobs found for this repository yet.");

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1415,6 +1415,47 @@ test("result returns the stored output for the latest finished job by default", 
   );
 });
 
+test("result identifies an explicitly referenced active job", async (t) => {
+  for (const status of ["queued", "running"]) {
+    await t.test(status, () => {
+      const workspace = makeTempDir();
+      const stateDir = resolveStateDir(workspace);
+      fs.mkdirSync(stateDir, { recursive: true });
+
+      fs.writeFileSync(
+        path.join(stateDir, "state.json"),
+        `${JSON.stringify(
+          {
+            version: 1,
+            config: { stopReviewGate: false },
+            jobs: [
+              {
+                id: `task-${status}`,
+                status,
+                title: "Codex Task",
+                jobClass: "task",
+                createdAt: "2026-03-18T15:30:00.000Z",
+                updatedAt: "2026-03-18T15:30:01.000Z"
+              }
+            ]
+          },
+          null,
+          2
+        )}\n`,
+        "utf8"
+      );
+
+      const result = run("node", [SCRIPT, "result", `task-${status}`], {
+        cwd: workspace
+      });
+
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, new RegExp(`Job task-${status} is still ${status}`));
+      assert.doesNotMatch(result.stderr, /No job found/);
+    });
+  }
+});
+
 test("result without a job id prefers the latest finished job from the current Claude session", () => {
   const workspace = makeTempDir();
   const stateDir = resolveStateDir(workspace);


### PR DESCRIPTION
Users requesting the result of an active job receive a false “No job found” error.

Fixes #498.

## Observable sequence

- Run `result <job-id>` for a queued or running job.
- Expected: report the job's current state and tell the user to try again after it finishes.
- Actual: report that no matching job exists.

## Root cause and fix

Explicit references were matched only after filtering the job list to terminal states, so active jobs could never reach the existing active-state error. Match explicit references against all jobs first, then branch on the selected job's status.

The CLI regression test covers both queued and running jobs and verifies that neither is reported as missing.

## Validation

- Focused regression: queued and running cases passed
- Full test suite: passed
- `pnpm run build`: passed
- `git diff --check`: clean

## Actual screenshots

Before and after screenshots use the same stored running job and command.

**Before — active job incorrectly reported missing**

![The result command on main reports that the stored running job cannot be found](https://github.com/user-attachments/assets/1487e2c9-7dbe-42b5-a766-4eb4d0f62509)

**After — active job reports its actual state and next action**

![The same result command on the fix branch reports that the job is still running](https://github.com/user-attachments/assets/69ad600b-e40e-40f9-a53b-eed6bb4858a9)
