### PR TITLE
test: reap the brokers and temp dirs a suite run leaves behind

### DIFF
--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -21,10 +21,11 @@ function reapTempDirs() {
       if (session) {
         teardownBrokerSession({ ...session, killProcess: terminateProcessTree });
       }
+      fs.rmSync(dir, { recursive: true, force: true });
     } catch {
-      // Best effort: a missing or malformed broker session must not fail the run.
+      // Best effort at exit: a malformed broker session, or a dir Windows still holds a
+      // handle on right after the kill, must not fail an otherwise-passing test file.
     }
-    fs.rmSync(dir, { recursive: true, force: true });
   }
 }
 

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -4,8 +4,38 @@ import path from "node:path";
 import process from "node:process";
 import { spawnSync } from "node:child_process";
 
+import { loadBrokerSession, teardownBrokerSession } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+
+// `ensureBrokerSession` keys the app-server broker by cwd and spawns it detached, and
+// every test here gets a fresh cwd -- so a suite run strands one broker tree per test
+// that reached the app server. A broker exits only on a shutdown RPC or a signal, and
+// the SessionEnd hook that would normally reap it never fires under `npm test`, so
+// nothing else ever will. Reap them, and the mkdtemp dirs, when the test process exits.
+const tempDirs = [];
+
+function reapTempDirs() {
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      const session = loadBrokerSession(dir);
+      if (session) {
+        teardownBrokerSession({ ...session, killProcess: terminateProcessTree });
+      }
+    } catch {
+      // Best effort: a missing or malformed broker session must not fail the run.
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// `exit` only: an interrupted run still leaks, but a signal handler here would also
+// have to re-raise, and every normal run goes through `exit`.
+process.once("exit", reapTempDirs);
+
 export function makeTempDir(prefix = "codex-plugin-test-") {
-  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
 }
 
 export function writeExecutable(filePath, source) {


### PR DESCRIPTION
`makeTempDir` gives every test a fresh cwd, and `ensureBrokerSession` keys the app-server broker by cwd and spawns it `detached` + `unref`. So every test that reaches the app server spawns a brand-new broker, the reuse branch can never hit, and nothing shuts any of them down: a broker exits only on a `broker/shutdown` RPC or a signal, and the `SessionEnd` hook that would normally reap it never fires under `npm test`.

Measured on one Windows host after repeated suite runs:

| | |
|---|---|
| processes | **2257** against a ~330 baseline |
| of which `node.exe` with the test temp-dir prefix | 772 |
| orphaned `codex-plugin-test-*` temp dirs | 1443 (14 MB) |
| stale `cxc-*` broker session dirs | 388, against 389 live brokers |

Each leaked test broker holds a 4-process unit (`broker → bash -c "codex app-server" → env node <fixture> → conhost`).

**The change:** `makeTempDir` records the dirs it creates, and a `process.on("exit")` handler shuts down any broker registered against them and removes the dir.

**Verification** — same file, same suite, on Windows:

| | leaked `node.exe` | temp dirs | `cxc-*` dirs |
|---|---|---|---|
| before | 58 | +104 | 30 |
| after | 0 | 0 | 0 |

Zero growth held over three consecutive full-suite runs.

**Known limits**, both deliberate:
- `exit` only, so an interrupted (Ctrl-C) run still leaks. A signal handler here would also have to re-raise, and every normal run goes through `exit`.
- On Windows, `terminateProcessTree` reaches `taskkill` through `$SHELL`; under Git Bash the `/PID` flag is rewritten into a path and the kill silently fails. #577 fixes that. This PR is still correct without it — the temp dirs go either way, and the kill works on Linux/macOS and from cmd — but on a Git Bash host it needs #577 to actually reap.
