### PR TITLE
fix: parse structured output wrapped in a markdown code fence

### DIFF
--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -1185,6 +1185,19 @@ export function buildPersistentTaskThreadName(prompt) {
   return buildTaskThreadName(prompt);
 }
 
+// A model asked for JSON often wraps the reply in a markdown fence, which a
+// bare JSON.parse rejects — discarding a well-formed review in favour of the
+// raw-text fallback. Only a fence enclosing the WHOLE message is stripped, so
+// JSON carrying backticks inside string values is untouched and genuinely
+// malformed output still fails.
+const FENCED_MESSAGE = /^```[A-Za-z0-9_+-]*[ \t]*\r?\n([\s\S]*?)\r?\n?```[ \t]*$/;
+
+function unfenceStructuredOutput(rawOutput) {
+  const trimmed = String(rawOutput).trim();
+  const fenced = FENCED_MESSAGE.exec(trimmed);
+  return fenced ? fenced[1] : trimmed;
+}
+
 export function parseStructuredOutput(rawOutput, fallback = {}) {
   if (!rawOutput) {
     return {
@@ -1197,7 +1210,7 @@ export function parseStructuredOutput(rawOutput, fallback = {}) {
 
   try {
     return {
-      parsed: JSON.parse(rawOutput),
+      parsed: JSON.parse(unfenceStructuredOutput(rawOutput)),
       parseError: null,
       rawOutput,
       ...fallback

--- a/tests/codex-structured-output.test.mjs
+++ b/tests/codex-structured-output.test.mjs
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseStructuredOutput } from "../plugins/codex/scripts/lib/codex.mjs";
+
+const REVIEW = { verdict: "approve", summary: "Looks fine.", findings: [] };
+
+test("parseStructuredOutput reads a bare JSON message", () => {
+  const result = parseStructuredOutput(JSON.stringify(REVIEW));
+
+  assert.equal(result.parseError, null);
+  assert.deepEqual(result.parsed, REVIEW);
+});
+
+test("parseStructuredOutput reads JSON wrapped in a fenced code block", () => {
+  const result = parseStructuredOutput("```json\n" + JSON.stringify(REVIEW) + "\n```");
+
+  assert.equal(result.parseError, null);
+  assert.deepEqual(result.parsed, REVIEW);
+});
+
+test("parseStructuredOutput reads a fence with no language tag", () => {
+  const result = parseStructuredOutput("```\n" + JSON.stringify(REVIEW) + "\n```");
+
+  assert.equal(result.parseError, null);
+  assert.deepEqual(result.parsed, REVIEW);
+});
+
+test("parseStructuredOutput reads a fenced message with CRLF line endings", () => {
+  const result = parseStructuredOutput("```json\r\n" + JSON.stringify(REVIEW) + "\r\n```");
+
+  assert.equal(result.parseError, null);
+  assert.deepEqual(result.parsed, REVIEW);
+});
+
+test("parseStructuredOutput keeps backticks inside string values", () => {
+  const withTicks = { summary: "pass `--base main` to scope the review" };
+  const result = parseStructuredOutput("```json\n" + JSON.stringify(withTicks) + "\n```");
+
+  assert.equal(result.parseError, null);
+  assert.deepEqual(result.parsed, withTicks);
+});
+
+test("parseStructuredOutput still reports malformed JSON rather than swallowing it", () => {
+  const result = parseStructuredOutput('{"verdict": ');
+
+  assert.equal(result.parsed, null);
+  assert.match(result.parseError, /JSON/);
+  assert.equal(result.rawOutput, '{"verdict": ');
+});
+
+test("parseStructuredOutput still reports prose that is not JSON at all", () => {
+  const result = parseStructuredOutput("I was unable to complete the review.");
+
+  assert.equal(result.parsed, null);
+  assert.ok(result.parseError);
+});
+
+test("parseStructuredOutput reports an empty message with the caller's failure text", () => {
+  const result = parseStructuredOutput("", { failureMessage: "no final message" });
+
+  assert.equal(result.parsed, null);
+  assert.equal(result.parseError, "no final message");
+});


### PR DESCRIPTION
## Problem

`parseStructuredOutput` in `plugins/codex/scripts/lib/codex.mjs` calls `JSON.parse` on the raw final message. A model asked to reply with JSON frequently wraps it in a fence, so the parse throws:

```
Codex did not return valid structured JSON.
- Parse error: Unexpected token '`', "```json
{"... is not valid JSON
```

The review then falls back to printing the raw message. Nothing is lost, but the structured path — verdict, findings, per-finding file and line — is unavailable.

I hit this on **2 of 3 consecutive `/codex:adversarial-review` runs** against the same repository. Identical prompts; whether the reply arrived fenced or bare varied run to run, so it is not deterministic and not something the caller can avoid.

## Fix

Strip a fence, but only one that encloses the **entire** message:

```js
const FENCED_MESSAGE = /^```[A-Za-z0-9_+-]*[ \t]*\r?\n([\s\S]*?)\r?\n?```[ \t]*$/;
```

That keeps JSON carrying backticks inside string values intact, and leaves malformed output, prose and empty messages failing exactly as they do today. This is deliberately narrow: it only recovers output that never reached the schema check. The existing graceful degradation for an unexpected review *shape* (`renderReviewResult`, covered in `tests/render.test.mjs`) is untouched.

## Tests

New `tests/codex-structured-output.test.mjs`, in the existing `node:test` style.

| | pristine | with fix |
|---|---|---|
| bare JSON | pass | pass |
| ` ```json ` fenced | **fail** | pass |
| fence with no language tag | **fail** | pass |
| fenced with CRLF | **fail** | pass |
| backticks inside a string value | **fail** | pass |
| malformed JSON | pass (rejected) | pass (rejected) |
| prose, not JSON | pass (rejected) | pass (rejected) |
| empty message | pass | pass |

Four cases fail against the current parser and pass with the change; the other four pass either way, so the fix cannot be silently loosening the parser into one that accepts anything.

## Full suite

`npm test` on macOS / Node v23.11.0, before and after:

- **before:** 87 passing, 4 failing
- **after:** 95 passing (+8, exactly the new tests), same 4 failing

The failing set is byte-identical before and after:

```
resolveStateDir uses a temp-backed per-workspace directory
result returns the stored output for the latest finished job by default
status preserves adversarial review kind labels
status shows phases, hints, and the latest finished job
```

These four fail on pristine `main` in my environment and are unrelated to this change — I have not investigated them and am not claiming they are broken upstream, only that this PR neither causes nor fixes them.