### PR TITLE
fix: give the app-server broker an idle timeout, and kill the one it replaces

### DIFF
--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -8,7 +8,7 @@ import process from "node:process";
 import { parseArgs } from "./lib/args.mjs";
 import { BROKER_BUSY_RPC_CODE, CodexAppServerClient } from "./lib/app-server.mjs";
 import { parseBrokerEndpoint } from "./lib/broker-endpoint.mjs";
-import { BROKER_IDLE_MS_ENV } from "./lib/broker-lifecycle.mjs";
+import { BROKER_IDLE_MS_ENV, clearBrokerSession, loadBrokerSession } from "./lib/broker-lifecycle.mjs";
 
 const STREAMING_METHODS = new Set(["turn/start", "review/start", "thread/compact/start"]);
 
@@ -140,6 +140,20 @@ async function main() {
       return;
     }
     idleTimer = setTimeout(() => {
+      // Drop our own `broker.json` first. `ensureBrokerSession` would probe and repair
+      // it, but the `reuseExistingBroker` callers -- auth status and turn interrupt --
+      // read the stored endpoint without probing, so a record left pointing at this
+      // dead socket turns into an app-server failure for them instead of the direct
+      // spawn they fall back to when there is no record at all.
+      // Match on the endpoint, not the pid: a replacement broker may already own this
+      // cwd, and pids get recycled.
+      try {
+        if (loadBrokerSession(cwd)?.endpoint === endpoint) {
+          clearBrokerSession(cwd);
+        }
+      } catch {
+        // A racing writer must not turn the idle exit into a crash.
+      }
       shutdown(server).finally(() => process.exit(0));
     }, IDLE_TIMEOUT_MS);
     idleTimer.unref(); // never hold the process open just to wait for its own exit

--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -8,6 +8,7 @@ import process from "node:process";
 import { parseArgs } from "./lib/args.mjs";
 import { BROKER_BUSY_RPC_CODE, CodexAppServerClient } from "./lib/app-server.mjs";
 import { parseBrokerEndpoint } from "./lib/broker-endpoint.mjs";
+import { BROKER_IDLE_MS_ENV } from "./lib/broker-lifecycle.mjs";
 
 const STREAMING_METHODS = new Set(["turn/start", "review/start", "thread/compact/start"]);
 
@@ -115,8 +116,38 @@ async function main() {
 
   appClient.setNotificationHandler(routeNotification);
 
+  // Until now a broker exited only on `broker/shutdown` or a signal, so anything that
+  // lost track of one -- a hard-killed parent, a replaced-but-not-killed stale session,
+  // a test run with no teardown -- stranded it and the ~9-process codex stack under it,
+  // forever. An idle broker holds no state worth keeping: a turn keeps its socket open
+  // for its whole duration, so zero sockets means nothing is in flight, and the thread
+  // itself lives in $CODEX_HOME/sessions and is resumable. The next caller respawns one.
+  // The env override exists so a test can watch a real broker exit on its own; 30
+  // minutes is the shipped value.
+  const IDLE_TIMEOUT_MS = Number(process.env[BROKER_IDLE_MS_ENV]) || 30 * 60 * 1000;
+  let idleTimer = null;
+
+  function cancelIdleTimer() {
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
+    }
+  }
+
+  function restartIdleTimer(server) {
+    cancelIdleTimer();
+    if (sockets.size > 0) {
+      return;
+    }
+    idleTimer = setTimeout(() => {
+      shutdown(server).finally(() => process.exit(0));
+    }, IDLE_TIMEOUT_MS);
+    idleTimer.unref(); // never hold the process open just to wait for its own exit
+  }
+
   const server = net.createServer((socket) => {
     sockets.add(socket);
+    cancelIdleTimer();
     socket.setEncoding("utf8");
     let buffer = "";
 
@@ -225,11 +256,13 @@ async function main() {
     socket.on("close", () => {
       sockets.delete(socket);
       clearSocketOwnership(socket);
+      restartIdleTimer(server);
     });
 
     socket.on("error", () => {
       sockets.delete(socket);
       clearSocketOwnership(socket);
+      restartIdleTimer(server);
     });
   });
 
@@ -243,7 +276,8 @@ async function main() {
     process.exit(0);
   });
 
-  server.listen(listenTarget.path);
+  // Start it now too: a broker nobody ever connects to is exactly the stranded case.
+  server.listen(listenTarget.path, () => restartIdleTimer(server));
 }
 
 main().catch((error) => {

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -983,7 +983,17 @@ async function handleCancel(argv) {
     );
   }
 
-  terminateProcessTree(job.pid ?? Number.NaN);
+  const termination = terminateProcessTree(job.pid ?? Number.NaN);
+  if (termination.attempted && !termination.treeConfirmed) {
+    // The job's own process is gone, but the kill could not account for what was under
+    // it. Say so rather than reporting a clean cancellation: a surviving codex or broker
+    // child keeps running, and nothing else makes a second pass at it.
+    appendLogLine(
+      job.logFile,
+      `Cancelled, but the process tree under pid ${job.pid} could not be fully confirmed stopped. ` +
+        "Check for leftover codex processes if the workspace behaves oddly."
+    );
+  }
   appendLogLine(job.logFile, "Cancelled by user.");
 
   const completedAt = nowIso();

--- a/plugins/codex/scripts/lib/broker-lifecycle.mjs
+++ b/plugins/codex/scripts/lib/broker-lifecycle.mjs
@@ -237,14 +237,18 @@ export async function ensureBrokerSession(cwd, options = {}) {
 
   const ready = await waitForBrokerEndpoint(endpoint, options.timeoutMs ?? 2000);
   if (!ready) {
+    // We spawned this one, but the endpoint wait runs out its full timeout even when the
+    // child died immediately -- `codex app-server` failing at startup does exactly that --
+    // and node reaps the child, so by now the pid can belong to somebody else. A child
+    // node still holds open is the one case where the pid is unambiguously ours.
+    const childStillRunning = child.exitCode === null && child.signalCode === null;
     teardownBrokerSession({
       endpoint,
       pidFile,
       logFile,
       sessionDir,
       pid: child.pid ?? null,
-      // We spawned this one and it never came up, so it is unambiguously ours to kill.
-      killProcess: terminateBrokerProcess
+      killProcess: childStillRunning ? terminateBrokerProcess : null
     });
     return null;
   }

--- a/plugins/codex/scripts/lib/broker-lifecycle.mjs
+++ b/plugins/codex/scripts/lib/broker-lifecycle.mjs
@@ -6,7 +6,7 @@ import process from "node:process";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { createBrokerEndpoint, parseBrokerEndpoint } from "./broker-endpoint.mjs";
-import { terminateProcessTree } from "./process.mjs";
+import { runCommand, terminateProcessTree } from "./process.mjs";
 import { resolveStateDir } from "./state.mjs";
 
 export const PID_FILE_ENV = "CODEX_COMPANION_APP_SERVER_PID_FILE";
@@ -15,6 +15,7 @@ export const LOG_FILE_ENV = "CODEX_COMPANION_APP_SERVER_LOG_FILE";
 // app-server-broker.mjs. It lives here because importing that script runs it.
 export const BROKER_IDLE_MS_ENV = "CODEX_COMPANION_BROKER_IDLE_MS";
 const BROKER_STATE_FILE = "broker.json";
+const PROCESS_START_TIME_TIMEOUT_MS = 2000;
 
 export function createBrokerSessionDir(prefix = "cxc-") {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -77,6 +78,71 @@ function resolveBrokerStateFile(cwd) {
   return path.join(resolveStateDir(cwd), BROKER_STATE_FILE);
 }
 
+export function readProcessStartTime(pid, options = {}) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return null;
+  }
+
+  const platform = options.platform ?? process.platform;
+  try {
+    if (platform === "linux") {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+      const fieldsAfterCommand = stat.slice(stat.lastIndexOf(")") + 2).trim().split(/\s+/);
+      return fieldsAfterCommand[19] ?? null;
+    }
+
+    const runCommandImpl = options.runCommandImpl ?? runCommand;
+    const commandOptions = {
+      env: options.env,
+      shell: false,
+      timeout: PROCESS_START_TIME_TIMEOUT_MS
+    };
+    const result =
+      platform === "win32"
+        ? runCommandImpl(
+            "powershell.exe",
+            [
+              "-NoProfile",
+              "-NonInteractive",
+              "-Command",
+              `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`
+            ],
+            commandOptions
+          )
+        : runCommandImpl(
+            // macOS has no finer-grained portable ps start-time field. `lstart` is
+            // second-resolution, so PID reuse within the same second remains possible.
+            "ps",
+            ["-p", String(pid), "-o", "lstart="],
+            commandOptions
+          );
+    if (result.error || result.status !== 0) {
+      return null;
+    }
+    return result.stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+export function brokerProcessMatchesRecordedStart(existing, options = {}) {
+  if (typeof existing.processStartTime !== "string") {
+    return false;
+  }
+  const readProcessStartTimeImpl = options.readProcessStartTime ?? readProcessStartTime;
+  try {
+    return (
+      readProcessStartTimeImpl(existing.pid, {
+        env: options.env,
+        platform: options.platform,
+        runCommandImpl: options.runCommandImpl
+      }) === existing.processStartTime
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function loadBrokerSession(cwd) {
   const stateFile = resolveBrokerStateFile(cwd);
   if (!fs.existsSync(stateFile)) {
@@ -123,23 +189,25 @@ async function isBrokerEndpointReady(endpoint) {
 }
 
 export async function ensureBrokerSession(cwd, options = {}) {
+  const terminateBrokerProcess =
+    options.killProcess ?? options.terminateProcessTreeImpl ?? terminateProcessTree;
   const existing = loadBrokerSession(cwd);
   if (existing && (await isBrokerEndpointReady(existing.endpoint))) {
     return existing;
   }
 
   if (existing) {
+    const brokerPidVerified = brokerProcessMatchesRecordedStart(existing, options);
     teardownBrokerSession({
       endpoint: existing.endpoint ?? null,
       pidFile: existing.pidFile ?? null,
       logFile: existing.logFile ?? null,
       sessionDir: existing.sessionDir ?? null,
       pid: existing.pid ?? null,
-      // Default to actually killing it. This teardown deletes the pid, log and state
-      // files either way, so a broker left running here becomes invisible to every
-      // later reaper -- including the SessionEnd hook, which finds brokers through
-      // the state file this call just cleared.
-      killProcess: options.killProcess ?? terminateProcessTree
+      // A pid is safe to target only while its immutable process start time still
+      // matches the value recorded when this broker was spawned. Missing, unreadable
+      // or mismatched identity skips the kill, but teardown still clears stale files.
+      killProcess: brokerPidVerified ? terminateBrokerProcess : null
     });
     clearBrokerSession(cwd);
   }
@@ -161,6 +229,11 @@ export async function ensureBrokerSession(cwd, options = {}) {
     logFile,
     env: options.env ?? process.env
   });
+  const readProcessStartTimeImpl = options.readProcessStartTime ?? readProcessStartTime;
+  const processStartTime = readProcessStartTimeImpl(child.pid, {
+    env: options.env,
+    runCommandImpl: options.runCommandImpl
+  });
 
   const ready = await waitForBrokerEndpoint(endpoint, options.timeoutMs ?? 2000);
   if (!ready) {
@@ -171,7 +244,7 @@ export async function ensureBrokerSession(cwd, options = {}) {
       sessionDir,
       pid: child.pid ?? null,
       // We spawned this one and it never came up, so it is unambiguously ours to kill.
-      killProcess: options.killProcess ?? terminateProcessTree
+      killProcess: terminateBrokerProcess
     });
     return null;
   }
@@ -181,7 +254,8 @@ export async function ensureBrokerSession(cwd, options = {}) {
     pidFile,
     logFile,
     sessionDir,
-    pid: child.pid ?? null
+    pid: child.pid ?? null,
+    processStartTime
   };
   saveBrokerSession(cwd, session);
   return session;

--- a/plugins/codex/scripts/lib/broker-lifecycle.mjs
+++ b/plugins/codex/scripts/lib/broker-lifecycle.mjs
@@ -6,10 +6,14 @@ import process from "node:process";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { createBrokerEndpoint, parseBrokerEndpoint } from "./broker-endpoint.mjs";
+import { terminateProcessTree } from "./process.mjs";
 import { resolveStateDir } from "./state.mjs";
 
 export const PID_FILE_ENV = "CODEX_COMPANION_APP_SERVER_PID_FILE";
 export const LOG_FILE_ENV = "CODEX_COMPANION_APP_SERVER_LOG_FILE";
+// Test-facing override for the broker's idle timeout; the shipped value is in
+// app-server-broker.mjs. It lives here because importing that script runs it.
+export const BROKER_IDLE_MS_ENV = "CODEX_COMPANION_BROKER_IDLE_MS";
 const BROKER_STATE_FILE = "broker.json";
 
 export function createBrokerSessionDir(prefix = "cxc-") {
@@ -99,15 +103,23 @@ export function clearBrokerSession(cwd) {
   }
 }
 
+// A healthy broker answers the first probe immediately, so the second, longer one
+// only costs time when the broker is already in trouble. Without it a merely busy
+// broker on a loaded host misses 150 ms, gets replaced, and its process is stranded.
 async function isBrokerEndpointReady(endpoint) {
   if (!endpoint) {
     return false;
   }
-  try {
-    return await waitForBrokerEndpoint(endpoint, 150);
-  } catch {
-    return false;
+  for (const timeoutMs of [150, 1000]) {
+    try {
+      if (await waitForBrokerEndpoint(endpoint, timeoutMs)) {
+        return true;
+      }
+    } catch {
+      return false;
+    }
   }
+  return false;
 }
 
 export async function ensureBrokerSession(cwd, options = {}) {
@@ -123,7 +135,11 @@ export async function ensureBrokerSession(cwd, options = {}) {
       logFile: existing.logFile ?? null,
       sessionDir: existing.sessionDir ?? null,
       pid: existing.pid ?? null,
-      killProcess: options.killProcess ?? null
+      // Default to actually killing it. This teardown deletes the pid, log and state
+      // files either way, so a broker left running here becomes invisible to every
+      // later reaper -- including the SessionEnd hook, which finds brokers through
+      // the state file this call just cleared.
+      killProcess: options.killProcess ?? terminateProcessTree
     });
     clearBrokerSession(cwd);
   }
@@ -154,7 +170,8 @@ export async function ensureBrokerSession(cwd, options = {}) {
       logFile,
       sessionDir,
       pid: child.pid ?? null,
-      killProcess: options.killProcess ?? null
+      // We spawned this one and it never came up, so it is unambiguously ours to kill.
+      killProcess: options.killProcess ?? terminateProcessTree
     });
     return null;
   }

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -82,6 +82,24 @@ function processIsGone(pid, killImpl) {
   }
 }
 
+// A process that is already on its way out -- taskkill losing the race with a turn that
+// was just interrupted reports "Access is denied", exit 1 -- is still briefly alive, so a
+// single instantaneous probe calls it a failure. Give it a bounded moment to finish.
+// This whole function is synchronous, hence the Atomics sleep rather than a timer.
+function waitForProcessGone(pid, killImpl, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  const idle = new Int32Array(new SharedArrayBuffer(4));
+  for (;;) {
+    if (processIsGone(pid, killImpl)) {
+      return true;
+    }
+    if (Date.now() >= deadline) {
+      return false;
+    }
+    Atomics.wait(idle, 0, 0, Math.min(50, Math.max(1, deadline - Date.now())));
+  }
+}
+
 export function terminateProcessTree(pid, options = {}) {
   if (!Number.isFinite(pid)) {
     return { attempted: false, delivered: false, method: null };
@@ -109,13 +127,14 @@ export function terminateProcessTree(pid, options = {}) {
       return { attempted: true, delivered: false, method: "taskkill", result };
     }
 
-    // `/T` makes taskkill walk the tree, and it exits non-zero when it killed the target
-    // but could not reap one descendant -- "The operation attempted is not supported",
-    // exit 255, which is what a console host or an already-exiting child produces. The
-    // exit code does not separate that from a genuine failure, and the message is
-    // localized, so ask the OS whether the target itself is gone rather than parsing
-    // either. The target being dead is what every caller of this actually asked for.
-    if (!result.error && processIsGone(pid, killImpl)) {
+    // taskkill exits non-zero in two cases where the target still ends up dead: it killed
+    // the target but could not reap a descendant ("The operation attempted is not
+    // supported", exit 255), and it raced a process that was already terminating
+    // ("Access is denied", exit 1 -- what `cancel` hits after interrupting the turn).
+    // The exit code separates neither from a genuine failure, and both messages are
+    // localized, so ask the OS whether the target is gone instead of parsing either.
+    // That is what every caller of this actually asked for.
+    if (!result.error && waitForProcessGone(pid, killImpl, options.killWaitMs ?? 1000)) {
       return { attempted: true, delivered: true, method: "taskkill", result };
     }
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -125,7 +125,12 @@ export function terminateProcessTree(pid, options = {}) {
       !result.error &&
       (result.status === TASKKILL_PROCESS_NOT_FOUND || looksLikeMissingProcessMessage(combinedOutput))
     ) {
-      return { attempted: true, delivered: false, treeConfirmed: true, method: "taskkill", result };
+      // "No such process" is about the root at this instant, not about what it spawned
+      // while it was alive. A worker that died mid-turn leaves its `codex app-server`
+      // child orphaned, and with the root gone `/T` has nothing left to walk from. That
+      // is not a corner case here: `cancel` only reaches this branch for a job the state
+      // still calls running, which is exactly the crashed-worker case.
+      return { attempted: true, delivered: false, treeConfirmed: false, method: "taskkill", result };
     }
 
     // taskkill exits non-zero both after failing to reap a descendant ("The operation
@@ -137,8 +142,8 @@ export function terminateProcessTree(pid, options = {}) {
     // But a non-zero taskkill never establishes that the REST of the tree went with it,
     // and `/T` leaves no way to enumerate what survived once the root is gone. So the
     // two facts are reported separately -- `delivered` is about the target, and
-    // `treeConfirmed` is about everything under it. This is the one branch that cannot
-    // account for the whole tree.
+    // `treeConfirmed` is about everything under it. Like the missing-root branch above,
+    // this one cannot account for the whole tree.
     if (!result.error && waitForProcessGone(pid, killImpl, options.killWaitMs ?? 1000)) {
       return { attempted: true, delivered: true, treeConfirmed: false, method: "taskkill", result };
     }

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -8,6 +8,7 @@ export function runCommand(command, args = [], options = {}) {
     encoding: "utf8",
     input: options.input,
     maxBuffer: options.maxBuffer,
+    timeout: options.timeout,
     stdio: options.stdio ?? "pipe",
     shell: options.shell ?? (process.platform === "win32" ? (process.env.SHELL || true) : false),
     windowsHide: true
@@ -102,7 +103,7 @@ function waitForProcessGone(pid, killImpl, timeoutMs) {
 
 export function terminateProcessTree(pid, options = {}) {
   if (!Number.isFinite(pid)) {
-    return { attempted: false, delivered: false, method: null };
+    return { attempted: false, delivered: false, treeConfirmed: true, method: null };
   }
 
   const platform = options.platform ?? process.platform;
@@ -116,7 +117,7 @@ export function terminateProcessTree(pid, options = {}) {
     });
 
     if (!result.error && result.status === 0) {
-      return { attempted: true, delivered: true, method: "taskkill", result };
+      return { attempted: true, delivered: true, treeConfirmed: true, method: "taskkill", result };
     }
 
     const combinedOutput = `${result.stderr}\n${result.stdout}`.trim();
@@ -124,27 +125,31 @@ export function terminateProcessTree(pid, options = {}) {
       !result.error &&
       (result.status === TASKKILL_PROCESS_NOT_FOUND || looksLikeMissingProcessMessage(combinedOutput))
     ) {
-      return { attempted: true, delivered: false, method: "taskkill", result };
+      return { attempted: true, delivered: false, treeConfirmed: true, method: "taskkill", result };
     }
 
-    // taskkill exits non-zero in two cases where the target still ends up dead: it killed
-    // the target but could not reap a descendant ("The operation attempted is not
-    // supported", exit 255), and it raced a process that was already terminating
-    // ("Access is denied", exit 1 -- what `cancel` hits after interrupting the turn).
-    // The exit code separates neither from a genuine failure, and both messages are
-    // localized, so ask the OS whether the target is gone instead of parsing either.
-    // That is what every caller of this actually asked for.
+    // taskkill exits non-zero both after failing to reap a descendant ("The operation
+    // attempted is not supported", 255) and when it races a root that was already
+    // terminating ("Access is denied", 1 -- what `cancel` hits after interrupting the
+    // turn). Both messages are localized, so the root's own liveness is the only usable
+    // signal: it is gone, and the kill should not throw for either case.
+    //
+    // But a non-zero taskkill never establishes that the REST of the tree went with it,
+    // and `/T` leaves no way to enumerate what survived once the root is gone. So the
+    // two facts are reported separately -- `delivered` is about the target, and
+    // `treeConfirmed` is about everything under it. This is the one branch that cannot
+    // account for the whole tree.
     if (!result.error && waitForProcessGone(pid, killImpl, options.killWaitMs ?? 1000)) {
-      return { attempted: true, delivered: true, method: "taskkill", result };
+      return { attempted: true, delivered: true, treeConfirmed: false, method: "taskkill", result };
     }
 
     if (result.error?.code === "ENOENT") {
       try {
         killImpl(pid);
-        return { attempted: true, delivered: true, method: "kill" };
+        return { attempted: true, delivered: true, treeConfirmed: true, method: "kill" };
       } catch (error) {
         if (error?.code === "ESRCH") {
-          return { attempted: true, delivered: false, method: "kill" };
+          return { attempted: true, delivered: false, treeConfirmed: true, method: "kill" };
         }
         throw error;
       }
@@ -159,21 +164,21 @@ export function terminateProcessTree(pid, options = {}) {
 
   try {
     killImpl(-pid, "SIGTERM");
-    return { attempted: true, delivered: true, method: "process-group" };
+    return { attempted: true, delivered: true, treeConfirmed: true, method: "process-group" };
   } catch (error) {
     if (error?.code !== "ESRCH") {
       try {
         killImpl(pid, "SIGTERM");
-        return { attempted: true, delivered: true, method: "process" };
+        return { attempted: true, delivered: true, treeConfirmed: true, method: "process" };
       } catch (innerError) {
         if (innerError?.code === "ESRCH") {
-          return { attempted: true, delivered: false, method: "process" };
+          return { attempted: true, delivered: false, treeConfirmed: true, method: "process" };
         }
         throw innerError;
       }
     }
 
-    return { attempted: true, delivered: false, method: "process-group" };
+    return { attempted: true, delivered: false, treeConfirmed: true, method: "process-group" };
   }
 }
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -54,6 +54,23 @@ function looksLikeMissingProcessMessage(text) {
   return /not found|no running instance|cannot find|does not exist|no such process/i.test(text);
 }
 
+// taskkill's exit code for "no such process". Locale-independent, unlike the message
+// text: on a non-English Windows the "not found" wording is translated and the regex
+// above never matches, so an already-dead pid would surface as a thrown error.
+const TASKKILL_PROCESS_NOT_FOUND = 128;
+
+// On Windows runCommand spawns through $SHELL, which is Git Bash when Claude Code runs
+// from it. MSYS then rewrites taskkill's `/PID` flag into a path (`C:/Program Files/Git/PID`)
+// and the call fails. Disable the conversion for this child only -- setting it on the
+// node process itself would break the `/c/...` paths node needs to resolve.
+function envWithoutMsysPathConversion(env) {
+  return {
+    ...(env ?? process.env),
+    MSYS_NO_PATHCONV: "1",
+    MSYS2_ARG_CONV_EXCL: "*"
+  };
+}
+
 export function terminateProcessTree(pid, options = {}) {
   if (!Number.isFinite(pid)) {
     return { attempted: false, delivered: false, method: null };
@@ -66,7 +83,7 @@ export function terminateProcessTree(pid, options = {}) {
   if (platform === "win32") {
     const result = runCommandImpl("taskkill", ["/PID", String(pid), "/T", "/F"], {
       cwd: options.cwd,
-      env: options.env
+      env: envWithoutMsysPathConversion(options.env)
     });
 
     if (!result.error && result.status === 0) {
@@ -74,7 +91,10 @@ export function terminateProcessTree(pid, options = {}) {
     }
 
     const combinedOutput = `${result.stderr}\n${result.stdout}`.trim();
-    if (!result.error && looksLikeMissingProcessMessage(combinedOutput)) {
+    if (
+      !result.error &&
+      (result.status === TASKKILL_PROCESS_NOT_FOUND || looksLikeMissingProcessMessage(combinedOutput))
+    ) {
       return { attempted: true, delivered: false, method: "taskkill", result };
     }
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -71,6 +71,17 @@ function envWithoutMsysPathConversion(env) {
   };
 }
 
+// Signal 0 tests for existence without touching the process. EPERM means it is alive
+// under another owner, so anything but ESRCH counts as still running.
+function processIsGone(pid, killImpl) {
+  try {
+    killImpl(pid, 0);
+    return false;
+  } catch (error) {
+    return error?.code === "ESRCH";
+  }
+}
+
 export function terminateProcessTree(pid, options = {}) {
   if (!Number.isFinite(pid)) {
     return { attempted: false, delivered: false, method: null };
@@ -96,6 +107,16 @@ export function terminateProcessTree(pid, options = {}) {
       (result.status === TASKKILL_PROCESS_NOT_FOUND || looksLikeMissingProcessMessage(combinedOutput))
     ) {
       return { attempted: true, delivered: false, method: "taskkill", result };
+    }
+
+    // `/T` makes taskkill walk the tree, and it exits non-zero when it killed the target
+    // but could not reap one descendant -- "The operation attempted is not supported",
+    // exit 255, which is what a console host or an already-exiting child produces. The
+    // exit code does not separate that from a genuine failure, and the message is
+    // localized, so ask the OS whether the target itself is gone rather than parsing
+    // either. The target being dead is what every caller of this actually asked for.
+    if (!result.error && processIsGone(pid, killImpl)) {
+      return { attempted: true, delivered: true, method: "taskkill", result };
     }
 
     if (result.error?.code === "ENOENT") {

--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -139,7 +139,20 @@ async function main() {
   }
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+// `process.argv[1]` is resolved to an absolute path but never through symlinks, while
+// `import.meta.url` always is. A plugin root reached through a symlink -- what a locally
+// linked install looks like -- makes the two differ, and comparing them literally would
+// skip `main()` and turn SessionStart/SessionEnd into a silent no-op. Compare what the
+// two paths actually point at, and fall back to the literal check if either is unreadable.
+function invokedAsEntryPoint() {
+  try {
+    return fs.realpathSync(process.argv[1] ?? "") === fs.realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return process.argv[1] === fileURLToPath(import.meta.url);
+  }
+}
+
+if (invokedAsEntryPoint()) {
   main().catch((error) => {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);

--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -2,10 +2,12 @@
 
 import fs from "node:fs";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
 import { terminateProcessTree } from "./lib/process.mjs";
 import { BROKER_ENDPOINT_ENV } from "./lib/app-server.mjs";
 import {
+  brokerProcessMatchesRecordedStart,
   clearBrokerSession,
   LOG_FILE_ENV,
   loadBrokerSession,
@@ -80,7 +82,7 @@ function handleSessionStart(input) {
   appendEnvVar(PLUGIN_DATA_ENV, process.env[PLUGIN_DATA_ENV]);
 }
 
-async function handleSessionEnd(input) {
+export async function handleSessionEnd(input, options = {}) {
   const cwd = input.cwd || process.cwd();
   const brokerSession =
     loadBrokerSession(cwd) ??
@@ -96,6 +98,16 @@ async function handleSessionEnd(input) {
   const logFile = brokerSession?.logFile ?? null;
   const sessionDir = brokerSession?.sessionDir ?? null;
   const pid = brokerSession?.pid ?? null;
+  const brokerPidVerified = brokerSession
+    ? brokerProcessMatchesRecordedStart(brokerSession, options)
+    : false;
+  const terminateBrokerProcess = (targetPid) =>
+    terminateProcessTree(targetPid, {
+      platform: options.platform,
+      runCommandImpl: options.runCommandImpl,
+      killImpl: options.killImpl,
+      killWaitMs: options.killWaitMs
+    });
 
   if (brokerEndpoint) {
     await sendBrokerShutdown(brokerEndpoint);
@@ -108,7 +120,7 @@ async function handleSessionEnd(input) {
     logFile,
     sessionDir,
     pid,
-    killProcess: terminateProcessTree
+    killProcess: brokerPidVerified ? terminateBrokerProcess : null
   });
   clearBrokerSession(cwd);
 }
@@ -127,7 +139,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/tests/broker-idle.test.mjs
+++ b/tests/broker-idle.test.mjs
@@ -98,17 +98,27 @@ test("replacing a stale broker kills the process it replaces", async () => {
 
   // Record it against an endpoint nothing is listening on: that is what a broker whose
   // endpoint went unreachable looks like to `ensureBrokerSession`.
+  const unreachableDir = createBrokerSessionDir();
   saveBrokerSession(cwd, {
-    endpoint: createBrokerEndpoint(createBrokerSessionDir()),
+    endpoint: createBrokerEndpoint(unreachableDir),
     pidFile: path.join(sessionDir, "broker.pid"),
     logFile: path.join(sessionDir, "broker.log"),
     sessionDir,
     pid: stale.pid
   });
 
-  await ensureBrokerSession(cwd, { scriptPath: BROKER_SCRIPT, env });
+  const replacement = await ensureBrokerSession(cwd, { scriptPath: BROKER_SCRIPT, env });
 
   assert.equal(await waitForExit(stale.pid, 10000), true, "the replaced broker is still running");
+
+  // The replacement self-reaps on its 300 ms idle timeout, but its session dir holds a
+  // log file, so nothing removes it. A test in a leak fix does not get to leak.
+  await waitForExit(replacement?.pid, 10000);
+  for (const dir of [sessionDir, unreachableDir, replacement?.sessionDir]) {
+    if (dir) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
 });
 
 // The timeout must not fire under a connected client: a turn holds its socket open for

--- a/tests/broker-idle.test.mjs
+++ b/tests/broker-idle.test.mjs
@@ -277,6 +277,32 @@ test("session end does not kill a broker pid whose start time does not match", a
   assert.equal(loadBrokerSession(cwd), null, "the stale session record survived");
 });
 
+// The endpoint wait does not watch the child, so a broker that dies at startup still
+// costs the full timeout -- and node reaps it, freeing the pid for the whole window.
+test("a broker that dies before its endpoint opens is not killed by pid", async () => {
+  const cwd = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+
+  const scriptDir = makeTempDir();
+  const scriptPath = path.join(scriptDir, "broker-that-exits.mjs");
+  fs.writeFileSync(scriptPath, "process.exit(1);\n", "utf8");
+
+  const killedPids = [];
+  const session = await ensureBrokerSession(cwd, {
+    scriptPath,
+    env: buildEnv(binDir),
+    timeoutMs: 2000,
+    killProcess(pid) {
+      killedPids.push(pid);
+    }
+  });
+
+  assert.equal(session, null, "a broker that never came up was reported ready");
+  assert.deepEqual(killedPids, [], "a reaped pid was killed");
+  assert.equal(loadBrokerSession(cwd), null, "a failed spawn left a session record");
+});
+
 test("process start-time probes are bounded and timeouts are unverifiable", () => {
   let captured = null;
   const timeoutError = new Error("probe timed out");

--- a/tests/broker-idle.test.mjs
+++ b/tests/broker-idle.test.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import net from "node:net";
+import os from "node:os";
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import test from "node:test";
@@ -395,4 +396,46 @@ test("the SessionEnd hook still runs when invoked the way hooks.json invokes it"
   assert.equal(loadBrokerSession(cwd), null, "the hook did not run: broker.json survived");
 
   fs.rmSync(sessionDir, { recursive: true, force: true });
+});
+
+// Reaching the same script through a symlinked plugin root gives `process.argv[1]` the
+// link path while `import.meta.url` resolves to the target, so an entry-point guard that
+// compares the two literally stops running the hook at all -- silently, since a hook that
+// exits 0 without doing anything looks exactly like a hook with nothing to do.
+test("the SessionEnd hook still runs when its plugin root is a symlink", async () => {
+  const cwd = makeTempDir();
+  const sessionDir = createBrokerSessionDir();
+  saveBrokerSession(cwd, {
+    endpoint: createBrokerEndpoint(sessionDir),
+    pidFile: path.join(sessionDir, "broker.pid"),
+    logFile: path.join(sessionDir, "broker.log"),
+    sessionDir,
+    pid: null // nothing to kill; this test is only about whether main() ran at all
+  });
+
+  const scriptsDir = fileURLToPath(new URL("../plugins/codex/scripts", import.meta.url));
+  // Deliberately not under `makeTempDir`: its exit reaper deletes recursively, and a link
+  // to the real scripts directory is not something to hand a recursive delete.
+  const linkParent = fs.mkdtempSync(path.join(os.tmpdir(), "codex-plugin-link-"));
+  const linkRoot = path.join(linkParent, "scripts");
+  fs.symlinkSync(scriptsDir, linkRoot, "junction"); // "junction" is ignored off Windows
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [path.join(linkRoot, "session-lifecycle-hook.mjs"), "SessionEnd"],
+      { input: JSON.stringify({ cwd }), encoding: "utf8" }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(loadBrokerSession(cwd), null, "the hook did not run through the symlink");
+  } finally {
+    try {
+      fs.unlinkSync(linkRoot);
+    } catch {
+      fs.rmdirSync(linkRoot); // Windows removes a junction this way, target untouched
+    }
+    fs.rmSync(linkParent, { recursive: true, force: true });
+    fs.rmSync(sessionDir, { recursive: true, force: true });
+  }
 });

--- a/tests/broker-idle.test.mjs
+++ b/tests/broker-idle.test.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import net from "node:net";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -12,11 +13,13 @@ import {
   createBrokerSessionDir,
   ensureBrokerSession,
   loadBrokerSession,
+  readProcessStartTime,
   saveBrokerSession,
   spawnBrokerProcess,
   waitForBrokerEndpoint
 } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
 import { createBrokerEndpoint, parseBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-endpoint.mjs";
+import { handleSessionEnd } from "../plugins/codex/scripts/session-lifecycle-hook.mjs";
 
 const BROKER_SCRIPT = fileURLToPath(
   new URL("../plugins/codex/scripts/app-server-broker.mjs", import.meta.url)
@@ -151,21 +154,155 @@ test("replacing a stale broker kills the process it replaces", async () => {
     pidFile: path.join(sessionDir, "broker.pid"),
     logFile: path.join(sessionDir, "broker.log"),
     sessionDir,
-    pid: stale.pid
+    pid: stale.pid,
+    processStartTime: readProcessStartTime(stale.pid)
   });
 
-  const replacement = await ensureBrokerSession(cwd, { scriptPath: BROKER_SCRIPT, env });
+  const killedPids = [];
+  let replacement = null;
+  try {
+    replacement = await ensureBrokerSession(cwd, {
+      scriptPath: BROKER_SCRIPT,
+      env,
+      terminateProcessTreeImpl(pid) {
+        killedPids.push(pid);
+        stale.kill("SIGTERM");
+      }
+    });
 
-  assert.equal(await waitForExit(stale.pid, 10000), true, "the replaced broker is still running");
-
-  // The replacement self-reaps on its 300 ms idle timeout, but its session dir holds a
-  // log file, so nothing removes it. A test in a leak fix does not get to leak.
-  await waitForExit(replacement?.pid, 10000);
-  for (const dir of [sessionDir, unreachableDir, replacement?.sessionDir]) {
-    if (dir) {
-      fs.rmSync(dir, { recursive: true, force: true });
+    assert.deepEqual(killedPids, [stale.pid], "the default broker terminator was not used");
+    assert.equal(await waitForExit(stale.pid, 10000), true, "the replaced broker is still running");
+  } finally {
+    if (isAlive(stale.pid)) {
+      stale.kill("SIGTERM");
+    }
+    await waitForExit(stale.pid, 10000);
+    // The replacement self-reaps on its 300 ms idle timeout, but its session dir holds a
+    // log file, so nothing removes it. A test in a leak fix does not get to leak.
+    await waitForExit(replacement?.pid, 10000);
+    for (const dir of [sessionDir, unreachableDir, replacement?.sessionDir]) {
+      if (dir && fs.existsSync(dir)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
     }
   }
+});
+
+test("replacing stale state does not kill a pid whose start time does not match", async () => {
+  const cwd = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  const env = { ...buildEnv(binDir), [BROKER_IDLE_MS_ENV]: "300" };
+  const recycledPid = 424242;
+
+  const sessionDir = createBrokerSessionDir();
+  const unreachableDir = createBrokerSessionDir();
+  const pidFile = path.join(sessionDir, "broker.pid");
+  const logFile = path.join(sessionDir, "broker.log");
+  fs.writeFileSync(pidFile, `${recycledPid}\n`, "utf8");
+  fs.writeFileSync(logFile, "stale\n", "utf8");
+  saveBrokerSession(cwd, {
+    endpoint: createBrokerEndpoint(unreachableDir),
+    pidFile,
+    logFile,
+    sessionDir,
+    pid: recycledPid,
+    processStartTime: "recorded-start"
+  });
+
+  const killedPids = [];
+  let replacement = null;
+  try {
+    replacement = await ensureBrokerSession(cwd, {
+      scriptPath: BROKER_SCRIPT,
+      env,
+      readProcessStartTime() {
+        return "different-start";
+      },
+      killProcess(pid) {
+        killedPids.push(pid);
+      }
+    });
+
+    assert.deepEqual(killedPids, [], "a recycled pid was killed");
+    assert.equal(fs.existsSync(pidFile), false, "the stale pid file survived");
+    assert.equal(fs.existsSync(logFile), false, "the stale log file survived");
+    assert.notEqual(loadBrokerSession(cwd)?.pid, recycledPid, "the stale state survived");
+  } finally {
+    if (replacement?.pid) {
+      await waitForExit(replacement.pid, 10000);
+    }
+    for (const dir of [sessionDir, unreachableDir, replacement?.sessionDir]) {
+      if (dir && fs.existsSync(dir)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  }
+});
+
+test("session end does not kill a broker pid whose start time does not match", async () => {
+  const cwd = makeTempDir();
+  const sessionDir = createBrokerSessionDir();
+  const pidFile = path.join(sessionDir, "broker.pid");
+  const logFile = path.join(sessionDir, "broker.log");
+  const recycledPid = 424242;
+  fs.writeFileSync(pidFile, `${recycledPid}\n`, "utf8");
+  fs.writeFileSync(logFile, "stale\n", "utf8");
+  saveBrokerSession(cwd, {
+    endpoint: null,
+    pidFile,
+    logFile,
+    sessionDir,
+    pid: recycledPid,
+    processStartTime: "recorded-start"
+  });
+
+  const killedPids = [];
+  await handleSessionEnd(
+    { cwd, session_id: "identity-test" },
+    {
+      platform: "linux",
+      readProcessStartTime() {
+        return "different-start";
+      },
+      killImpl(pid) {
+        killedPids.push(pid);
+      }
+    }
+  );
+
+  assert.deepEqual(killedPids, [], "the session hook killed a recycled pid");
+  assert.equal(fs.existsSync(pidFile), false, "the stale pid file survived");
+  assert.equal(fs.existsSync(logFile), false, "the stale log file survived");
+  assert.equal(loadBrokerSession(cwd), null, "the stale session record survived");
+});
+
+test("process start-time probes are bounded and timeouts are unverifiable", () => {
+  let captured = null;
+  const timeoutError = new Error("probe timed out");
+  timeoutError.code = "ETIMEDOUT";
+
+  const startTime = readProcessStartTime(1234, {
+    platform: "win32",
+    env: { PATH: "C:\\Windows\\System32" },
+    runCommandImpl(command, args, options) {
+      captured = { command, args, options };
+      return {
+        command,
+        args,
+        status: 0,
+        signal: null,
+        stdout: "",
+        stderr: "",
+        error: timeoutError
+      };
+    }
+  });
+
+  assert.equal(startTime, null, "a timed-out probe was treated as verified");
+  assert.equal(captured?.command, "powershell.exe");
+  assert.equal(captured?.options.timeout, 2000, "the identity probe was not bounded");
+  assert.equal(captured?.options.shell, false);
 });
 
 // The timeout must not fire under a connected client: a turn holds its socket open for
@@ -200,6 +337,36 @@ test("a connected client holds the broker open, and releases it on disconnect", 
 
   socket.end();
   assert.equal(await waitForExit(child.pid, 10000), true, "broker survived its client");
+
+  fs.rmSync(sessionDir, { recursive: true, force: true });
+});
+
+// The file is now importable for tests, which means `main()` sits behind an entry-point guard.
+// Get that guard wrong and the SessionEnd broker reaper becomes a silent no-op: exit 0, no output,
+// nothing reaped. Nothing else in the suite would notice, so run the file the way hooks.json does.
+test("the SessionEnd hook still runs when invoked the way hooks.json invokes it", async () => {
+  const cwd = makeTempDir();
+  const sessionDir = createBrokerSessionDir();
+  saveBrokerSession(cwd, {
+    endpoint: createBrokerEndpoint(sessionDir),
+    pidFile: path.join(sessionDir, "broker.pid"),
+    logFile: path.join(sessionDir, "broker.log"),
+    sessionDir,
+    pid: null // nothing to kill; this test is only about whether main() ran at all
+  });
+  assert.notEqual(loadBrokerSession(cwd), null, "precondition: the record exists");
+
+  const hookScript = fileURLToPath(
+    new URL("../plugins/codex/scripts/session-lifecycle-hook.mjs", import.meta.url)
+  ).split(path.sep).join("/"); // exactly how hooks.json spells it
+
+  const result = spawnSync(process.execPath, [hookScript, "SessionEnd"], {
+    input: JSON.stringify({ cwd }),
+    encoding: "utf8"
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(loadBrokerSession(cwd), null, "the hook did not run: broker.json survived");
 
   fs.rmSync(sessionDir, { recursive: true, force: true });
 });

--- a/tests/broker-idle.test.mjs
+++ b/tests/broker-idle.test.mjs
@@ -11,6 +11,7 @@ import {
   BROKER_IDLE_MS_ENV,
   createBrokerSessionDir,
   ensureBrokerSession,
+  loadBrokerSession,
   saveBrokerSession,
   spawnBrokerProcess,
   waitForBrokerEndpoint
@@ -68,11 +69,57 @@ test("a broker nobody connects to exits on its own", async () => {
 
   // Wait on the pid file, not the endpoint: probing the endpoint would connect and
   // disconnect, which is the other code path. Nothing here ever connects.
+  // Record it the way ensureBrokerSession would, so the idle exit has something to clear.
+  saveBrokerSession(cwd, { endpoint, pidFile, logFile, sessionDir, pid: child.pid });
+
+  // Wait on the pid file, not the endpoint: probing the endpoint would connect and
+  // disconnect, which is the other code path. Nothing here ever connects.
   assert.equal(await waitForFile(pidFile, 10000), true, "broker never came up");
   assert.equal(await waitForExit(child.pid, 10000), true, "broker was still alive after idling");
   assert.equal(fs.existsSync(pidFile), false, "the pid file outlived the broker");
+  // `reuseExistingBroker` callers read this record without probing, so a survivor points
+  // them at a dead socket instead of the direct spawn they fall back to when it is absent.
+  assert.equal(loadBrokerSession(cwd), null, "broker.json outlived the broker");
 
   fs.rmSync(sessionDir, { recursive: true, force: true });
+});
+
+// Only its own record: by the time an idle broker exits, a replacement may already own
+// this cwd, and clearing that would strand the live one.
+test("an idle broker leaves a replacement's session record alone", async () => {
+  const cwd = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+
+  const sessionDir = createBrokerSessionDir();
+  const pidFile = path.join(sessionDir, "broker.pid");
+  const child = spawnBrokerProcess({
+    scriptPath: BROKER_SCRIPT,
+    cwd,
+    endpoint: createBrokerEndpoint(sessionDir),
+    pidFile,
+    logFile: path.join(sessionDir, "broker.log"),
+    env: { ...buildEnv(binDir), [BROKER_IDLE_MS_ENV]: "300" }
+  });
+  assert.equal(await waitForFile(pidFile, 10000), true, "broker never came up");
+
+  // A different broker's record, as a replacement would have written it.
+  const otherDir = createBrokerSessionDir();
+  const other = {
+    endpoint: createBrokerEndpoint(otherDir),
+    pidFile: path.join(otherDir, "broker.pid"),
+    logFile: path.join(otherDir, "broker.log"),
+    sessionDir: otherDir,
+    pid: 999999
+  };
+  saveBrokerSession(cwd, other);
+
+  assert.equal(await waitForExit(child.pid, 10000), true, "broker was still alive after idling");
+  assert.deepEqual(loadBrokerSession(cwd), other, "it cleared someone else's record");
+
+  for (const dir of [sessionDir, otherDir]) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // Replacing a stale broker deletes its pid, log and state files whether or not the

--- a/tests/broker-idle.test.mjs
+++ b/tests/broker-idle.test.mjs
@@ -1,0 +1,148 @@
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+import { makeTempDir } from "./helpers.mjs";
+import { buildEnv, installFakeCodex } from "./fake-codex-fixture.mjs";
+import {
+  BROKER_IDLE_MS_ENV,
+  createBrokerSessionDir,
+  ensureBrokerSession,
+  saveBrokerSession,
+  spawnBrokerProcess,
+  waitForBrokerEndpoint
+} from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { createBrokerEndpoint, parseBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-endpoint.mjs";
+
+const BROKER_SCRIPT = fileURLToPath(
+  new URL("../plugins/codex/scripts/app-server-broker.mjs", import.meta.url)
+);
+
+function isAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return false;
+}
+
+const waitForExit = (pid, timeoutMs) => waitFor(() => !isAlive(pid), timeoutMs);
+const waitForFile = (filePath, timeoutMs) => waitFor(() => fs.existsSync(filePath), timeoutMs);
+
+// A broker is spawned detached and outlives its parent, so before the idle timeout the
+// only ways it ever exited were a `broker/shutdown` RPC and SIGTERM/SIGINT. Anything
+// that lost track of one stranded it, and the codex stack under it, permanently.
+test("a broker nobody connects to exits on its own", async () => {
+  const cwd = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+
+  const sessionDir = createBrokerSessionDir();
+  const endpoint = createBrokerEndpoint(sessionDir);
+  const pidFile = path.join(sessionDir, "broker.pid");
+  const logFile = path.join(sessionDir, "broker.log");
+
+  const child = spawnBrokerProcess({
+    scriptPath: BROKER_SCRIPT,
+    cwd,
+    endpoint,
+    pidFile,
+    logFile,
+    env: { ...buildEnv(binDir), [BROKER_IDLE_MS_ENV]: "300" }
+  });
+
+  // Wait on the pid file, not the endpoint: probing the endpoint would connect and
+  // disconnect, which is the other code path. Nothing here ever connects.
+  assert.equal(await waitForFile(pidFile, 10000), true, "broker never came up");
+  assert.equal(await waitForExit(child.pid, 10000), true, "broker was still alive after idling");
+  assert.equal(fs.existsSync(pidFile), false, "the pid file outlived the broker");
+
+  fs.rmSync(sessionDir, { recursive: true, force: true });
+});
+
+// Replacing a stale broker deletes its pid, log and state files whether or not the
+// process was killed -- so a survivor becomes invisible to every later reaper,
+// including the SessionEnd hook, which finds brokers through the state file this path
+// clears. Before the fix the sole production caller passed no killProcess at all.
+test("replacing a stale broker kills the process it replaces", async () => {
+  const cwd = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  const env = { ...buildEnv(binDir), [BROKER_IDLE_MS_ENV]: "300" };
+
+  const sessionDir = createBrokerSessionDir();
+  const stale = spawnBrokerProcess({
+    scriptPath: BROKER_SCRIPT,
+    cwd,
+    endpoint: createBrokerEndpoint(sessionDir),
+    pidFile: path.join(sessionDir, "broker.pid"),
+    logFile: path.join(sessionDir, "broker.log"),
+    env: { ...env, [BROKER_IDLE_MS_ENV]: "600000" }
+  });
+  assert.equal(await waitForFile(path.join(sessionDir, "broker.pid"), 10000), true);
+
+  // Record it against an endpoint nothing is listening on: that is what a broker whose
+  // endpoint went unreachable looks like to `ensureBrokerSession`.
+  saveBrokerSession(cwd, {
+    endpoint: createBrokerEndpoint(createBrokerSessionDir()),
+    pidFile: path.join(sessionDir, "broker.pid"),
+    logFile: path.join(sessionDir, "broker.log"),
+    sessionDir,
+    pid: stale.pid
+  });
+
+  await ensureBrokerSession(cwd, { scriptPath: BROKER_SCRIPT, env });
+
+  assert.equal(await waitForExit(stale.pid, 10000), true, "the replaced broker is still running");
+});
+
+// The timeout must not fire under a connected client: a turn holds its socket open for
+// its whole duration, so killing a broker with a live socket would kill a running job.
+test("a connected client holds the broker open, and releases it on disconnect", async () => {
+  const cwd = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+
+  const sessionDir = createBrokerSessionDir();
+  const endpoint = createBrokerEndpoint(sessionDir);
+
+  const child = spawnBrokerProcess({
+    scriptPath: BROKER_SCRIPT,
+    cwd,
+    endpoint,
+    pidFile: path.join(sessionDir, "broker.pid"),
+    logFile: path.join(sessionDir, "broker.log"),
+    env: { ...buildEnv(binDir), [BROKER_IDLE_MS_ENV]: "300" }
+  });
+
+  assert.equal(await waitForBrokerEndpoint(endpoint, 10000), true, "broker never came up");
+
+  const socket = await new Promise((resolve, reject) => {
+    const s = net.connect(parseBrokerEndpoint(endpoint).path);
+    s.on("connect", () => resolve(s));
+    s.on("error", reject);
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 1200));
+  assert.equal(isAlive(child.pid), true, "broker exited while a client was connected");
+
+  socket.end();
+  assert.equal(await waitForExit(child.pid, 10000), true, "broker survived its client");
+
+  fs.rmSync(sessionDir, { recursive: true, force: true });
+});

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -101,16 +101,43 @@ test("terminateProcessTree accepts a taskkill failure whose target is nonetheles
   assert.equal(probedSignal, 0, "the target must be probed, not signalled");
 });
 
-test("terminateProcessTree still throws when taskkill fails and the target is alive", () => {
+// The real failure behind `/codex:cancel`: the turn was just interrupted, so the worker
+// is already terminating and taskkill loses the race with "Access is denied". The target
+// is not gone at the instant taskkill returns -- only a moment later.
+test("terminateProcessTree waits out a target that is still exiting", () => {
+  let probes = 0;
+  const outcome = terminateProcessTree(1234, {
+    platform: "win32",
+    killWaitMs: 500,
+    runCommandImpl(command, args) {
+      return { command, args, status: 1, signal: null, stdout: "", stderr: "오류: 액세스가 거부되었습니다.", error: null };
+    },
+    killImpl() {
+      probes += 1;
+      if (probes < 3) {
+        return true; // still winding down
+      }
+      const error = new Error("no such process");
+      error.code = "ESRCH";
+      throw error;
+    }
+  });
+
+  assert.equal(outcome.delivered, true);
+  assert.ok(probes >= 3, "it gave up after a single probe");
+});
+
+test("terminateProcessTree still throws when taskkill fails and the target stays alive", () => {
   assert.throws(
     () =>
       terminateProcessTree(1234, {
         platform: "win32",
+        killWaitMs: 0,
         runCommandImpl(command, args) {
           return { command, args, status: 1, signal: null, stdout: "", stderr: "Access is denied.", error: null };
         },
         killImpl() {
-          return true; // the probe finds it running
+          return true; // never goes away
         }
       }),
     /Access is denied|taskkill/

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -39,6 +39,7 @@ test("terminateProcessTree uses taskkill on Windows", () => {
     }
   });
   assert.equal(outcome.delivered, true);
+  assert.equal(outcome.treeConfirmed, true, "a clean taskkill accounts for the whole tree");
   assert.equal(outcome.method, "taskkill");
 });
 
@@ -65,13 +66,14 @@ test("terminateProcessTree treats exit code 128 as already stopped on a non-Engl
 
   assert.equal(outcome.attempted, true);
   assert.equal(outcome.delivered, false);
+  assert.equal(outcome.treeConfirmed, true, "there was no process, so no tree is in doubt");
   assert.equal(outcome.method, "taskkill");
 });
 
 // The real message, from a Korean Windows host: taskkill killed the target but could not
 // reap one descendant. Keying on the text would reintroduce the locale bug this file
 // exists for, so the target's own liveness has to decide it.
-test("terminateProcessTree accepts a taskkill failure whose target is nonetheless gone", () => {
+test("terminateProcessTree reports a partial taskkill failure when only the root is known gone", () => {
   let probedSignal;
   const outcome = terminateProcessTree(1234, {
     platform: "win32",
@@ -97,6 +99,7 @@ test("terminateProcessTree accepts a taskkill failure whose target is nonetheles
 
   assert.equal(outcome.attempted, true);
   assert.equal(outcome.delivered, true);
+  assert.equal(outcome.treeConfirmed, false, "a partial kill must not claim the tree");
   assert.equal(outcome.method, "taskkill");
   assert.equal(probedSignal, 0, "the target must be probed, not signalled");
 });
@@ -124,6 +127,7 @@ test("terminateProcessTree waits out a target that is still exiting", () => {
   });
 
   assert.equal(outcome.delivered, true);
+  assert.equal(outcome.treeConfirmed, false, "a raced kill cannot account for the tree");
   assert.ok(probes >= 3, "it gave up after a single probe");
 });
 

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -66,7 +66,11 @@ test("terminateProcessTree treats exit code 128 as already stopped on a non-Engl
 
   assert.equal(outcome.attempted, true);
   assert.equal(outcome.delivered, false);
-  assert.equal(outcome.treeConfirmed, true, "there was no process, so no tree is in doubt");
+  assert.equal(
+    outcome.treeConfirmed,
+    false,
+    "a root that is already gone says nothing about the children it left behind"
+  );
   assert.equal(outcome.method, "taskkill");
 });
 

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -68,6 +68,55 @@ test("terminateProcessTree treats exit code 128 as already stopped on a non-Engl
   assert.equal(outcome.method, "taskkill");
 });
 
+// The real message, from a Korean Windows host: taskkill killed the target but could not
+// reap one descendant. Keying on the text would reintroduce the locale bug this file
+// exists for, so the target's own liveness has to decide it.
+test("terminateProcessTree accepts a taskkill failure whose target is nonetheless gone", () => {
+  let probedSignal;
+  const outcome = terminateProcessTree(1234, {
+    platform: "win32",
+    runCommandImpl(command, args) {
+      return {
+        command,
+        args,
+        status: 255,
+        signal: null,
+        stdout: "",
+        stderr:
+          "오류: PID 27048인 프로세스(PID 1234인 자식 프로세스)를 종료할 수 없습니다.\n오류: 시도한 작업은 지원되지 않습니다.",
+        error: null
+      };
+    },
+    killImpl(pid, signal) {
+      probedSignal = signal;
+      const error = new Error("no such process");
+      error.code = "ESRCH";
+      throw error;
+    }
+  });
+
+  assert.equal(outcome.attempted, true);
+  assert.equal(outcome.delivered, true);
+  assert.equal(outcome.method, "taskkill");
+  assert.equal(probedSignal, 0, "the target must be probed, not signalled");
+});
+
+test("terminateProcessTree still throws when taskkill fails and the target is alive", () => {
+  assert.throws(
+    () =>
+      terminateProcessTree(1234, {
+        platform: "win32",
+        runCommandImpl(command, args) {
+          return { command, args, status: 1, signal: null, stdout: "", stderr: "Access is denied.", error: null };
+        },
+        killImpl() {
+          return true; // the probe finds it running
+        }
+      }),
+    /Access is denied|taskkill/
+  );
+});
+
 test("terminateProcessTree treats missing Windows processes as already stopped", () => {
   const outcome = terminateProcessTree(1234, {
     platform: "win32",

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -7,8 +7,9 @@ test("terminateProcessTree uses taskkill on Windows", () => {
   let captured = null;
   const outcome = terminateProcessTree(1234, {
     platform: "win32",
-    runCommandImpl(command, args) {
-      captured = { command, args };
+    env: { PATH: "C:\\Windows\\System32", SHELL: "C:\\Program Files\\Git\\bin\\bash.exe" },
+    runCommandImpl(command, args, options) {
+      captured = { command, args, options };
       return {
         command,
         args,
@@ -26,9 +27,44 @@ test("terminateProcessTree uses taskkill on Windows", () => {
 
   assert.deepEqual(captured, {
     command: "taskkill",
-    args: ["/PID", "1234", "/T", "/F"]
+    args: ["/PID", "1234", "/T", "/F"],
+    options: {
+      cwd: undefined,
+      env: {
+        PATH: "C:\\Windows\\System32",
+        SHELL: "C:\\Program Files\\Git\\bin\\bash.exe",
+        MSYS_NO_PATHCONV: "1",
+        MSYS2_ARG_CONV_EXCL: "*"
+      }
+    }
   });
   assert.equal(outcome.delivered, true);
+  assert.equal(outcome.method, "taskkill");
+});
+
+test("terminateProcessTree treats exit code 128 as already stopped on a non-English Windows", () => {
+  // Korean Windows: taskkill translates "not found", so the English regex cannot match.
+  // Only the exit code identifies the case. Without it this call throws.
+  const outcome = terminateProcessTree(1234, {
+    platform: "win32",
+    runCommandImpl(command, args) {
+      return {
+        command,
+        args,
+        status: 128,
+        signal: null,
+        stdout: "",
+        stderr: "오류: 프로세스 \"1234\"을(를) 찾을 수 없습니다.",
+        error: null
+      };
+    },
+    killImpl() {
+      throw new Error("kill fallback should not run");
+    }
+  });
+
+  assert.equal(outcome.attempted, true);
+  assert.equal(outcome.delivered, false);
   assert.equal(outcome.method, "taskkill");
 });
 


### PR DESCRIPTION
> Stacked on #577 — it contains the taskkill fix this one's kill path depends on, so the diff to review here is the last commit only. Without #577 the new `replacing a stale broker kills the process it replaces` test fails on a Git Bash host; that is not a hypothetical, it is how the dependency was found.

An app-server broker is spawned `detached` + `unref` and exits only on a `broker/shutdown` RPC or SIGTERM/SIGINT. Anything that loses track of one strands it — and the ~9-process codex stack under it — permanently. One Windows host reached 2257 processes against a ~330 baseline. Two independent causes:

**1. No idle timeout.** Nothing reaps a broker whose parent was hard-killed. Now it exits after 30 minutes with zero connected sockets. That is safe to do: a turn holds its socket open for its whole duration, so zero sockets means nothing is in flight, and the thread itself lives in `$CODEX_HOME/sessions` and stays resumable — the next caller just respawns a broker. This is the only fix that covers *every* way a broker gets stranded.

**2. The stale-replacement path never killed.** `teardownBrokerSession`'s kill is opt-in and the sole production caller (`app-server.mjs`, via `ensureBrokerSession`) passed no `killProcess`. It deleted the broker's pid, log and state files anyway, so the survivor became invisible to every later reaper — including `session-lifecycle-hook.mjs`, which finds brokers through the state file this path had just cleared. Note that hook already passes `killProcess: terminateProcessTree`: same helper, one call site wired, the other not.

Observed live, unprompted, mid-investigation: four brokers alive for a single cwd while `broker.json` named one. The session then ended, the `SessionEnd` hook reaped only the named broker, and the other three stayed up with no state file at all.

`ensureBrokerSession` now defaults `killProcess` to `terminateProcessTree` on both teardown paths — replacing a stale broker, and cleaning up one we just spawned that never became ready.

**Probe change.** The readiness check that declares a broker stale now retries at 1s after the 150 ms attempt. A healthy broker answers the first probe immediately, so the retry only costs time when the broker is already in trouble — and without it a merely busy broker on a loaded host gets replaced for missing 150 ms, which is how a stranded broker gets created in the first place.

**Tests** (`tests/broker-idle.test.mjs`, three, all spawning a real broker over the fake-codex fixture):
- a broker nobody connects to exits on its own — waits on the pid file, never on the endpoint, since probing the endpoint would connect and exercise the other path
- replacing a stale broker kills the process it replaces
- a connected client holds the broker open, and releases it on disconnect

Each was checked by breaking the line it protects and confirming that test — and only that test — fails. The idle timeout is overridable through `CODEX_COMPANION_BROKER_IDLE_MS` so the tests can watch a real broker exit; 30 minutes is the shipped value.

Full suite on Windows: 116 tests, 107 pass, 9 fail — the 9 are pre-existing and unrelated (platform-specific: unix sockets, temp-dir layout, transfer/native-import).
