### PR TITLE
fix: name the schema's required keys in the adversarial review prompt

### DIFF
--- a/plugins/codex/prompts/adversarial-review.md
+++ b/plugins/codex/prompts/adversarial-review.md
@@ -47,14 +47,22 @@ A finding should answer:
 
 <structured_output_contract>
 Return only valid JSON matching the provided schema.
+The top-level object must contain exactly these four keys:
+- `verdict`: either `approve` or `needs-attention`
+- `summary`: a non-empty string
+- `findings`: an array, empty when there is nothing to report
+- `next_steps`: an array of strings, empty when there is nothing to do
 Keep the output compact and specific.
 Use `needs-attention` if there is any material risk worth blocking on.
 Use `approve` only if you cannot support any substantive adversarial finding from the provided context.
-Every finding must include:
-- the affected file
-- `line_start` and `line_end`
-- a confidence score from 0 to 1
-- a concrete recommendation
+Every finding object must contain exactly these eight keys:
+- `severity`: one of `low`, `medium`, `high`
+- `title`: a short one-line label
+- `body`: the explanation, including any inference it depends on
+- `file`: the affected file
+- `line_start` and `line_end`: integers
+- `confidence`: a number from 0 to 1
+- `recommendation`: a concrete change
 Write the summary like a terse ship/no-ship assessment, not a neutral recap.
 </structured_output_contract>
 

--- a/tests/review-prompt-schema.test.mjs
+++ b/tests/review-prompt-schema.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PROMPT = path.join(ROOT, "plugins/codex/prompts/adversarial-review.md");
+const SCHEMA = path.join(ROOT, "plugins/codex/schemas/review-output.schema.json");
+
+const prompt = fs.readFileSync(PROMPT, "utf8");
+const schema = JSON.parse(fs.readFileSync(SCHEMA, "utf8"));
+
+// The prompt tells the model to "return only valid JSON matching the provided
+// schema", but the schema itself travels separately, as the outputSchema
+// parameter on turn/start. Wherever that parameter does not reach the model the
+// instruction points at something invisible, and the model fills the gap by
+// guessing. Naming each required key in the prompt keeps the contract legible
+// on its own; these tests keep the two from drifting apart as the schema grows.
+
+test("every top-level key the schema requires is named in the review prompt", () => {
+  for (const key of schema.required) {
+    assert.ok(
+      prompt.includes(`\`${key}\``),
+      `schema requires top-level "${key}" but the prompt never names it`
+    );
+  }
+});
+
+test("every finding key the schema requires is named in the review prompt", () => {
+  for (const key of schema.properties.findings.items.required) {
+    assert.ok(
+      prompt.includes(`\`${key}\``),
+      `schema requires finding."${key}" but the prompt never names it`
+    );
+  }
+});
+
+test("the verdict values the prompt offers are the ones the schema accepts", () => {
+  for (const value of schema.properties.verdict.enum) {
+    assert.ok(
+      prompt.includes(`\`${value}\``),
+      `schema allows verdict "${value}" but the prompt never offers it`
+    );
+  }
+});


### PR DESCRIPTION
## Problem

`prompts/adversarial-review.md` instructs the model to *"Return only valid JSON matching the provided schema"*, but the schema itself travels by a different channel — the `outputSchema` parameter on `turn/start`. The prompt names none of the schema's top-level keys.

Wherever that parameter doesn't reach the model, the instruction points at something invisible and the model fills the gap by guessing. It said so itself, unprompted, in four consecutive runs:

> "The schema isn't provided but standard fields."
> "no explicit schema; however structured_output_contract says valid JSON."
> "We need infer schema."

## Evidence

Conformance tracked the **prompt text**, not the schema. Every key spelled out in prose was produced; every key known only to the schema was missed.

| Level | Key | Named in prompt? | Produced |
|---|---|---|---|
| top-level | `summary`, `findings` | yes | 3/3 runs |
| top-level | `verdict` | **no** | 2/3 runs |
| top-level | `next_steps` | **no** | **0/3 runs** |
| finding | `file`, `line_start`, `line_end`, `confidence`, `recommendation` | yes | present |
| finding | `severity`, `title`, `body` | **no** | rendered `[low] Finding 1 (unknown:220-236)` / `No details provided.` |

Nine keys, no exceptions in either direction. The result is `Codex returned JSON with an unexpected review shape. - Validation error: Missing array next_steps.` (or `Missing string verdict`), and the review degrades to raw text.

## Fix

Name every schema-required key in `<structured_output_contract>`, so the contract is legible without the side channel.

Measured on the same commit with only this variable changed:

- **before** — `{"summary": "approve", "reasoning": "...", "findings": []}` → degraded
- **after (top-level keys named)** — `Verdict: needs-attention`, findings, `Next steps:` with two items, zero degradation markers
- **after (finding keys also named)** — findings render with real severities (`[high]`, `[medium]`), titles, bodies and `file:line` locations, replacing the placeholder text above

This is redundant wherever `outputSchema` is already enforced and costs nothing there. Where it isn't, it's the difference between a structured review and a raw-text fallback.

I have **not** isolated where `outputSchema` is lost — a non-OpenAI provider dropping an unsupported parameter is the obvious candidate, but the app-server or the model ignoring it would look identical from here. The fix is deliberately robust to all three, which is why I'm proposing it without having named the culprit.

## Caveat

This is a prompt change, so its effect is probabilistic. I have one clean before/after per level, not a distribution. It cannot regress anything: it adds constraints that already hold wherever the schema is enforced.

## Tests

New `tests/review-prompt-schema.test.mjs` reads the prompt and the schema and asserts the prompt names every required key, so the two can't drift apart as the schema grows. Two of its three cases fail against the current prompt; the third (verdict enum values) passes either way, since the prompt already offered `approve`/`needs-attention`.

## Full suite

`npm test` on macOS / Node v23.11.0:

- **pristine `main`:** 87 passing, 4 failing
- **this branch:** 90 passing (+3, exactly the new tests), **same 4 failing, identical names**

The four pre-existing failures (`resolveStateDir …`, `result returns the stored output …`, `status shows phases …`, `status preserves adversarial review kind labels`) fail on pristine `main` in my environment and are unrelated to this change. I haven't investigated them and am not claiming they're broken upstream.

## Relationship to #583

Independent. [#583](https://github.com/openai/codex-plugin-cc/pull/583) fixes malformed *transport* (a fenced reply failing `JSON.parse`); this fixes missing *content* (a parseable reply that omits required keys). Either can merge without the other. On a provider that enforces neither, both are needed to get a structured review.