### PR TITLE
fix: persist Codex review threads

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -413,7 +413,8 @@ async function executeReviewRun(request) {
     model: request.model,
     sandbox: "read-only",
     outputSchema: readOutputSchema(REVIEW_SCHEMA),
-    onProgress: request.onProgress
+    onProgress: request.onProgress,
+    persistThread: true
   });
   const parsed = parseStructuredOutput(result.finalMessage, {
     status: result.status,

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -1010,7 +1010,7 @@ export async function runAppServerReview(cwd, options = {}) {
     const thread = await startThread(client, cwd, {
       model: options.model,
       sandbox: "read-only",
-      ephemeral: true,
+      ephemeral: false,
       threadName: options.threadName
     });
     const sourceThreadId = thread.thread.id;

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -364,6 +364,8 @@ test("review accepts the quoted raw argument style for built-in base-branch revi
   assert.equal(result.status, 0);
   assert.match(result.stdout, /Reviewed changes against main/);
   assert.match(result.stdout, /No material issues found/);
+  const state = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  assert.equal(state.threads[0].ephemeral, false);
 });
 
 test("adversarial review renders structured findings over app-server turn/start", () => {
@@ -384,6 +386,8 @@ test("adversarial review renders structured findings over app-server turn/start"
 
   assert.equal(result.status, 0);
   assert.match(result.stdout, /Missing empty-state guard/);
+  const state = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  assert.equal(state.threads[0].ephemeral, false);
 });
 
 test("adversarial review accepts the same base-branch targeting as review", () => {


### PR DESCRIPTION
## Summary

Persist Codex threads created by both review commands so their session IDs
remain resumable after the broker restarts.

Fixes #529

## Changes

- Make native `/codex:review` threads non-ephemeral
- Enable thread persistence for `/codex:adversarial-review`
- Add regression assertions verifying both review paths start threads with
  `ephemeral: false`

## Testing

- Targeted native review persistence test passes
- Targeted adversarial review persistence test passes
- Full test suite was also executed on Windows
- Existing Windows/environment-specific test failures are unrelated to this change