### PR TITLE
Fix SessionEnd hook timeout for Codex CLI 0.145

### DIFF
--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -18,7 +18,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-lifecycle-hook.mjs\" SessionEnd",
-            "timeout": 5
+            "timeout": 3
           }
         ]
       }

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -204,10 +204,14 @@ test("internal docs use task terminology for rescue runs", () => {
 
 test("hooks keep session-end cleanup and stop gating enabled", () => {
   const source = read("hooks/hooks.json");
+  const config = JSON.parse(source);
+  const sessionEndHook = config.hooks.SessionEnd[0].hooks[0];
+
   assert.match(source, /SessionStart/);
   assert.match(source, /SessionEnd/);
   assert.match(source, /stop-review-gate-hook\.mjs/);
   assert.match(source, /session-lifecycle-hook\.mjs/);
+  assert.equal(sessionEndHook.timeout, 3);
 });
 
 test("setup command can offer Codex install and still points users to codex login", () => {


### PR DESCRIPTION
## Summary

- lower the bundled `SessionEnd` hook timeout from 5 seconds to the Codex CLI maximum of 3 seconds
- add a regression assertion for the distributed hook configuration
- eliminate the startup warning introduced by Codex CLI 0.145

## Validation

- `node --test tests/commands.test.mjs` — 8 passed
- `npm test` — 91 passed
- `npm run check-version` — all version metadata matches 1.0.6
- `git diff --check` — clean

TDD evidence: the focused test first failed with `5 !== 3`, then passed after the one-value configuration change.

## AI Review Protocol

- `/simplify` ran with two parallel read-only reviewers; both reported no material findings
- `review-swarm` skipped because this is a two-file, one-value configuration fix with focused regression coverage
- final `autoreview --mode local --parallel-tests "node --test tests/commands.test.mjs"` completed cleanly with no accepted/actionable findings

## Review Evidence

Accepted findings fixed: none.

Rejected findings: none.

Residual risk: the lifecycle hook already relies on the host timeout if broker shutdown hangs. Codex CLI 0.145 enforces the same effective 3-second cap today, so this patch aligns declared and effective behavior without changing that pre-existing teardown characteristic.