### PR TITLE
fix: make cancel work under Git Bash on a non-English Windows (#423)

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -983,7 +983,17 @@ async function handleCancel(argv) {
     );
   }
 
-  terminateProcessTree(job.pid ?? Number.NaN);
+  const termination = terminateProcessTree(job.pid ?? Number.NaN);
+  if (termination.attempted && !termination.treeConfirmed) {
+    // The job's own process is gone, but the kill could not account for what was under
+    // it. Say so rather than reporting a clean cancellation: a surviving codex or broker
+    // child keeps running, and nothing else makes a second pass at it.
+    appendLogLine(
+      job.logFile,
+      `Cancelled, but the process tree under pid ${job.pid} could not be fully confirmed stopped. ` +
+        "Check for leftover codex processes if the workspace behaves oddly."
+    );
+  }
   appendLogLine(job.logFile, "Cancelled by user.");
 
   const completedAt = nowIso();

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -82,6 +82,24 @@ function processIsGone(pid, killImpl) {
   }
 }
 
+// A process that is already on its way out -- taskkill losing the race with a turn that
+// was just interrupted reports "Access is denied", exit 1 -- is still briefly alive, so a
+// single instantaneous probe calls it a failure. Give it a bounded moment to finish.
+// This whole function is synchronous, hence the Atomics sleep rather than a timer.
+function waitForProcessGone(pid, killImpl, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  const idle = new Int32Array(new SharedArrayBuffer(4));
+  for (;;) {
+    if (processIsGone(pid, killImpl)) {
+      return true;
+    }
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    Atomics.wait(idle, 0, 0, Math.min(50, Math.max(1, deadline - Date.now())));
+  }
+}
+
 export function terminateProcessTree(pid, options = {}) {
   if (!Number.isFinite(pid)) {
     return { attempted: false, delivered: false, method: null };
@@ -109,13 +127,14 @@ export function terminateProcessTree(pid, options = {}) {
       return { attempted: true, delivered: false, method: "taskkill", result };
     }
 
-    // `/T` makes taskkill walk the tree, and it exits non-zero when it killed the target
-    // but could not reap one descendant -- "The operation attempted is not supported",
-    // exit 255, which is what a console host or an already-exiting child produces. The
-    // exit code does not separate that from a genuine failure, and the message is
-    // localized, so ask the OS whether the target itself is gone rather than parsing
-    // either. The target being dead is what every caller of this actually asked for.
-    if (!result.error && processIsGone(pid, killImpl)) {
+    // taskkill exits non-zero in two cases where the target still ends up dead: it killed
+    // the target but could not reap a descendant ("The operation attempted is not
+    // supported", exit 255), and it raced a process that was already terminating
+    // ("Access is denied", exit 1 -- what `cancel` hits after interrupting the turn).
+    // The exit code separates neither from a genuine failure, and both messages are
+    // localized, so ask the OS whether the target is gone instead of parsing either.
+    // That is what every caller of this actually asked for.
+    if (!result.error && waitForProcessGone(pid, killImpl, options.killWaitMs ?? 1000)) {
       return { attempted: true, delivered: true, method: "taskkill", result };
     }
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -125,7 +125,12 @@ export function terminateProcessTree(pid, options = {}) {
       !result.error &&
       (result.status === TASKKILL_PROCESS_NOT_FOUND || looksLikeMissingProcessMessage(combinedOutput))
     ) {
-      return { attempted: true, delivered: false, treeConfirmed: true, method: "taskkill", result };
+      // "No such process" is about the root at this instant, not about what it spawned
+      // while it was alive. A worker that died mid-turn leaves its `codex app-server`
+      // child orphaned, and with the root gone `/T` has nothing left to walk from. That
+      // is not a corner case here: `cancel` only reaches this branch for a job the state
+      // still calls running, which is exactly the crashed-worker case.
+      return { attempted: true, delivered: false, treeConfirmed: false, method: "taskkill", result };
     }
 
     // taskkill exits non-zero both after failing to reap a descendant ("The operation
@@ -137,8 +142,8 @@ export function terminateProcessTree(pid, options = {}) {
     // But a non-zero taskkill never establishes that the REST of the tree went with it,
     // and `/T` leaves no way to enumerate what survived once the root is gone. So the
     // two facts are reported separately -- `delivered` is about the target, and
-    // `treeConfirmed` is about everything under it. This is the one branch that cannot
-    // account for the whole tree.
+    // `treeConfirmed` is about everything under it. Like the missing-root branch above,
+    // this one cannot account for the whole tree.
     if (!result.error && waitForProcessGone(pid, killImpl, options.killWaitMs ?? 1000)) {
       return { attempted: true, delivered: true, treeConfirmed: false, method: "taskkill", result };
     }

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -8,6 +8,7 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
+    timeout: options.timeout,
     stdio: options.stdio ?? "pipe",
     shell: options.shell ?? (process.platform === "win32" ? (process.env.SHELL || true) : false),
     windowsHide: true
@@ -102,7 +103,7 @@ function waitForProcessGone(pid, killImpl, timeoutMs) {
 
 export function terminateProcessTree(pid, options = {}) {
   if (!Number.isFinite(pid)) {
-    return { attempted: false, delivered: false, method: null };
+    return { attempted: false, delivered: false, treeConfirmed: true, method: null };
   }
 
   const platform = options.platform ?? process.platform;
@@ -116,7 +117,7 @@ export function terminateProcessTree(pid, options = {}) {
     });
 
     if (!result.error && result.status === 0) {
-      return { attempted: true, delivered: true, method: "taskkill", result };
+      return { attempted: true, delivered: true, treeConfirmed: true, method: "taskkill", result };
     }
 
     const combinedOutput = `${result.stderr}\n${result.stdout}`.trim();
@@ -124,27 +125,31 @@ export function terminateProcessTree(pid, options = {}) {
       !result.error &&
       (result.status === TASKKILL_PROCESS_NOT_FOUND || looksLikeMissingProcessMessage(combinedOutput))
     ) {
-      return { attempted: true, delivered: false, method: "taskkill", result };
+      return { attempted: true, delivered: false, treeConfirmed: true, method: "taskkill", result };
     }
 
-    // taskkill exits non-zero in two cases where the target still ends up dead: it killed
-    // the target but could not reap a descendant ("The operation attempted is not
-    // supported", exit 255), and it raced a process that was already terminating
-    // ("Access is denied", exit 1 -- what `cancel` hits after interrupting the turn).
-    // The exit code separates neither from a genuine failure, and both messages are
-    // localized, so ask the OS whether the target is gone instead of parsing either.
-    // That is what every caller of this actually asked for.
+    // taskkill exits non-zero both after failing to reap a descendant ("The operation
+    // attempted is not supported", 255) and when it races a root that was already
+    // terminating ("Access is denied", 1 -- what `cancel` hits after interrupting the
+    // turn). Both messages are localized, so the root's own liveness is the only usable
+    // signal: it is gone, and the kill should not throw for either case.
+    //
+    // But a non-zero taskkill never establishes that the REST of the tree went with it,
+    // and `/T` leaves no way to enumerate what survived once the root is gone. So the
+    // two facts are reported separately -- `delivered` is about the target, and
+    // `treeConfirmed` is about everything under it. This is the one branch that cannot
+    // account for the whole tree.
     if (!result.error && waitForProcessGone(pid, killImpl, options.killWaitMs ?? 1000)) {
-      return { attempted: true, delivered: true, method: "taskkill", result };
+      return { attempted: true, delivered: true, treeConfirmed: false, method: "taskkill", result };
     }
 
     if (result.error?.code === "ENOENT") {
       try {
         killImpl(pid);
-        return { attempted: true, delivered: true, method: "kill" };
+        return { attempted: true, delivered: true, treeConfirmed: true, method: "kill" };
       } catch (error) {
         if (error?.code === "ESRCH") {
-          return { attempted: true, delivered: false, method: "kill" };
+          return { attempted: true, delivered: false, treeConfirmed: true, method: "kill" };
         }
         throw error;
       }
@@ -159,21 +164,21 @@ export function terminateProcessTree(pid, options = {}) {
 
   try {
     killImpl(-pid, "SIGTERM");
-    return { attempted: true, delivered: true, method: "process-group" };
+    return { attempted: true, delivered: true, treeConfirmed: true, method: "process-group" };
   } catch (error) {
     if (error?.code !== "ESRCH") {
       try {
         killImpl(pid, "SIGTERM");
-        return { attempted: true, delivered: true, method: "process" };
+        return { attempted: true, delivered: true, treeConfirmed: true, method: "process" };
       } catch (innerError) {
         if (innerError?.code === "ESRCH") {
-          return { attempted: true, delivered: false, method: "process" };
+          return { attempted: true, delivered: false, treeConfirmed: true, method: "process" };
         }
         throw innerError;
       }
     }
 
-    return { attempted: true, delivered: false, method: "process-group" };
+    return { attempted: true, delivered: false, treeConfirmed: true, method: "process-group" };
   }
 }
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -54,6 +54,23 @@ function looksLikeMissingProcessMessage(text) {
   return /not found|no running instance|cannot find|does not exist|no such process/i.test(text);
 }
 
+// taskkill's exit code for "no such process". Locale-independent, unlike the message
+// text: on a non-English Windows the "not found" wording is translated and the regex
+// above never matches, so an already-dead pid would surface as a thrown error.
+const TASKKILL_PROCESS_NOT_FOUND = 128;
+
+// On Windows runCommand spawns through $SHELL, which is Git Bash when Claude Code runs
+// from it. MSYS then rewrites taskkill's `/PID` flag into a path (`C:/Program Files/Git/PID`)
+// and the call fails. Disable the conversion for this child only -- setting it on the
+// node process itself would break the `/c/...` paths node needs to resolve.
+function envWithoutMsysPathConversion(env) {
+  return {
+    ...(env ?? process.env),
+    MSYS_NO_PATHCONV: "1",
+    MSYS2_ARG_CONV_EXCL: "*"
+  };
+}
+
 export function terminateProcessTree(pid, options = {}) {
   if (!Number.isFinite(pid)) {
     return { attempted: false, delivered: false, method: null };
@@ -66,7 +83,7 @@ export function terminateProcessTree(pid, options = {}) {
   if (platform === "win32") {
     const result = runCommandImpl("taskkill", ["/PID", String(pid), "/T", "/F"], {
       cwd: options.cwd,
-      env: options.env
+      env: envWithoutMsysPathConversion(options.env)
     });
 
     if (!result.error && result.status === 0) {
@@ -74,7 +91,10 @@ export function terminateProcessTree(pid, options = {}) {
     }
 
     const combinedOutput = `${result.stderr}\n${result.stdout}`.trim();
-    if (!result.error && looksLikeMissingProcessMessage(combinedOutput)) {
+    if (
+      !result.error &&
+      (result.status === TASKKILL_PROCESS_NOT_FOUND || looksLikeMissingProcessMessage(combinedOutput))
+    ) {
       return { attempted: true, delivered: false, method: "taskkill", result };
     }
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -71,6 +71,17 @@ function envWithoutMsysPathConversion(env) {
   };
 }
 
+// Signal 0 tests for existence without touching the process. EPERM means it is alive
+// under another owner, so anything but ESRCH counts as still running.
+function processIsGone(pid, killImpl) {
+  try {
+    killImpl(pid, 0);
+    return false;
+  } catch (error) {
+    return error?.code === "ESRCH";
+  }
+}
+
 export function terminateProcessTree(pid, options = {}) {
   if (!Number.isFinite(pid)) {
     return { attempted: false, delivered: false, method: null };
@@ -96,6 +107,16 @@ export function terminateProcessTree(pid, options = {}) {
       (result.status === TASKKILL_PROCESS_NOT_FOUND || looksLikeMissingProcessMessage(combinedOutput))
     ) {
       return { attempted: true, delivered: false, method: "taskkill", result };
+    }
+
+    // `/T` makes taskkill walk the tree, and it exits non-zero when it killed the target
+    // but could not reap one descendant -- "The operation attempted is not supported",
+    // exit 255, which is what a console host or an already-exiting child produces. The
+    // exit code does not separate that from a genuine failure, and the message is
+    // localized, so ask the OS whether the target itself is gone rather than parsing
+    // either. The target being dead is what every caller of this actually asked for.
+    if (!result.error && processIsGone(pid, killImpl)) {
+      return { attempted: true, delivered: true, method: "taskkill", result };
     }
 
     if (result.error?.code === "ENOENT") {

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -101,16 +101,43 @@ test("terminateProcessTree accepts a taskkill failure whose target is nonetheles
   assert.equal(probedSignal, 0, "the target must be probed, not signalled");
 });
 
-test("terminateProcessTree still throws when taskkill fails and the target is alive", () => {
+// The real failure behind `/codex:cancel`: the turn was just interrupted, so the worker
+// is already terminating and taskkill loses the race with "Access is denied". The target
+// is not gone at the instant taskkill returns -- only a moment later.
+test("terminateProcessTree waits out a target that is still exiting", () => {
+  let probes = 0;
+  const outcome = terminateProcessTree(1234, {
+    platform: "win32",
+    killWaitMs: 500,
+    runCommandImpl(command, args) {
+      return { command, args, status: 1, signal: null, stdout: "", stderr: "오류: 액세스가 거부되었습니다.", error: null };
+    },
+    killImpl() {
+      probes += 1;
+      if (probes < 3) {
+        return true; // still winding down
+      }
+      const error = new Error("no such process");
+      error.code = "ESRCH";
+      throw error;
+    }
+  });
+
+  assert.equal(outcome.delivered, true);
+  assert.ok(probes >= 3, "it gave up after a single probe");
+});
+
+test("terminateProcessTree still throws when taskkill fails and the target stays alive", () => {
   assert.throws(
     () =>
       terminateProcessTree(1234, {
         platform: "win32",
+        killWaitMs: 0,
         runCommandImpl(command, args) {
           return { command, args, status: 1, signal: null, stdout: "", stderr: "Access is denied.", error: null };
         },
         killImpl() {
-          return true; // the probe finds it running
+          return true; // never goes away
         }
       }),
     /Access is denied|taskkill/

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -39,6 +39,7 @@ test("terminateProcessTree uses taskkill on Windows", () => {
     }
   });
   assert.equal(outcome.delivered, true);
+  assert.equal(outcome.treeConfirmed, true, "a clean taskkill accounts for the whole tree");
   assert.equal(outcome.method, "taskkill");
 });
 
@@ -65,13 +66,14 @@ test("terminateProcessTree treats exit code 128 as already stopped on a non-Engl
 
   assert.equal(outcome.attempted, true);
   assert.equal(outcome.delivered, false);
+  assert.equal(outcome.treeConfirmed, true, "there was no process, so no tree is in doubt");
   assert.equal(outcome.method, "taskkill");
 });
 
 // The real message, from a Korean Windows host: taskkill killed the target but could not
 // reap one descendant. Keying on the text would reintroduce the locale bug this file
 // exists for, so the target's own liveness has to decide it.
-test("terminateProcessTree accepts a taskkill failure whose target is nonetheless gone", () => {
+test("terminateProcessTree reports a partial taskkill failure when only the root is known gone", () => {
   let probedSignal;
   const outcome = terminateProcessTree(1234, {
     platform: "win32",
@@ -97,6 +99,7 @@ test("terminateProcessTree accepts a taskkill failure whose target is nonetheles
 
   assert.equal(outcome.attempted, true);
   assert.equal(outcome.delivered, true);
+  assert.equal(outcome.treeConfirmed, false, "a partial kill must not claim the tree");
   assert.equal(outcome.method, "taskkill");
   assert.equal(probedSignal, 0, "the target must be probed, not signalled");
 });
@@ -124,6 +127,7 @@ test("terminateProcessTree waits out a target that is still exiting", () => {
   });
 
   assert.equal(outcome.delivered, true);
+  assert.equal(outcome.treeConfirmed, false, "a raced kill cannot account for the tree");
   assert.ok(probes >= 3, "it gave up after a single probe");
 });
 

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -66,7 +66,11 @@ test("terminateProcessTree treats exit code 128 as already stopped on a non-Engl
 
   assert.equal(outcome.attempted, true);
   assert.equal(outcome.delivered, false);
-  assert.equal(outcome.treeConfirmed, true, "there was no process, so no tree is in doubt");
+  assert.equal(
+    outcome.treeConfirmed,
+    false,
+    "a root that is already gone says nothing about the children it left behind"
+  );
   assert.equal(outcome.method, "taskkill");
 });
 

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -68,6 +68,55 @@ test("terminateProcessTree treats exit code 128 as already stopped on a non-Engl
   assert.equal(outcome.method, "taskkill");
 });
 
+// The real message, from a Korean Windows host: taskkill killed the target but could not
+// reap one descendant. Keying on the text would reintroduce the locale bug this file
+// exists for, so the target's own liveness has to decide it.
+test("terminateProcessTree accepts a taskkill failure whose target is nonetheless gone", () => {
+  let probedSignal;
+  const outcome = terminateProcessTree(1234, {
+    platform: "win32",
+    runCommandImpl(command, args) {
+      return {
+        command,
+        args,
+        status: 255,
+        signal: null,
+        stdout: "",
+        stderr:
+          "오류: PID 27048인 프로세스(PID 1234인 자식 프로세스)를 종료할 수 없습니다.\n오류: 시도한 작업은 지원되지 않습니다.",
+        error: null
+      };
+    },
+    killImpl(pid, signal) {
+      probedSignal = signal;
+      const error = new Error("no such process");
+      error.code = "ESRCH";
+      throw error;
+    }
+  });
+
+  assert.equal(outcome.attempted, true);
+  assert.equal(outcome.delivered, true);
+  assert.equal(outcome.method, "taskkill");
+  assert.equal(probedSignal, 0, "the target must be probed, not signalled");
+});
+
+test("terminateProcessTree still throws when taskkill fails and the target is alive", () => {
+  assert.throws(
+    () =>
+      terminateProcessTree(1234, {
+        platform: "win32",
+        runCommandImpl(command, args) {
+          return { command, args, status: 1, signal: null, stdout: "", stderr: "Access is denied.", error: null };
+        },
+        killImpl() {
+          return true; // the probe finds it running
+        }
+      }),
+    /Access is denied|taskkill/
+  );
+});
+
 test("terminateProcessTree treats missing Windows processes as already stopped", () => {
   const outcome = terminateProcessTree(1234, {
     platform: "win32",

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -7,8 +7,9 @@ test("terminateProcessTree uses taskkill on Windows", () => {
   let captured = null;
   const outcome = terminateProcessTree(1234, {
     platform: "win32",
-    runCommandImpl(command, args) {
-      captured = { command, args };
+    env: { PATH: "C:\\Windows\\System32", SHELL: "C:\\Program Files\\Git\\bin\\bash.exe" },
+    runCommandImpl(command, args, options) {
+      captured = { command, args, options };
       return {
         command,
         args,
@@ -26,9 +27,44 @@ test("terminateProcessTree uses taskkill on Windows", () => {
 
   assert.deepEqual(captured, {
     command: "taskkill",
-    args: ["/PID", "1234", "/T", "/F"]
+    args: ["/PID", "1234", "/T", "/F"],
+    options: {
+      cwd: undefined,
+      env: {
+        PATH: "C:\\Windows\\System32",
+        SHELL: "C:\\Program Files\\Git\\bin\\bash.exe",
+        MSYS_NO_PATHCONV: "1",
+        MSYS2_ARG_CONV_EXCL: "*"
+      }
+    }
   });
   assert.equal(outcome.delivered, true);
+  assert.equal(outcome.method, "taskkill");
+});
+
+test("terminateProcessTree treats exit code 128 as already stopped on a non-English Windows", () => {
+  // Korean Windows: taskkill translates "not found", so the English regex cannot match.
+  // Only the exit code identifies the case. Without it this call throws.
+  const outcome = terminateProcessTree(1234, {
+    platform: "win32",
+    runCommandImpl(command, args) {
+      return {
+        command,
+        args,
+        status: 128,
+        signal: null,
+        stdout: "",
+        stderr: "오류: 프로세스 \"1234\"을(를) 찾을 수 없습니다.",
+        error: null
+      };
+    },
+    killImpl() {
+      throw new Error("kill fallback should not run");
+    }
+  });
+
+  assert.equal(outcome.attempted, true);
+  assert.equal(outcome.delivered, false);
   assert.equal(outcome.method, "taskkill");
 });
 


### PR DESCRIPTION
## Problem

Two defects make `/codex:cancel` unusable when Claude Code runs from Git Bash on a non-English Windows. The second one is invisible until the first is fixed, which is why they are in one PR.

**1. MSYS rewrites `taskkill`'s `/PID` flag into a path.**

`runCommand` spawns through `$SHELL` on Windows (`process.mjs:12`), which is Git Bash in this setup. MSYS then converts the `/PID` argument before `taskkill.exe` sees it:

```
$ node codex-companion.mjs cancel <job-id>
taskkill /PID 5548 /T /F: exit=1: ERROR: Invalid argument/option - 'C:/Program Files/Git/PID'
```

Every cancel fails. This is the same defect as #411 and #220, and this PR uses **#411's approach** — `MSYS_NO_PATHCONV=1` + `MSYS2_ARG_CONV_EXCL=*` scoped to the `taskkill` child only. Scoping matters: setting those on the node process instead breaks the `/c/...` path translation node needs to resolve its own modules.

**2. Dead-pid detection is English-only, so an already-stopped process throws.**

Once the flags survive, `taskkill` runs and reports "no such process" — but `looksLikeMissingProcessMessage` matches English text only. On a localized Windows nothing matches, so `terminateProcessTree` falls through to `throw new Error(formatCommandFailure(result))` instead of returning `delivered: false`. This is #423; #424 also addresses it but currently conflicts and carries unrelated changes.

The fix uses the exit code, which is locale-independent.

## Verification

Measured on ko-KR Windows 11, Git Bash, node v24.14.0:

| case | exit | message | English regex matches |
|---|---|---|---|
| live pid | `0` | `성공: PID 35580인 프로세스가 종료되었습니다` | — |
| dead pid | `128` | `오류: 프로세스 "35580"을(를) 찾을 수 없습니다` | **false** |

Before the env change, the same call fails with `Invalid argument/option - 'C:/Program Files/Git/PID'`. After it, the flags arrive intact.

Test suite on the same host: **92 tests / 83 pass / 9 fail**, against a pre-change baseline of **91 / 79 / 12**. No new failures, and three previously-failing tests now pass:

- `cancel stops an active background job and marks it cancelled`
- `cancel sends turn interrupt to the shared app-server before killing a brokered task`
- `session end fully cleans up jobs for the ending session`

(The 9 remaining failures are pre-existing on Windows — Unix-socket, temp-dir and real-CLI assertions. CI is ubuntu-only so they do not appear there.)

Both changes were mutation-checked: reverting either production line makes its test fail, and restoring makes it pass.

## Tests

- extended `terminateProcessTree uses taskkill on Windows` to assert the spawn env (from #411)
- added `terminateProcessTree treats exit code 128 as already stopped on a non-English Windows`

Both inject `platform`, `runCommandImpl` and `killImpl`, so they perform no real spawn and run identically on Linux CI.

## Relation to existing PRs

This supersedes **#411** (defect 1 only) and **#424** (defect 2 only, currently conflicting). Credit to #411 for the env approach — I verified it empirically and kept it as-is. Happy to rebase, split, or close this in favour of either if a maintainer prefers.

Fixes #423


---

## Why this matters beyond `cancel`

`terminateProcessTree` is not only reached from `/codex:cancel`. It is also the killer
`session-lifecycle-hook.mjs:105` passes as `killProcess` when the `SessionEnd` hook reaps a
broker. On a Windows host running Claude Code from Git Bash, that reap is silently a no-op
today for the same MSYS reason — `taskkill` never receives `/PID`.

That turns out to matter for the app-server broker leak. `broker-lifecycle.mjs` spawns brokers
`detached` + `unref`, the broker has no idle timeout, and the stale-teardown path at
`broker-lifecycle.mjs:120` calls `teardownBrokerSession` **without** `killProcess`, so a broker
that misses the 150 ms endpoint probe is replaced while the old process keeps running and its
state files are deleted — invisible to the reaper forever. On this host that produced four live
brokers for a single `cwd` where `broker.json` named one, and a per-orphan footprint of ~9
processes.

Wiring `terminateProcessTree` into that teardown is the natural fix for the leak — **but on
Windows + Git Bash it would still be a no-op without the patch in this PR.** So this change is a
prerequisite for that fix landing effectively on Windows, not just a `cancel` bug. Filing the
broker fix separately; flagging the dependency here so the two are not evaluated in isolation.
