### PR TITLE
fix(commands): rename /codex:review to /codex:review-codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ they already have.
 
 ## What You Get
 
-- `/codex:review` for a normal read-only Codex review
+- `/codex:review-codex` for a normal read-only Codex review
 - `/codex:adversarial-review` for a steerable challenge review
 - `/codex:rescue`, `/codex:transfer`, `/codex:status`, `/codex:result`, and `/codex:cancel` to delegate work, hand off sessions, and manage background jobs
 
@@ -67,14 +67,14 @@ After install, you should see:
 One simple first run is:
 
 ```bash
-/codex:review --background
+/codex:review-codex --background
 /codex:status
 /codex:result
 ```
 
 ## Usage
 
-### `/codex:review`
+### `/codex:review-codex`
 
 Runs a normal Codex review on your current work. It gives you the same quality of code review as running `/review` inside Codex directly.
 
@@ -91,9 +91,9 @@ Use `--base <ref>` for branch review. It also supports `--wait` and `--backgroun
 Examples:
 
 ```bash
-/codex:review
-/codex:review --base main
-/codex:review --background
+/codex:review-codex
+/codex:review-codex --base main
+/codex:review-codex --background
 ```
 
 This command is read-only and will not perform any changes. When run in the background you can use [`/codex:status`](#codexstatus) to check on the progress and [`/codex:cancel`](#codexcancel) to cancel the ongoing task.
@@ -104,8 +104,8 @@ Runs a **steerable** review that questions the chosen implementation and design.
 
 It can be used to pressure-test assumptions, tradeoffs, failure modes, and whether a different approach would have been safer or simpler.
 
-It uses the same review target selection as `/codex:review`, including `--base <ref>` for branch review.
-It also supports `--wait` and `--background`. Unlike `/codex:review`, it can take extra focus text after the flags.
+It uses the same review target selection as `/codex:review-codex`, including `--base <ref>` for branch review.
+It also supports `--wait` and `--background`. Unlike `/codex:review-codex`, it can take extra focus text after the flags.
 
 Use it when you want:
 
@@ -241,7 +241,7 @@ When the review gate is enabled, the plugin uses a `Stop` hook to run a targeted
 ### Review Before Shipping
 
 ```bash
-/codex:review
+/codex:review-codex
 ```
 
 ### Hand A Problem To Codex

--- a/plugins/codex/commands/adversarial-review.md
+++ b/plugins/codex/commands/adversarial-review.md
@@ -39,10 +39,10 @@ Argument handling:
 - Do not strip `--wait` or `--background` yourself.
 - Do not weaken the adversarial framing or rewrite the user's focus text.
 - The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
-- `/codex:adversarial-review` uses the same review target selection as `/codex:review`.
+- `/codex:adversarial-review` uses the same review target selection as `/codex:review-codex`.
 - It supports working-tree review, branch review, and `--base <ref>`.
 - It does not support `--scope staged` or `--scope unstaged`.
-- Unlike `/codex:review`, it can still take extra focus text after the flags.
+- Unlike `/codex:review-codex`, it can still take extra focus text after the flags.
 
 Foreground flow:
 - Run:

--- a/plugins/codex/commands/result.md
+++ b/plugins/codex/commands/result.md
@@ -12,4 +12,4 @@ Present the full command output to the user. Do not summarize or condense it. Pr
 - The complete result payload, including verdict, summary, findings, details, artifacts, and next steps
 - File paths and line numbers exactly as reported
 - Any error messages or parse errors
-- Follow-up commands such as `/codex:status <id>` and `/codex:review`
+- Follow-up commands such as `/codex:status <id>` and `/codex:review-codex`

--- a/plugins/codex/commands/review-codex.md
+++ b/plugins/codex/commands/review-codex.md
@@ -36,7 +36,7 @@ Argument handling:
 - Do not strip `--wait` or `--background` yourself.
 - Do not add extra review instructions or rewrite the user's intent.
 - The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
-- `/codex:review` is native-review only. It does not support staged-only review, unstaged-only review, or extra focus text.
+- `/codex:review-codex` is native-review only. It does not support staged-only review, unstaged-only review, or extra focus text.
 - If the user needs custom review instructions or more adversarial framing, they should use `/codex:adversarial-review`.
 
 Foreground flow:

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -271,13 +271,13 @@ function buildNativeReviewTarget(target) {
 function validateNativeReviewRequest(target, focusText) {
   if (focusText.trim()) {
     throw new Error(
-      `\`/codex:review\` now maps directly to the built-in reviewer and does not support custom focus text. Retry with \`/codex:adversarial-review ${focusText.trim()}\` for focused review instructions.`
+      `\`/codex:review-codex\` now maps directly to the built-in reviewer and does not support custom focus text. Retry with \`/codex:adversarial-review ${focusText.trim()}\` for focused review instructions.`
     );
   }
 
   const nativeTarget = buildNativeReviewTarget(target);
   if (!nativeTarget) {
-    throw new Error("This `/codex:review` target is not supported by the built-in reviewer. Retry with `/codex:adversarial-review` for custom targeting.");
+    throw new Error("This `/codex:review-codex` target is not supported by the built-in reviewer. Retry with `/codex:adversarial-review` for custom targeting.");
   }
 
   return nativeTarget;

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -152,7 +152,7 @@ function pushJobDetails(lines, job, options = {}) {
     lines.push(`  Result: /codex:result ${job.id}`);
   }
   if (job.status !== "queued" && job.status !== "running" && job.jobClass === "task" && job.write && options.showReviewHint) {
-    lines.push("  Review changes: /codex:review --wait");
+    lines.push("  Review changes: /codex:review-codex --wait");
     lines.push("  Stricter review: /codex:adversarial-review --wait");
   }
   if (job.progressPreview?.length) {

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -72,7 +72,7 @@ function parseStopReviewOutput(rawOutput) {
     return {
       ok: false,
       reason:
-        "The stop-time Codex review task returned no final output. Run /codex:review --wait manually or bypass the gate."
+        "The stop-time Codex review task returned no final output. Run /codex:review-codex --wait manually or bypass the gate."
     };
   }
 
@@ -91,7 +91,7 @@ function parseStopReviewOutput(rawOutput) {
   return {
     ok: false,
     reason:
-      "The stop-time Codex review task returned an unexpected answer. Run /codex:review --wait manually or bypass the gate."
+      "The stop-time Codex review task returned an unexpected answer. Run /codex:review-codex --wait manually or bypass the gate."
   };
 }
 
@@ -113,7 +113,7 @@ function runStopReview(cwd, input = {}) {
     return {
       ok: false,
       reason:
-        "The stop-time Codex review task timed out after 15 minutes. Run /codex:review --wait manually or bypass the gate."
+        "The stop-time Codex review task timed out after 15 minutes. Run /codex:review-codex --wait manually or bypass the gate."
     };
   }
 
@@ -123,7 +123,7 @@ function runStopReview(cwd, input = {}) {
       ok: false,
       reason: detail
         ? `The stop-time Codex review task failed: ${detail}`
-        : "The stop-time Codex review task failed. Run /codex:review --wait manually or bypass the gate."
+        : "The stop-time Codex review task failed. Run /codex:review-codex --wait manually or bypass the gate."
     };
   }
 
@@ -134,7 +134,7 @@ function runStopReview(cwd, input = {}) {
     return {
       ok: false,
       reason:
-        "The stop-time Codex review task returned invalid JSON. Run /codex:review --wait manually or bypass the gate."
+        "The stop-time Codex review task returned invalid JSON. Run /codex:review-codex --wait manually or bypass the gate."
     };
   }
 }

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -12,7 +12,7 @@ function read(relativePath) {
 }
 
 test("review command uses AskUserQuestion and background Bash while staying review-only", () => {
-  const source = read("commands/review.md");
+  const source = read("commands/review-codex.md");
   assert.match(source, /AskUserQuestion/);
   assert.match(source, /\bBash\(/);
   assert.match(source, /Do not fix issues/i);
@@ -64,7 +64,7 @@ test("adversarial review command uses AskUserQuestion and background Bash while 
   assert.match(source, /Claude Code's `Bash\(..., run_in_background: true\)` is what actually detaches the run/i);
   assert.match(source, /When in doubt, run the review/i);
   assert.match(source, /\(Recommended\)/);
-  assert.match(source, /uses the same review target selection as `\/codex:review`/i);
+  assert.match(source, /uses the same review target selection as `\/codex:review-codex`/i);
   assert.match(source, /supports working-tree review, branch review, and `--base <ref>`/i);
   assert.match(source, /does not support `--scope staged` or `--scope unstaged`/i);
   assert.match(source, /can still take extra focus text after the flags/i);
@@ -77,7 +77,7 @@ test("continue is not exposed as a user-facing command", () => {
     "cancel.md",
     "rescue.md",
     "result.md",
-    "review.md",
+    "review-codex.md",
     "setup.md",
     "status.md",
     "transfer.md"
@@ -159,9 +159,9 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(readme, /`spark`, the plugin maps that to `gpt-5\.3-codex-spark`/i);
   assert.match(readme, /continue a previous Codex task/i);
   assert.match(readme, /### `\/codex:setup`/);
-  assert.match(readme, /### `\/codex:review`/);
+  assert.match(readme, /### `\/codex:review-codex`/);
   assert.match(readme, /### `\/codex:adversarial-review`/);
-  assert.match(readme, /uses the same review target selection as `\/codex:review`/i);
+  assert.match(readme, /uses the same review target selection as `\/codex:review-codex`/i);
   assert.match(readme, /--base main challenge whether this was the right caching and retry design/);
   assert.match(readme, /### `\/codex:rescue`/);
   assert.match(readme, /### `\/codex:transfer`/);


### PR DESCRIPTION
## Summary
- Renames the Codex review slash command from `/codex:review` to `/codex:review-codex` (command file `review-codex.md`)
- Updates README, companion error strings, stop-gate hints, and tests to match
- Frees bare `/review` in Cursor so local review skills are not shadowed by this plugin command

## Test plan
- [ ] Confirm slash picker shows `review-codex` / `/codex:review-codex` and no longer registers bare `review` from this plugin
- [ ] Run `/codex:review-codex --wait` on a small working-tree change
- [ ] Run `node --test tests/commands.test.mjs`