### PR TITLE
Document workaround for hidden explicit commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,26 @@ When the review gate is enabled, the plugin uses a `Stop` hook to run a targeted
 > [!WARNING]
 > The review gate can create a long-running Claude/Codex loop and may drain usage limits quickly. Only enable it when you plan to actively monitor the session.
 
+## Troubleshooting
+
+### Claude says a `/codex:*` command is unavailable
+
+Claude Code can hide commands that set `disable-model-invocation: true` from the agent's available-skills list, even when you explicitly enter the command. This affects `/codex:review`, `/codex:adversarial-review`, `/codex:transfer`, `/codex:status`, `/codex:result`, and `/codex:cancel`.
+
+If Claude refuses one of these commands, ask it to **try the command through the Skill tool anyway**. This is a [known Claude Code issue](https://github.com/anthropics/claude-code/issues/50075); the command normally runs once Claude attempts the explicit invocation.
+
+To make the workaround persistent, add this guidance to your global `~/.claude/CLAUDE.md`:
+
+```md
+## Explicit slash commands
+
+When the user explicitly enters a slash command, try invoking it through the Skill
+tool even if it is missing from the available-skills list. Commands with
+`disable-model-invocation: true` are hidden from that list, but an explicit user
+command is not automatic model invocation. Only report that the command is
+unavailable if the Skill tool itself returns an error.
+```
+
 ## Typical Flows
 
 ### Review Before Shipping


### PR DESCRIPTION
Users can be told an explicitly entered `/codex:*` command is unavailable because Claude Code hides manual-only commands from the agent's skills list.

Closes #238.

## Observable sequence

- Enter a command such as `/codex:status` or `/codex:review`.
- Expected: Claude attempts the explicit command.
- Actual: Claude may refuse because commands with `disable-model-invocation: true` are absent from its available-skills list.

## Documentation change

- Add a troubleshooting entry linked to the upstream Claude Code issue.
- List every currently affected plugin command.
- Provide a ready-to-paste global `CLAUDE.md` instruction that distinguishes explicit user commands from automatic model invocation.

This is a documentation-only change; command configuration and runtime behavior are unchanged.

## Validation

- `node --test tests/commands.test.mjs`: 8 passed
- Full test suite: passed
- `git diff --check`: clean

## Actual screenshots

**README workaround — actual terminal diff**

![The terminal diff adds the troubleshooting note and global CLAUDE.md workaround](https://github.com/user-attachments/assets/0e173816-71b4-4fa3-80e9-863da67aae66)

**Focused documentation validation — actual terminal output**

![Eight focused command documentation tests passing in the terminal](https://github.com/user-attachments/assets/8947038d-32b7-4de9-a734-c9529d210a50)
