### PR TITLE
Avoid rerunning stop review on blocked retries

### DIFF
--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -156,6 +156,11 @@ function main() {
     return;
   }
 
+  if (input.stop_hook_active) {
+    logNote(runningTaskNote);
+    return;
+  }
+
   const setupNote = buildSetupNote(cwd);
   if (setupNote) {
     logNote(setupNote);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1979,6 +1979,33 @@ test("stop hook runs a stop-time review task and blocks on findings when the rev
   assert.match(status.stdout, /Codex Stop Gate Review/);
 });
 
+test("stop hook does not rerun the review when handling a blocked stop retry", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  const setup = run("node", [SCRIPT, "setup", "--enable-review-gate", "--json"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+  assert.equal(setup.status, 0, setup.stderr);
+
+  const retry = run("node", [STOP_HOOK], {
+    cwd: repo,
+    env: buildEnv(binDir),
+    input: JSON.stringify({
+      cwd: repo,
+      session_id: "sess-stop-review-retry",
+      stop_hook_active: true,
+      last_assistant_message: "This response was already reviewed."
+    })
+  });
+
+  assert.equal(retry.status, 0, retry.stderr);
+  assert.equal(retry.stdout.trim(), "");
+});
+
 test("stop hook logs running tasks to stderr without blocking when the review gate is disabled", () => {
   const repo = makeTempDir();
   initGitRepo(repo);


### PR DESCRIPTION
Fixes #548.

After a Stop hook blocks, Claude Code invokes it again with `stop_hook_active: true`. The review gate currently ignores that flag, so a failed or blocking Codex review can run and block repeatedly until the harness cap is reached.

This allows the retry to finish without starting another review, while still reporting any running Codex task on stderr. The regression test enables the review gate and verifies that an active stop retry produces no blocking decision.

Tests:
- `npm test` (92 passed)
- `npm run build`