### PR TITLE
feat: show persistent delegated tasks in Codex Desktop

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -491,7 +491,8 @@ async function executeTaskRun(request) {
     sandbox: request.write ? "workspace-write" : "read-only",
     onProgress: request.onProgress,
     persistThread: true,
-    threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
+    threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT),
+    threadSource: taskMetadata.threadSource
   });
 
   const rawOutput = typeof result.finalMessage === "string" ? result.finalMessage : "";
@@ -541,7 +542,8 @@ function buildTaskRunMetadata({ prompt, resumeLast = false }) {
   if (!resumeLast && String(prompt ?? "").includes(STOP_REVIEW_TASK_MARKER)) {
     return {
       title: "Codex Stop Gate Review",
-      summary: "Stop-gate review of previous Claude turn"
+      summary: "Stop-gate review of previous Claude turn",
+      threadSource: null
     };
   }
 
@@ -549,7 +551,8 @@ function buildTaskRunMetadata({ prompt, resumeLast = false }) {
   const fallbackSummary = resumeLast ? DEFAULT_CONTINUE_PROMPT : "Task";
   return {
     title,
-    summary: shorten(prompt || fallbackSummary)
+    summary: shorten(prompt || fallbackSummary),
+    threadSource: "user"
   };
 }
 

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -67,7 +67,8 @@ function buildThreadParams(cwd, options = {}) {
     approvalPolicy: options.approvalPolicy ?? "never",
     sandbox: options.sandbox ?? "read-only",
     serviceName: SERVICE_NAME,
-    ephemeral: options.ephemeral ?? true
+    ephemeral: options.ephemeral ?? true,
+    ...(options.threadSource ? { threadSource: options.threadSource } : {})
   };
 }
 
@@ -1115,7 +1116,8 @@ export async function runAppServerTurn(cwd, options = {}) {
         model: options.model,
         sandbox: options.sandbox,
         ephemeral: options.persistThread ? false : true,
-        threadName: options.persistThread ? options.threadName : options.threadName ?? null
+        threadName: options.persistThread ? options.threadName : options.threadName ?? null,
+        threadSource: options.threadSource
       });
       threadId = response.thread.id;
     }

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -116,13 +116,14 @@ function send(message) {
   process.stdout.write(JSON.stringify(message) + "\\n");
 }
 
-function nextThread(state, cwd, ephemeral) {
+function nextThread(state, cwd, ephemeral, threadSource = null) {
   const thread = {
     id: "thr_" + state.nextThreadId++,
     cwd: cwd || process.cwd(),
     name: null,
     preview: "",
     ephemeral: Boolean(ephemeral),
+    threadSource,
     createdAt: now(),
     updatedAt: now()
   };
@@ -312,7 +313,7 @@ rl.on("line", (line) => {
         if (requiresExperimental("persistExtendedHistory", message, state) || requiresExperimental("persistFullHistory", message, state)) {
           throw new Error("thread/start.persistFullHistory requires experimentalApi capability");
         }
-        const thread = nextThread(state, message.params.cwd, message.params.ephemeral);
+        const thread = nextThread(state, message.params.cwd, message.params.ephemeral, message.params.threadSource ?? null);
         send({ id: message.id, result: { thread: buildThread(thread), model: message.params.model || "gpt-5.4", modelProvider: "openai", serviceTier: null, cwd: thread.cwd, approvalPolicy: "never", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
         send({ method: "thread/started", params: { thread: { id: thread.id } } });
         break;

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -155,6 +155,8 @@ test("review renders a no-findings result from app-server review/start", () => {
   assert.equal(result.status, 0);
   assert.match(result.stdout, /Reviewed uncommitted changes/);
   assert.match(result.stdout, /No material issues found/);
+  const fakeState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  assert.equal(fakeState.threads[0].threadSource, null);
 });
 
 test("task runs when the active provider does not require OpenAI login", () => {
@@ -173,6 +175,8 @@ test("task runs when the active provider does not require OpenAI login", () => {
 
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Handled the requested task/);
+  const fakeState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  assert.equal(fakeState.threads[0].threadSource, "user");
 });
 
 test("task runs without auth preflight so Codex can refresh an expired session", () => {
@@ -384,6 +388,8 @@ test("adversarial review renders structured findings over app-server turn/start"
 
   assert.equal(result.status, 0);
   assert.match(result.stdout, /Missing empty-state guard/);
+  const fakeState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  assert.equal(fakeState.threads[0].threadSource, null);
 });
 
 test("adversarial review accepts the same base-branch targeting as review", () => {
@@ -1967,6 +1973,8 @@ test("stop hook runs a stop-time review task and blocks on findings when the rev
   assert.match(fakeState.lastTurnStart.prompt, /<compact_output_contract>/i);
   assert.match(fakeState.lastTurnStart.prompt, /Only review the work from the previous Claude turn/i);
   assert.match(fakeState.lastTurnStart.prompt, /I completed the refactor and updated the retry logic\./);
+  assert.equal(fakeState.threads[0].threadSource, null);
+  assert.equal(fakeState.threads[1].threadSource, "user");
 
   const status = run("node", [SCRIPT, "status"], {
     cwd: repo,


### PR DESCRIPTION
## Summary

- Set `threadSource: "user"` for newly created persistent `task` and `rescue`
  threads so Codex Desktop includes them in its task list.
- Preserve the existing handling of reviews, transfers, and stop-gate runs.
- Add runtime tests for thread-source selection.

## Problem

Persistent `task` and `rescue` threads already support resume by thread ID.
Codex Desktop lists user threads, while the plugin currently leaves the source
value unset for these runs. Users therefore need the thread ID to reopen the
conversation in Desktop.

## Approach

`buildThreadParams()` now accepts an optional `threadSource`. New persistent
`task` and `rescue` threads use `"user"`. Review, adversarial review, transfer,
and stop-gate paths keep their existing source handling.

The origin metadata still identifies Claude Code as the caller.

| Flow | Result |
| --- | --- |
| New persistent task or rescue | Listed in Codex Desktop |
| Resume an existing task | Reuses the same thread |
| Review or adversarial review | Existing behavior preserved |
| Transfer | Existing behavior preserved |
| Stop-gate review | Existing behavior preserved |

## User impact

A delegated task appears in the Codex Desktop sidebar. The user can open it,
continue the conversation in Desktop, and later resume the same thread from
Claude Code. Creating the thread leaves the current Desktop task in focus.

## Validation

- Focused thread-source tests: 4/4 passed.
- Version metadata, plugin manifest validation, and syntax checks passed.
- App-server type generation and TypeScript compilation passed on Windows 11.
- A Windows 11 canary confirmed automatic sidebar listing, stable task focus,
  one shared thread ID, and history continuity between Desktop and Claude Code.
- The thread remained available after the Claude Code session ended.
- Full-suite comparison: 86/91 passed on both the feature implementation and
  the upstream baseline, with matching results across all 91 tests.
