### PR TITLE
feat: recover a lost result from the Codex rollout transcript

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -923,7 +923,10 @@ function handleResult(argv) {
   // only exist in codex's own rollout transcript. Recover the last one so a job
   // that ended without writing back is not a total loss.
   const threadId = storedJob?.threadId ?? job.threadId ?? null;
-  const recovered = storedJobHasOutput(storedJob) ? null : readLastAssistantMessage(threadId);
+  const turnId = storedJob?.turnId ?? job.turnId ?? null;
+  const recovered = storedJobHasOutput(storedJob)
+    ? null
+    : readLastAssistantMessage(threadId, { turnId });
   const payload = {
     job,
     storedJob,

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -57,12 +57,14 @@ import {
   renderNativeReviewResult,
   renderReviewResult,
   renderStoredJobResult,
+  storedJobHasOutput,
   renderCancelReport,
   renderJobStatusReport,
   renderSetupReport,
   renderStatusReport,
   renderTaskResult
 } from "./lib/render.mjs";
+import { readLastAssistantMessage } from "./lib/rollout.mjs";
 
 const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json");
@@ -917,12 +919,18 @@ function handleResult(argv) {
   const reference = positionals[0] ?? "";
   const { workspaceRoot, job } = resolveResultJob(cwd, reference);
   const storedJob = readStoredJob(workspaceRoot, job.id);
+  // Nothing was stored: the turn may still have produced assistant messages that
+  // only exist in codex's own rollout transcript. Recover the last one so a job
+  // that ended without writing back is not a total loss.
+  const threadId = storedJob?.threadId ?? job.threadId ?? null;
+  const recovered = storedJobHasOutput(storedJob) ? null : readLastAssistantMessage(threadId);
   const payload = {
     job,
-    storedJob
+    storedJob,
+    recovered
   };
 
-  outputCommandResult(payload, renderStoredJobResult(job, storedJob), options.json);
+  outputCommandResult(payload, renderStoredJobResult(job, storedJob, recovered), options.json);
 }
 
 function handleTaskResumeCandidate(argv) {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -650,7 +650,7 @@ async function withDirectAppServer(cwd, fn) {
   }
 }
 
-function resolveCodexHome() {
+export function resolveCodexHome() {
   return path.resolve(process.env.CODEX_HOME || path.join(os.homedir(), ".codex"));
 }
 

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -409,7 +409,7 @@ export function storedJobHasOutput(storedJob) {
 export function renderStoredJobResult(job, storedJob, recovered = null) {
   const threadId = storedJob?.threadId ?? job.threadId ?? null;
   const resumeCommand = threadId ? `codex resume ${threadId}` : null;
-  if (isStructuredReviewStoredResult(storedJob) && storedJob?.rendered) {
+  if (isStructuredReviewStoredResult(storedJob) && hasText(storedJob?.rendered)) {
     const output = storedJob.rendered.endsWith("\n") ? storedJob.rendered : `${storedJob.rendered}\n`;
     if (!threadId) {
       return output;

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -387,7 +387,20 @@ export function renderJobStatusReport(job) {
   return `${lines.join("\n").trimEnd()}\n`;
 }
 
-export function renderStoredJobResult(job, storedJob) {
+export function storedJobHasOutput(storedJob) {
+  if (isStructuredReviewStoredResult(storedJob) && storedJob?.rendered) {
+    return true;
+  }
+  if (typeof storedJob?.result?.rawOutput === "string" && storedJob.result.rawOutput) {
+    return true;
+  }
+  if (typeof storedJob?.result?.codex?.stdout === "string" && storedJob.result.codex.stdout) {
+    return true;
+  }
+  return Boolean(storedJob?.rendered);
+}
+
+export function renderStoredJobResult(job, storedJob, recovered = null) {
   const threadId = storedJob?.threadId ?? job.threadId ?? null;
   const resumeCommand = threadId ? `codex resume ${threadId}` : null;
   if (isStructuredReviewStoredResult(storedJob) && storedJob?.rendered) {
@@ -438,8 +451,22 @@ export function renderStoredJobResult(job, storedJob) {
     lines.push("", job.errorMessage);
   } else if (storedJob?.errorMessage) {
     lines.push("", storedJob.errorMessage);
-  } else {
+  } else if (!recovered) {
     lines.push("", "No captured result payload was stored for this job.");
+  }
+
+  if (recovered) {
+    // Labelled as partial on purpose: this is the last thing codex said, not a
+    // completed turn. Treat it as an unverified lead, not a verdict.
+    lines.push(
+      "",
+      "## Recovered from the Codex transcript (PARTIAL)",
+      "",
+      "No result was stored for this job, so this is the last assistant message",
+      `codex recorded. The turn may not have finished. Source: ${recovered.file}`,
+      "",
+      recovered.text.trimEnd()
+    );
   }
 
   return `${lines.join("\n").trimEnd()}\n`;

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -388,7 +388,10 @@ export function renderJobStatusReport(job) {
 }
 
 // Whitespace is not output: a stored "\n" would otherwise count as a result and
-// suppress the transcript recovery that has the real answer.
+// suppress the transcript recovery that has the real answer. Every place that decides
+// "this job has output" -- storedJobHasOutput and each early return in
+// renderStoredJobResult -- must agree on that, or one of them suppresses the recovery
+// and the other discards it.
 function hasText(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
@@ -418,8 +421,8 @@ export function renderStoredJobResult(job, storedJob, recovered = null) {
   }
 
   const rawOutput =
-    (typeof storedJob?.result?.rawOutput === "string" && storedJob.result.rawOutput) ||
-    (typeof storedJob?.result?.codex?.stdout === "string" && storedJob.result.codex.stdout) ||
+    (hasText(storedJob?.result?.rawOutput) && storedJob.result.rawOutput) ||
+    (hasText(storedJob?.result?.codex?.stdout) && storedJob.result.codex.stdout) ||
     "";
   if (rawOutput) {
     const output = rawOutput.endsWith("\n") ? rawOutput : `${rawOutput}\n`;
@@ -429,7 +432,7 @@ export function renderStoredJobResult(job, storedJob, recovered = null) {
     return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
   }
 
-  if (storedJob?.rendered) {
+  if (hasText(storedJob?.rendered)) {
     const output = storedJob.rendered.endsWith("\n") ? storedJob.rendered : `${storedJob.rendered}\n`;
     if (!threadId) {
       return output;

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -387,17 +387,23 @@ export function renderJobStatusReport(job) {
   return `${lines.join("\n").trimEnd()}\n`;
 }
 
+// Whitespace is not output: a stored "\n" would otherwise count as a result and
+// suppress the transcript recovery that has the real answer.
+function hasText(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
 export function storedJobHasOutput(storedJob) {
-  if (isStructuredReviewStoredResult(storedJob) && storedJob?.rendered) {
+  if (isStructuredReviewStoredResult(storedJob) && hasText(storedJob?.rendered)) {
     return true;
   }
-  if (typeof storedJob?.result?.rawOutput === "string" && storedJob.result.rawOutput) {
+  if (hasText(storedJob?.result?.rawOutput)) {
     return true;
   }
-  if (typeof storedJob?.result?.codex?.stdout === "string" && storedJob.result.codex.stdout) {
+  if (hasText(storedJob?.result?.codex?.stdout)) {
     return true;
   }
-  return Boolean(storedJob?.rendered);
+  return hasText(storedJob?.rendered);
 }
 
 export function renderStoredJobResult(job, storedJob, recovered = null) {
@@ -456,14 +462,20 @@ export function renderStoredJobResult(job, storedJob, recovered = null) {
   }
 
   if (recovered) {
-    // Labelled as partial on purpose: this is the last thing codex said, not a
-    // completed turn. Treat it as an unverified lead, not a verdict.
+    // The transcript says whether the turn reached its own `task_complete`. Only the
+    // cut-short case is a lead rather than a verdict, so only it is labelled partial.
     lines.push(
       "",
-      "## Recovered from the Codex transcript (PARTIAL)",
+      recovered.complete
+        ? "## Recovered from the Codex transcript"
+        : "## Recovered from the Codex transcript (PARTIAL)",
       "",
-      "No result was stored for this job, so this is the last assistant message",
-      `codex recorded. The turn may not have finished. Source: ${recovered.file}`,
+      recovered.complete
+        ? "No result was stored for this job, but the turn did finish -- this is the"
+        : "No result was stored for this job, so this is the last assistant message",
+      recovered.complete
+        ? `final message codex recorded. Source: ${recovered.file}`
+        : `codex recorded. The turn may not have finished. Source: ${recovered.file}`,
       "",
       recovered.text.trimEnd()
     );

--- a/plugins/codex/scripts/lib/rollout.mjs
+++ b/plugins/codex/scripts/lib/rollout.mjs
@@ -1,0 +1,108 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { resolveCodexHome } from "./codex.mjs";
+
+// When a turn ends without writing a result back to the job record -- the companion
+// returned first, the app-server turn was interrupted, the process died -- `result`
+// has nothing to hand back. The assistant messages it *did* produce are already on
+// disk though: codex writes every turn to its own rollout transcript under
+// $CODEX_HOME/sessions/<YYYY>/<MM>/<DD>/rollout-<timestamp>-<threadId>.jsonl.
+// Reading the last assistant message there turns an unrecoverable job into a
+// partial answer. This is a read-only recovery path; it never writes to the job.
+
+function findRolloutFile(sessionsDir, threadId) {
+  const suffix = `-${threadId}.jsonl`;
+  const stack = [sessionsDir];
+
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue; // sessions dir absent, or a directory we cannot read: not fatal
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else if (entry.name.startsWith("rollout-") && entry.name.endsWith(suffix)) {
+        return full;
+      }
+    }
+  }
+
+  return null;
+}
+
+function messageText(payload) {
+  if (typeof payload?.content === "string") {
+    return payload.content;
+  }
+  if (!Array.isArray(payload?.content)) {
+    return "";
+  }
+  return payload.content.map((part) => (typeof part?.text === "string" ? part.text : "")).join("");
+}
+
+function readLastAssistantText(filePath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+
+  let latest = null;
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    let record;
+    try {
+      record = JSON.parse(trimmed);
+    } catch {
+      continue; // a killed turn can leave a half-written final line
+    }
+    const payload = record?.payload;
+    if (payload?.type !== "message" || payload?.role !== "assistant") {
+      continue;
+    }
+    const text = messageText(payload);
+    if (text.trim()) {
+      latest = text;
+    }
+  }
+
+  return latest;
+}
+
+/**
+ * Last assistant message codex recorded for `threadId`, or null when there is no
+ * transcript or it holds no assistant text.
+ *
+ * @param {string} threadId
+ * @param {{ sessionsDir?: string, codexHome?: string }} [options]
+ * @returns {{ text: string, file: string } | null}
+ */
+export function readLastAssistantMessage(threadId, options = {}) {
+  if (typeof threadId !== "string" || threadId.length === 0) {
+    return null;
+  }
+
+  const sessionsDir =
+    options.sessionsDir ?? path.join(options.codexHome ?? resolveCodexHome(), "sessions");
+  const file = findRolloutFile(sessionsDir, threadId);
+  if (!file) {
+    return null;
+  }
+
+  const text = readLastAssistantText(file);
+  if (!text) {
+    return null;
+  }
+
+  return { text, file };
+}

--- a/plugins/codex/scripts/lib/rollout.mjs
+++ b/plugins/codex/scripts/lib/rollout.mjs
@@ -10,6 +10,14 @@ import { resolveCodexHome } from "./codex.mjs";
 // $CODEX_HOME/sessions/<YYYY>/<MM>/<DD>/rollout-<timestamp>-<threadId>.jsonl.
 // Reading the last assistant message there turns an unrecoverable job into a
 // partial answer. This is a read-only recovery path; it never writes to the job.
+//
+// One transcript can hold many turns -- `--resume-last` reuses a thread, so a
+// later job appends to the same file. Recovery must therefore be scoped to the
+// job's own turn, or an old job gets handed a newer job's answer, which is worse
+// than handing it nothing. The assistant records carry no turn id of their own;
+// only `task_started` / `turn_context` / `task_complete` do, as `payload.turn_id`
+// (snake case -- the job record spells the same value `turnId`). So the scan
+// tracks the turn those markers open and keeps only messages inside the wanted one.
 
 function findRolloutFile(sessionsDir, threadId) {
   const suffix = `-${threadId}.jsonl`;
@@ -46,7 +54,7 @@ function messageText(payload) {
   return payload.content.map((part) => (typeof part?.text === "string" ? part.text : "")).join("");
 }
 
-function readLastAssistantText(filePath) {
+function readLastAssistantText(filePath, turnId) {
   let raw;
   try {
     raw = fs.readFileSync(filePath, "utf8");
@@ -55,6 +63,7 @@ function readLastAssistantText(filePath) {
   }
 
   let latest = null;
+  let openTurnId = null;
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) {
@@ -67,6 +76,12 @@ function readLastAssistantText(filePath) {
       continue; // a killed turn can leave a half-written final line
     }
     const payload = record?.payload;
+    if (typeof payload?.turn_id === "string" && payload.turn_id) {
+      openTurnId = payload.turn_id;
+    }
+    if (openTurnId !== turnId) {
+      continue; // another job's turn on this same thread
+    }
     if (payload?.type !== "message" || payload?.role !== "assistant") {
       continue;
     }
@@ -80,15 +95,21 @@ function readLastAssistantText(filePath) {
 }
 
 /**
- * Last assistant message codex recorded for `threadId`, or null when there is no
- * transcript or it holds no assistant text.
+ * Last assistant message codex recorded for `turnId` on `threadId`, or null when
+ * there is no transcript, that turn is not in it, or it holds no assistant text.
+ * A missing `turnId` also returns null: the turn cannot be identified, and a
+ * neighbouring turn's answer is a wrong answer.
  *
  * @param {string} threadId
- * @param {{ sessionsDir?: string, codexHome?: string }} [options]
+ * @param {{ turnId?: string | null, sessionsDir?: string, codexHome?: string }} [options]
  * @returns {{ text: string, file: string } | null}
  */
 export function readLastAssistantMessage(threadId, options = {}) {
+  const turnId = options.turnId;
   if (typeof threadId !== "string" || threadId.length === 0) {
+    return null;
+  }
+  if (typeof turnId !== "string" || turnId.length === 0) {
     return null;
   }
 
@@ -99,7 +120,7 @@ export function readLastAssistantMessage(threadId, options = {}) {
     return null;
   }
 
-  const text = readLastAssistantText(file);
+  const text = readLastAssistantText(file, turnId);
   if (!text) {
     return null;
   }

--- a/plugins/codex/scripts/lib/rollout.mjs
+++ b/plugins/codex/scripts/lib/rollout.mjs
@@ -54,7 +54,7 @@ function messageText(payload) {
   return payload.content.map((part) => (typeof part?.text === "string" ? part.text : "")).join("");
 }
 
-function readLastAssistantText(filePath, turnId) {
+function readTurnResult(filePath, turnId) {
   let raw;
   try {
     raw = fs.readFileSync(filePath, "utf8");
@@ -62,7 +62,8 @@ function readLastAssistantText(filePath, turnId) {
     return null;
   }
 
-  let latest = null;
+  let finished = null; // codex's own final message for the turn, from `task_complete`
+  let latest = null; // fallback: the last thing it said before the turn was cut short
   let openTurnId = null;
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
@@ -76,8 +77,20 @@ function readLastAssistantText(filePath, turnId) {
       continue; // a killed turn can leave a half-written final line
     }
     const payload = record?.payload;
-    if (typeof payload?.turn_id === "string" && payload.turn_id) {
-      openTurnId = payload.turn_id;
+    const marker = typeof payload?.turn_id === "string" && payload.turn_id ? payload.turn_id : null;
+
+    if (payload?.type === "task_complete") {
+      // Prefer this over the raw scan: it is the same text codex shows a caller that
+      // did get a result, already stripped of the citation markup the transcript keeps.
+      if (marker === turnId && typeof payload.last_agent_message === "string" && payload.last_agent_message.trim()) {
+        finished = payload.last_agent_message;
+      }
+      openTurnId = null; // the turn is over; later records belong to another one
+      continue;
+    }
+
+    if (marker) {
+      openTurnId = marker;
     }
     if (openTurnId !== turnId) {
       continue; // another job's turn on this same thread
@@ -91,18 +104,25 @@ function readLastAssistantText(filePath, turnId) {
     }
   }
 
-  return latest;
+  if (finished) {
+    return { text: finished, complete: true };
+  }
+  return latest ? { text: latest, complete: false } : null;
 }
 
 /**
- * Last assistant message codex recorded for `turnId` on `threadId`, or null when
- * there is no transcript, that turn is not in it, or it holds no assistant text.
- * A missing `turnId` also returns null: the turn cannot be identified, and a
- * neighbouring turn's answer is a wrong answer.
+ * What codex recorded for `turnId` on `threadId`, or null when there is no
+ * transcript, that turn is not in it, or it holds no assistant text. `complete` is
+ * true when the answer came from the turn's own `task_complete` record -- that turn
+ * finished, and this is the final message. False means the turn was cut short and
+ * the text is the last thing said before it stopped, which may be mid-thought.
+ *
+ * A missing `turnId` returns null: the turn cannot be identified, and a neighbouring
+ * turn's answer is a wrong answer.
  *
  * @param {string} threadId
  * @param {{ turnId?: string | null, sessionsDir?: string, codexHome?: string }} [options]
- * @returns {{ text: string, file: string } | null}
+ * @returns {{ text: string, complete: boolean, file: string } | null}
  */
 export function readLastAssistantMessage(threadId, options = {}) {
   const turnId = options.turnId;
@@ -120,10 +140,10 @@ export function readLastAssistantMessage(threadId, options = {}) {
     return null;
   }
 
-  const text = readLastAssistantText(file, turnId);
-  if (!text) {
+  const result = readTurnResult(file, turnId);
+  if (!result) {
     return null;
   }
 
-  return { text, file };
+  return { ...result, file };
 }

--- a/tests/rollout.test.mjs
+++ b/tests/rollout.test.mjs
@@ -117,13 +117,15 @@ test("readLastAssistantMessage falls back to the raw scan when the turn never co
   assert.equal(recovered.complete, false);
 });
 
-// A turn that errored records `task_complete` with an empty `last_agent_message`.
-test("readLastAssistantMessage ignores an empty final message on a failed turn", () => {
+// A turn that errored records `task_complete` with a blank `last_agent_message`.
+test("readLastAssistantMessage ignores a blank final message on a failed turn", () => {
   const sessionsDir = makeTempDir();
   writeRollout(sessionsDir, THREAD_ID, [
     turnStart(TURN_ID),
     assistantRecord("as far as I got"),
-    turnEnd(TURN_ID, "")
+    // Whitespace, not "": an empty string is falsy anyway, so only this catches a
+    // regression in the trim guard.
+    turnEnd(TURN_ID, "   ")
   ]);
 
   const recovered = readLastAssistantMessage(THREAD_ID, { turnId: TURN_ID, sessionsDir });

--- a/tests/rollout.test.mjs
+++ b/tests/rollout.test.mjs
@@ -8,12 +8,24 @@ import { readLastAssistantMessage } from "../plugins/codex/scripts/lib/rollout.m
 import { renderStoredJobResult, storedJobHasOutput } from "../plugins/codex/scripts/lib/render.mjs";
 
 const THREAD_ID = "019fbad1-b569-7d93-97be-1efbff2b73b2";
+const TURN_ID = "019fbad1-c711-7051-b5bd-5665f2da3919";
+const LATER_TURN_ID = "019fbb1d-a711-7051-b5bd-5665f2da3919";
 
 function assistantRecord(text) {
   return {
     type: "response_item",
     payload: { type: "message", role: "assistant", content: [{ type: "output_text", text }] }
   };
+}
+
+// The turn markers codex actually writes: only these carry `turn_id`, and the
+// assistant records between them carry none.
+function turnStart(turnId) {
+  return { type: "event_msg", payload: { type: "task_started", turn_id: turnId } };
+}
+
+function turnEnd(turnId) {
+  return { type: "event_msg", payload: { type: "task_complete", turn_id: turnId } };
 }
 
 // Mirrors a real transcript: nested <sessions>/<YYYY>/<MM>/<DD>/rollout-<ts>-<threadId>.jsonl
@@ -26,10 +38,11 @@ function writeRollout(sessionsDir, threadId, records) {
   return file;
 }
 
-test("readLastAssistantMessage returns the last assistant message, not the first", () => {
+test("readLastAssistantMessage returns the last assistant message of the turn, not the first", () => {
   const sessionsDir = makeTempDir();
   writeRollout(sessionsDir, THREAD_ID, [
     { type: "session_meta", payload: { id: THREAD_ID } },
+    turnStart(TURN_ID),
     assistantRecord("first pass, still investigating"),
     { type: "response_item", payload: { type: "reasoning", content: [{ text: "thinking" }] } },
     { type: "response_item", payload: { type: "custom_tool_call", payload: {} } },
@@ -37,38 +50,72 @@ test("readLastAssistantMessage returns the last assistant message, not the first
     { type: "event_msg", payload: { type: "token_count" } }
   ]);
 
-  const recovered = readLastAssistantMessage(THREAD_ID, { sessionsDir });
+  const recovered = readLastAssistantMessage(THREAD_ID, { turnId: TURN_ID, sessionsDir });
 
   assert.equal(recovered.text, "VERDICT: the lease is never released on cancellation");
   assert.equal(path.basename(recovered.file).endsWith(`-${THREAD_ID}.jsonl`), true);
 });
 
-test("readLastAssistantMessage survives the half-written final line a killed turn leaves", () => {
+// `--resume-last` reuses a thread, so a newer job appends its turn to the same
+// transcript. Recovering the older job must not hand back the newer job's answer.
+test("readLastAssistantMessage ignores turns belonging to another job on the same thread", () => {
   const sessionsDir = makeTempDir();
-  const file = writeRollout(sessionsDir, THREAD_ID, [assistantRecord("the recoverable answer")]);
-  fs.appendFileSync(file, '{"type":"response_item","payload":{"type":"mess', "utf8");
+  writeRollout(sessionsDir, THREAD_ID, [
+    { type: "session_meta", payload: { id: THREAD_ID } },
+    turnStart(TURN_ID),
+    assistantRecord("the answer this job produced"),
+    turnEnd(TURN_ID),
+    turnStart(LATER_TURN_ID),
+    assistantRecord("a later job's answer"),
+    turnEnd(LATER_TURN_ID)
+  ]);
 
-  assert.equal(readLastAssistantMessage(THREAD_ID, { sessionsDir }).text, "the recoverable answer");
+  assert.equal(
+    readLastAssistantMessage(THREAD_ID, { turnId: TURN_ID, sessionsDir }).text,
+    "the answer this job produced"
+  );
+  assert.equal(
+    readLastAssistantMessage(THREAD_ID, { turnId: LATER_TURN_ID, sessionsDir }).text,
+    "a later job's answer"
+  );
 });
 
-test("readLastAssistantMessage returns null when no transcript matches the thread id", () => {
+test("readLastAssistantMessage survives the half-written final line a killed turn leaves", () => {
   const sessionsDir = makeTempDir();
-  writeRollout(sessionsDir, "some-other-thread", [assistantRecord("not this one")]);
+  const file = writeRollout(sessionsDir, THREAD_ID, [
+    turnStart(TURN_ID),
+    assistantRecord("the recoverable answer")
+  ]);
+  fs.appendFileSync(file, '{"type":"response_item","payload":{"type":"mess', "utf8");
 
-  assert.equal(readLastAssistantMessage(THREAD_ID, { sessionsDir }), null);
-  assert.equal(readLastAssistantMessage("", { sessionsDir }), null);
-  assert.equal(readLastAssistantMessage(null, { sessionsDir }), null);
+  assert.equal(
+    readLastAssistantMessage(THREAD_ID, { turnId: TURN_ID, sessionsDir }).text,
+    "the recoverable answer"
+  );
+});
+
+test("readLastAssistantMessage returns null without a matching thread id or turn id", () => {
+  const sessionsDir = makeTempDir();
+  writeRollout(sessionsDir, "some-other-thread", [turnStart(TURN_ID), assistantRecord("not this one")]);
+
+  assert.equal(readLastAssistantMessage(THREAD_ID, { turnId: TURN_ID, sessionsDir }), null);
+  assert.equal(readLastAssistantMessage("", { turnId: TURN_ID, sessionsDir }), null);
+  assert.equal(readLastAssistantMessage(null, { turnId: TURN_ID, sessionsDir }), null);
+  // No turn id: the job's turn cannot be identified, so nothing is safe to return.
+  assert.equal(readLastAssistantMessage("some-other-thread", { sessionsDir }), null);
+  assert.equal(readLastAssistantMessage("some-other-thread", { turnId: null, sessionsDir }), null);
 });
 
 test("readLastAssistantMessage returns null when the transcript holds no assistant text", () => {
   const sessionsDir = makeTempDir();
   writeRollout(sessionsDir, THREAD_ID, [
     { type: "session_meta", payload: { id: THREAD_ID } },
+    turnStart(TURN_ID),
     { type: "response_item", payload: { type: "message", role: "user", content: [{ text: "go" }] } },
     assistantRecord("   ")
   ]);
 
-  assert.equal(readLastAssistantMessage(THREAD_ID, { sessionsDir }), null);
+  assert.equal(readLastAssistantMessage(THREAD_ID, { turnId: TURN_ID, sessionsDir }), null);
 });
 
 test("storedJobHasOutput distinguishes a stored result from an empty one", () => {

--- a/tests/rollout.test.mjs
+++ b/tests/rollout.test.mjs
@@ -24,8 +24,11 @@ function turnStart(turnId) {
   return { type: "event_msg", payload: { type: "task_started", turn_id: turnId } };
 }
 
-function turnEnd(turnId) {
-  return { type: "event_msg", payload: { type: "task_complete", turn_id: turnId } };
+function turnEnd(turnId, lastAgentMessage = "") {
+  return {
+    type: "event_msg",
+    payload: { type: "task_complete", turn_id: turnId, last_agent_message: lastAgentMessage }
+  };
 }
 
 // Mirrors a real transcript: nested <sessions>/<YYYY>/<MM>/<DD>/rollout-<ts>-<threadId>.jsonl
@@ -80,6 +83,55 @@ test("readLastAssistantMessage ignores turns belonging to another job on the sam
   );
 });
 
+// The transcript keeps codex's internal citation markup on the raw assistant record;
+// `task_complete.last_agent_message` is the same answer with that stripped, and its
+// presence is also the only proof the turn actually finished.
+test("readLastAssistantMessage prefers the finished turn's own final message", () => {
+  const sessionsDir = makeTempDir();
+  writeRollout(sessionsDir, THREAD_ID, [
+    turnStart(TURN_ID),
+    assistantRecord("the answer<oai-mem-citation>internal</citation_entries>"),
+    turnEnd(TURN_ID, "the answer")
+  ]);
+
+  const recovered = readLastAssistantMessage(THREAD_ID, { turnId: TURN_ID, sessionsDir });
+
+  assert.equal(recovered.text, "the answer");
+  assert.equal(recovered.complete, true);
+});
+
+test("readLastAssistantMessage falls back to the raw scan when the turn never completed", () => {
+  const sessionsDir = makeTempDir();
+  writeRollout(sessionsDir, THREAD_ID, [
+    turnStart(TURN_ID),
+    assistantRecord("still working on it"),
+    // no task_complete: the turn was interrupted
+    turnStart(LATER_TURN_ID),
+    assistantRecord("a later job's answer"),
+    turnEnd(LATER_TURN_ID, "a later job's answer")
+  ]);
+
+  const recovered = readLastAssistantMessage(THREAD_ID, { turnId: TURN_ID, sessionsDir });
+
+  assert.equal(recovered.text, "still working on it");
+  assert.equal(recovered.complete, false);
+});
+
+// A turn that errored records `task_complete` with an empty `last_agent_message`.
+test("readLastAssistantMessage ignores an empty final message on a failed turn", () => {
+  const sessionsDir = makeTempDir();
+  writeRollout(sessionsDir, THREAD_ID, [
+    turnStart(TURN_ID),
+    assistantRecord("as far as I got"),
+    turnEnd(TURN_ID, "")
+  ]);
+
+  const recovered = readLastAssistantMessage(THREAD_ID, { turnId: TURN_ID, sessionsDir });
+
+  assert.equal(recovered.text, "as far as I got");
+  assert.equal(recovered.complete, false);
+});
+
 test("readLastAssistantMessage survives the half-written final line a killed turn leaves", () => {
   const sessionsDir = makeTempDir();
   const file = writeRollout(sessionsDir, THREAD_ID, [
@@ -124,11 +176,18 @@ test("storedJobHasOutput distinguishes a stored result from an empty one", () =>
   assert.equal(storedJobHasOutput({ rendered: "# Report" }), true);
   assert.equal(storedJobHasOutput({ result: { rawOutput: "" } }), false);
   assert.equal(storedJobHasOutput(null), false);
+  // Whitespace would otherwise count as output and suppress the transcript recovery.
+  assert.equal(storedJobHasOutput({ result: { rawOutput: "\n" } }), false);
+  assert.equal(storedJobHasOutput({ rendered: "  \n " }), false);
 });
 
 test("renderStoredJobResult surfaces a recovered message instead of the empty-payload notice", () => {
   const job = { id: "job-1", status: "failed", threadId: THREAD_ID };
-  const recovered = { text: "VERDICT: the lease is never released", file: "C:/rollout.jsonl" };
+  const recovered = {
+    text: "VERDICT: the lease is never released",
+    complete: false,
+    file: "C:/rollout.jsonl"
+  };
 
   const rendered = renderStoredJobResult(job, null, recovered);
 
@@ -136,6 +195,18 @@ test("renderStoredJobResult surfaces a recovered message instead of the empty-pa
   assert.match(rendered, /VERDICT: the lease is never released/);
   assert.match(rendered, /C:\/rollout\.jsonl/);
   assert.doesNotMatch(rendered, /No captured result payload was stored/);
+});
+
+test("renderStoredJobResult drops the PARTIAL label when the turn did finish", () => {
+  const job = { id: "job-1", status: "failed", threadId: THREAD_ID };
+  const recovered = { text: "the final answer", complete: true, file: "C:/rollout.jsonl" };
+
+  const rendered = renderStoredJobResult(job, null, recovered);
+
+  assert.match(rendered, /Recovered from the Codex transcript$/m);
+  assert.match(rendered, /the turn did finish/);
+  assert.doesNotMatch(rendered, /PARTIAL/);
+  assert.doesNotMatch(rendered, /may not have finished/);
 });
 
 test("renderStoredJobResult keeps the empty-payload notice when nothing was recovered", () => {

--- a/tests/rollout.test.mjs
+++ b/tests/rollout.test.mjs
@@ -1,0 +1,99 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { makeTempDir } from "./helpers.mjs";
+import { readLastAssistantMessage } from "../plugins/codex/scripts/lib/rollout.mjs";
+import { renderStoredJobResult, storedJobHasOutput } from "../plugins/codex/scripts/lib/render.mjs";
+
+const THREAD_ID = "019fbad1-b569-7d93-97be-1efbff2b73b2";
+
+function assistantRecord(text) {
+  return {
+    type: "response_item",
+    payload: { type: "message", role: "assistant", content: [{ type: "output_text", text }] }
+  };
+}
+
+// Mirrors a real transcript: nested <sessions>/<YYYY>/<MM>/<DD>/rollout-<ts>-<threadId>.jsonl
+// with reasoning and tool records interleaved between the assistant turns.
+function writeRollout(sessionsDir, threadId, records) {
+  const dir = path.join(sessionsDir, "2026", "08", "01");
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `rollout-2026-08-01T09-55-38-${threadId}.jsonl`);
+  fs.writeFileSync(file, records.map((record) => JSON.stringify(record)).join("\n") + "\n", "utf8");
+  return file;
+}
+
+test("readLastAssistantMessage returns the last assistant message, not the first", () => {
+  const sessionsDir = makeTempDir();
+  writeRollout(sessionsDir, THREAD_ID, [
+    { type: "session_meta", payload: { id: THREAD_ID } },
+    assistantRecord("first pass, still investigating"),
+    { type: "response_item", payload: { type: "reasoning", content: [{ text: "thinking" }] } },
+    { type: "response_item", payload: { type: "custom_tool_call", payload: {} } },
+    assistantRecord("VERDICT: the lease is never released on cancellation"),
+    { type: "event_msg", payload: { type: "token_count" } }
+  ]);
+
+  const recovered = readLastAssistantMessage(THREAD_ID, { sessionsDir });
+
+  assert.equal(recovered.text, "VERDICT: the lease is never released on cancellation");
+  assert.equal(path.basename(recovered.file).endsWith(`-${THREAD_ID}.jsonl`), true);
+});
+
+test("readLastAssistantMessage survives the half-written final line a killed turn leaves", () => {
+  const sessionsDir = makeTempDir();
+  const file = writeRollout(sessionsDir, THREAD_ID, [assistantRecord("the recoverable answer")]);
+  fs.appendFileSync(file, '{"type":"response_item","payload":{"type":"mess', "utf8");
+
+  assert.equal(readLastAssistantMessage(THREAD_ID, { sessionsDir }).text, "the recoverable answer");
+});
+
+test("readLastAssistantMessage returns null when no transcript matches the thread id", () => {
+  const sessionsDir = makeTempDir();
+  writeRollout(sessionsDir, "some-other-thread", [assistantRecord("not this one")]);
+
+  assert.equal(readLastAssistantMessage(THREAD_ID, { sessionsDir }), null);
+  assert.equal(readLastAssistantMessage("", { sessionsDir }), null);
+  assert.equal(readLastAssistantMessage(null, { sessionsDir }), null);
+});
+
+test("readLastAssistantMessage returns null when the transcript holds no assistant text", () => {
+  const sessionsDir = makeTempDir();
+  writeRollout(sessionsDir, THREAD_ID, [
+    { type: "session_meta", payload: { id: THREAD_ID } },
+    { type: "response_item", payload: { type: "message", role: "user", content: [{ text: "go" }] } },
+    assistantRecord("   ")
+  ]);
+
+  assert.equal(readLastAssistantMessage(THREAD_ID, { sessionsDir }), null);
+});
+
+test("storedJobHasOutput distinguishes a stored result from an empty one", () => {
+  assert.equal(storedJobHasOutput({ result: { rawOutput: "done" } }), true);
+  assert.equal(storedJobHasOutput({ result: { codex: { stdout: "done" } } }), true);
+  assert.equal(storedJobHasOutput({ rendered: "# Report" }), true);
+  assert.equal(storedJobHasOutput({ result: { rawOutput: "" } }), false);
+  assert.equal(storedJobHasOutput(null), false);
+});
+
+test("renderStoredJobResult surfaces a recovered message instead of the empty-payload notice", () => {
+  const job = { id: "job-1", status: "failed", threadId: THREAD_ID };
+  const recovered = { text: "VERDICT: the lease is never released", file: "C:/rollout.jsonl" };
+
+  const rendered = renderStoredJobResult(job, null, recovered);
+
+  assert.match(rendered, /Recovered from the Codex transcript \(PARTIAL\)/);
+  assert.match(rendered, /VERDICT: the lease is never released/);
+  assert.match(rendered, /C:\/rollout\.jsonl/);
+  assert.doesNotMatch(rendered, /No captured result payload was stored/);
+});
+
+test("renderStoredJobResult keeps the empty-payload notice when nothing was recovered", () => {
+  const rendered = renderStoredJobResult({ id: "job-1", status: "failed" }, null, null);
+
+  assert.match(rendered, /No captured result payload was stored/);
+  assert.doesNotMatch(rendered, /PARTIAL/);
+});

--- a/tests/rollout.test.mjs
+++ b/tests/rollout.test.mjs
@@ -211,6 +211,23 @@ test("renderStoredJobResult drops the PARTIAL label when the turn did finish", (
   assert.doesNotMatch(rendered, /may not have finished/);
 });
 
+// Each early return in renderStoredJobResult is a separate chance to discard the
+// recovered message, and storedJobHasOutput has already decided these count as empty.
+test("renderStoredJobResult never lets a blank stored payload discard the recovery", () => {
+  const job = { id: "job-1", status: "failed", threadId: THREAD_ID };
+  const recovered = { text: "the recovered answer", complete: true, file: "C:/rollout.jsonl" };
+
+  for (const storedJob of [
+    { result: { rawOutput: "\n" } },
+    { result: { codex: { stdout: "   " } } },
+    { rendered: "  \n " },
+    { result: { parseError: null }, rendered: "\t" } // the structured-review branch
+  ]) {
+    const rendered = renderStoredJobResult(job, storedJob, recovered);
+    assert.match(rendered, /the recovered answer/, `discarded for ${JSON.stringify(storedJob)}`);
+  }
+});
+
 test("renderStoredJobResult keeps the empty-payload notice when nothing was recovered", () => {
   const rendered = renderStoredJobResult({ id: "job-1", status: "failed" }, null, null);
 


### PR DESCRIPTION
## Problem

When a job ends without writing a result back to its record, `/codex:result` has nothing to show:

```
# Codex Result

Job: task-xxxx
Status: failed
Codex session ID: 019fbad1-b569-7d30-8bb1-e9ee525dde8d

No captured result payload was stored for this job.
```

This happens whenever the turn and the record get out of sync — the companion returns before the turn completes, the app-server turn is interrupted, the launcher dies. `status` and `result` are both dead ends at that point, so the leg reads as a total loss.

**It usually isn't.** Codex has already written every assistant message to its own transcript at `$CODEX_HOME/sessions/<YYYY>/<MM>/<DD>/rollout-<timestamp>-<threadId>.jsonl`, and the job record already carries `threadId`. Nothing new needs to be captured — the data is on disk and simply never read.

Recovering it has repeatedly turned a "lost" leg into a usable answer for me, including one genuine high-severity finding that would otherwise have been thrown away.

## Change

When `readStoredJob` yields no output and the job has a `threadId`, look up the transcript and render its last assistant message under an explicit heading:

```
## Recovered from the Codex transcript (PARTIAL)

No result was stored for this job, so this is the last assistant message
codex recorded. The turn may not have finished. Source: <path>

<message>
```

- **Read-only.** It never writes to the job record, and a job that *did* store output takes the existing path untouched — `storedJobHasOutput` gates it.
- **Labelled PARTIAL on purpose.** The turn may have been mid-thought; this is a lead, not a verdict.
- Also exposed on `--json` as `payload.recovered`.
- `resolveCodexHome()` was already implemented in `lib/codex.mjs`; this only exports it.

New file `lib/rollout.mjs` does the filesystem work so `render.mjs` stays pure.

## Verification

**Against real data, not just fixtures.** Run over the 832 real transcripts on this machine, sampling four threads:

| thread | recovered | lookup |
|---|---|---|
| `019fba9c-063a-70a1…` | 1506 chars | 4 ms |
| `019fbab1-07d6-7d83…` | 994 chars | 3 ms |
| `019fbace-b8a5-79c2…` | 547 chars | 1 ms |
| `019fbad1-b569-7d93…` | 1790 chars | 6 ms |

Every one returned that thread's real final message. The directory walk is flat and uncached, and still costs single-digit milliseconds at 832 files.

Four mutations, each caught by its own test:

| mutation | test that fails |
|---|---|
| take the first assistant message instead of the last | `returns the last assistant message, not the first` |
| let a malformed line throw instead of skipping | `survives the half-written final line a killed turn leaves` |
| drop the `role === "assistant"` filter | `returns null when the transcript holds no assistant text` |
| render ignores the recovered message | `surfaces a recovered message instead of the empty-payload notice` |

The malformed-line case is not hypothetical: a killed turn leaves a truncated final line, which is exactly the situation this feature exists for.

Suite: **98 tests / 86 pass / 12 fail**, against a **91 / 79 / 12** baseline on the same host. No new failures. (Those 12 are pre-existing Windows-only failures — Unix-socket, temp-dir and real-CLI assertions. CI is ubuntu-only and does not see them.)

## Notes

- Format confirmed empirically: assistant turns are `record.type === "response_item"` with `payload.type === "message"`, `payload.role === "assistant"`, and `payload.content` a list of `{ type: "output_text", text }`. String `content` is handled too.
- The thread id in the filename matches `session_meta.id`, so the `rollout-*-<threadId>.jsonl` match is exact rather than heuristic.
- Environment: Windows 11, node v24.14.0.


---

## Update — turn scoping, and using the turn's own final message

Three commits since the original review, all in this path. The first fixes the P2 the automated review raised on this PR.

**`b1b1697` — scope the recovery to the job's own turn.** `--resume-last` reuses a thread, so one transcript can hold turns from several jobs; 47 of 836 transcripts on my host do. Recovering by thread alone returned the file's *last* assistant message, which for an older job is a newer job's answer — worse than returning nothing. The job record already carries `turnId`, and it holds the same value as the transcript's `payload.turn_id`.

The assistant records themselves carry no turn id — only `task_started`, `turn_context` and `task_complete` do — so the scan tracks the turn those markers open and keeps only the messages inside the wanted one. A job with no recorded `turnId` now recovers nothing rather than guessing.

**`fe3514f` — prefer `task_complete.last_agent_message`, and stop mislabelling finished turns.**

- `task_complete` was setting `openTurnId` instead of clearing it, so records between one turn's end and the next turn's start were attributed to the finished turn.
- The raw assistant records keep codex's internal citation markup — present on 91 of 843 assistant messages I sampled. `task_complete.last_agent_message` is the same answer without it, and it is recorded for every completed turn (169/169 sampled). Prefer it; fall back to the scan when the turn never completed, or when that message is empty, which is what an errored turn records.
- Its presence also proves the turn finished, so a recovered answer no longer claims "the turn may not have finished" when it demonstrably did. Only the cut-short case keeps the **PARTIAL** label.
- `storedJobHasOutput` counted a whitespace-only stored result as output, so a job that stored `"\n"` suppressed the recovery that had the real answer.

**`7597426`** — `renderStoredJobResult`'s structured-review branch returned early on any truthy `rendered`, so a whitespace-only one printed just that whitespace and dropped the recovered text. Both now gate on the same `hasText`.

**Verification.** 12 tests in `tests/rollout.test.mjs`; each was checked by breaking the line it protects and confirming that test — and only that test — fails. Also exercised against two real (threadId, turnId) pairs from actual job records on disk: both return the right text with no citation markup, and a deliberately wrong `turnId` returns null.
