### PR TITLE
Fix stale Codex advisor runtimes with opt-in direct mode

### DIFF
--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -610,7 +610,24 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
   }
 }
 
+const APP_SERVER_MODE_ENV = "CODEX_COMPANION_APP_SERVER_MODE";
+
+function resolveAppServerMode(env = process.env) {
+  const value = env[APP_SERVER_MODE_ENV];
+  if (value == null || value === "") {
+    return "default";
+  }
+  if (value === "direct") {
+    return "direct";
+  }
+  throw new Error(`Unsupported ${APP_SERVER_MODE_ENV} value: ${value}`);
+}
+
 async function withAppServer(cwd, fn) {
+  if (resolveAppServerMode() === "direct") {
+    return withDirectAppServer(cwd, fn);
+  }
+
   let client = null;
   try {
     client = await CodexAppServerClient.connect(cwd);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -2161,6 +2161,113 @@ test("commands lazily start and reuse one shared app-server after first use", as
   assert.equal(cleanup.status, 0, cleanup.stderr);
 });
 
+test("direct app-server mode starts a fresh process for every command", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const fakeStatePath = path.join(binDir, "fake-codex-state.json");
+
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "README.md"), "hello again\n");
+
+  const sharedEnv = buildEnv(binDir);
+  const directEnv = {
+    ...sharedEnv,
+    CODEX_COMPANION_APP_SERVER_MODE: "direct"
+  };
+
+  try {
+    const review = run("node", [SCRIPT, "review"], { cwd: repo, env: sharedEnv });
+    assert.equal(review.status, 0, review.stderr);
+    const sharedStarts = JSON.parse(fs.readFileSync(fakeStatePath, "utf8")).appServerStarts;
+    assert.ok(sharedStarts >= 1);
+    const brokerSession = loadBrokerSession(repo);
+
+    const adversarial = run("node", [SCRIPT, "adversarial-review"], {
+      cwd: repo,
+      env: directEnv
+    });
+    assert.equal(adversarial.status, 0, adversarial.stderr);
+    assert.equal(JSON.parse(fs.readFileSync(fakeStatePath, "utf8")).appServerStarts, sharedStarts + 1);
+
+    const task = run("node", [SCRIPT, "task", "challenge the current design"], {
+      cwd: repo,
+      env: directEnv
+    });
+    assert.equal(task.status, 0, task.stderr);
+    assert.equal(JSON.parse(fs.readFileSync(fakeStatePath, "utf8")).appServerStarts, sharedStarts + 2);
+    if (brokerSession) {
+      assert.equal(loadBrokerSession(repo)?.endpoint, brokerSession.endpoint);
+    }
+  } finally {
+    run("node", [SESSION_HOOK, "SessionEnd"], {
+      cwd: repo,
+      env: sharedEnv,
+      input: JSON.stringify({ hook_event_name: "SessionEnd", cwd: repo })
+    });
+  }
+});
+
+test("direct app-server mode does not retry a failed runtime", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const fakeStatePath = path.join(binDir, "fake-codex-state.json");
+
+  installFakeCodex(binDir, "auth-run-fails");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "check failed auth"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      CODEX_COMPANION_APP_SERVER_MODE: "direct"
+    }
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /authentication expired; run codex login/);
+  assert.equal(JSON.parse(fs.readFileSync(fakeStatePath, "utf8")).appServerStarts, 1);
+
+  const state = JSON.parse(
+    fs.readFileSync(path.join(resolveStateDir(repo), "state.json"), "utf8")
+  );
+  assert.equal(state.jobs.length, 1);
+  assert.equal(state.jobs[0].kind, "task");
+  assert.equal(state.jobs[0].status, "failed");
+});
+
+test("unsupported app-server mode fails before starting a runtime", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "reject invalid mode"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      CODEX_COMPANION_APP_SERVER_MODE: "shared-typo"
+    }
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /Unsupported CODEX_COMPANION_APP_SERVER_MODE value: shared-typo/
+  );
+  assert.equal(fs.existsSync(path.join(binDir, "fake-codex-state.json")), false);
+});
+
 test("setup reuses an existing shared app-server without starting another one", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
## Summary

- add an opt-in direct app-server mode for managed Codex companion calls
- start one fresh app-server per direct-mode invocation and never retry a failed runtime
- preserve the existing shared app-server behavior when the mode is unset
- fail explicitly for unsupported mode values

## Root cause

Claude Code advisor calls could reuse a stale shared Codex app-server after the CLI or runtime state changed. The managed wrapper needs a narrowly scoped way to request a fresh process without changing normal plugin behavior.

## Validation

- focused runtime tests: 5 passed, 0 failed
- `git diff --check origin/main...HEAD`: passed

No model, permission, write-access, deployment, or generic execution behavior is added.
