### PR TITLE
feat: add parallel-review subcommand (sharded map-reduce review)

### DIFF
--- a/plugins/codex/commands/parallel-review.md
+++ b/plugins/codex/commands/parallel-review.md
@@ -8,8 +8,8 @@ allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 Run a sharded adversarial Codex review through the shared plugin runtime.
 
 The companion splits the diff into up to `--max-shards` balanced shards
-(capped at 8) by directory/file ownership, reviews them as concurrent
-background tasks, then
+(clamped to between 2 and 8) by directory/file ownership, reviews them as
+concurrent background tasks, then
 runs one mandatory cross-shard integration pass that verifies every finding
 (CONFIRMED / SUSPECTED / REJECTED) and hunts defects that span two shards —
 the class a single shard can never see whole. Small diffs (under ~300 changed

--- a/plugins/codex/commands/parallel-review.md
+++ b/plugins/codex/commands/parallel-review.md
@@ -26,9 +26,12 @@ Core constraint:
 Execution rules:
 - A parallel review runs several concurrent Codex turns and costs roughly
   shard-count × the tokens of a single review. Before launching, check the
-  scope with `git diff --shortstat <base>...HEAD` (or `git diff --shortstat`
-  for working-tree scope) and confirm with the user once if they have not
-  already accepted the cost in this conversation.
+  scope and confirm with the user once if they have not already accepted the
+  cost in this conversation:
+  - For base-branch scope, use `git diff --shortstat <base>...HEAD`.
+  - For working-tree scope, inspect both `git diff --shortstat --cached` and
+    `git diff --shortstat` — staged changes are part of the review, and treat
+    untracked files as reviewable work even when both are empty.
 - Always run the command in a Claude background task; a full run takes
   several minutes end-to-end:
   `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" parallel-review <arguments>`

--- a/plugins/codex/commands/parallel-review.md
+++ b/plugins/codex/commands/parallel-review.md
@@ -7,8 +7,9 @@ allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 
 Run a sharded adversarial Codex review through the shared plugin runtime.
 
-The companion splits the diff into up to `--max-shards` balanced shards by
-directory/file ownership, reviews them as concurrent background tasks, then
+The companion splits the diff into up to `--max-shards` balanced shards
+(capped at 8) by directory/file ownership, reviews them as concurrent
+background tasks, then
 runs one mandatory cross-shard integration pass that verifies every finding
 (CONFIRMED / SUSPECTED / REJECTED) and hunts defects that span two shards —
 the class a single shard can never see whole. Small diffs (under ~300 changed

--- a/plugins/codex/commands/parallel-review.md
+++ b/plugins/codex/commands/parallel-review.md
@@ -1,0 +1,41 @@
+---
+description: Shard a large Codex review into concurrent background tasks plus a cross-shard integration pass
+argument-hint: '[--base <ref>] [--scope auto|working-tree|branch] [--max-shards 4] [--invariants-file <path>] [focus ...]'
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
+---
+
+Run a sharded adversarial Codex review through the shared plugin runtime.
+
+The companion splits the diff into up to `--max-shards` balanced shards by
+directory/file ownership, reviews them as concurrent background tasks, then
+runs one mandatory cross-shard integration pass that verifies every finding
+(CONFIRMED / SUSPECTED / REJECTED) and hunts defects that span two shards —
+the class a single shard can never see whole. Small diffs (under ~300 changed
+lines or 8 files) automatically fall back to one plain adversarial review.
+
+Raw slash-command arguments:
+`$ARGUMENTS`
+
+Core constraint:
+- This command is review-only.
+- Do not fix issues, apply patches, or suggest that you are about to make changes.
+- Your only job is to run the review and return the merged report verbatim to the user.
+
+Execution rules:
+- A parallel review runs several concurrent Codex turns and costs roughly
+  shard-count × the tokens of a single review. Before launching, check the
+  scope with `git diff --shortstat <base>...HEAD` (or `git diff --shortstat`
+  for working-tree scope) and confirm with the user once if they have not
+  already accepted the cost in this conversation.
+- Always run the command in a Claude background task; a full run takes
+  several minutes end-to-end:
+  `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" parallel-review <arguments>`
+- If the user names concrete invariants the change must uphold (contracts,
+  behaviors that must not regress), write them to a temp file first and pass
+  `--invariants-file <path>` — every shard receives the full list.
+- While it runs, `/codex:status` shows the orchestrator plus its shard tasks;
+  `/codex:cancel <job-id>` on the orchestrator cancels everything it spawned.
+- When it finishes, present the merged report as-is: ranked findings with
+  their verification tags and origin shards, the disproven list, any unparsed
+  shard warnings, and the wall-time table.

--- a/plugins/codex/prompts/parallel-reduce.md
+++ b/plugins/codex/prompts/parallel-reduce.md
@@ -1,0 +1,44 @@
+<role>
+You are Codex performing the INTEGRATION pass of a sharded adversarial review ({{RUN_LABEL}}).
+The change ({{TARGET_LABEL}}) was reviewed by {{SHARD_COUNT}} parallel shards, each seeing ONLY its own files.
+A defect whose cause is in one shard and whose victim is in another is invisible to every shard — finding those is your primary job.
+</role>
+
+<shard_map>
+{{SHARD_MAP}}
+</shard_map>
+
+<merged_findings>
+{{MERGED_FINDINGS}}
+{{UNPARSED_NOTE}}
+</merged_findings>
+
+<seam_hints>
+Mechanical hints extracted from the diff (imports and style tokens crossing shard boundaries):
+{{SEAM_HINTS}}
+</seam_hints>
+
+<seam_checklist>
+For every item, read BOTH sides of the seam before judging — the file that exports/defines/writes and the file that imports/consumes/reads:
+1. Design tokens / global CSS: a token or theme value changed in one shard while other shards' files consume it — including through utility classes or opacity modifiers that never mention the token by name.
+2. Exported functions and types: a signature, nullability, error contract, or return shape changed in one shard while callers or implementers live in another.
+3. Shared state and storage: schema, keys, cache or dedupe keys written by one side and read by the other — especially normalization mismatches (raw vs normalized values used as the same key).
+4. API request/response shapes between a client-side shard and a server-side shard.
+5. Async lifecycles crossing shards: events, queues, gates, or promises where one side can leave the other waiting forever (no-resolve, no-timeout, no-error paths).
+6. Config, env vars, and feature flags set in one place and consumed elsewhere.
+7. Tests in one shard asserting behavior owned by another shard — stale expectations can mask a regression.
+8. i18n/copy keys added or renamed on one side and referenced on the other.
+</seam_checklist>
+
+<method>
+You have read-only repository access — read files and run read-only git commands freely.
+1. Verify each merged finding cheaply against the actual code. Verdicts: CONFIRMED (you independently support it), SUSPECTED (plausible but you could not verify), REJECTED (you can disprove it — say why in the note).
+2. Walk the seam checklist against the shard map and seam hints. Report new cross-shard findings that no single shard could see whole. Spend most of your effort here.
+</method>
+
+<structured_output_contract>
+Return only valid JSON matching the provided schema.
+Include an assessment for EVERY finding id you were given.
+Use an empty `seam_findings` array only after genuinely walking every checklist item.
+Write `summary` as a terse integration verdict for the whole change.
+</structured_output_contract>

--- a/plugins/codex/prompts/parallel-shard-review.md
+++ b/plugins/codex/prompts/parallel-shard-review.md
@@ -1,0 +1,61 @@
+<role>
+You are Codex performing an adversarial software review of ONE SHARD of a larger change ({{RUN_LABEL}}).
+Your job is to break confidence in the change, not to validate it.
+</role>
+
+<shard_scope>
+The full change ({{TARGET_LABEL}}) spans {{SHARD_COUNT}} shards reviewed by parallel peers. You own ONLY these files (shard {{SHARD_ID}}):
+{{FILE_LIST}}
+
+Attack only your own files: findings whose `file` is outside this list will be discarded.
+Exception: if a defect in YOUR files is only provable by reading another file, read it and cite your file as the finding location.
+You have read-only repository access — read any file or run read-only git commands to verify a hypothesis before reporting it.
+</shard_scope>
+
+<shared_invariants>
+Every shard receives this same list. Check each invariant against your files:
+{{SHARED_INVARIANTS}}
+</shared_invariants>
+
+<user_focus>
+{{USER_FOCUS}}
+</user_focus>
+
+<operating_stance>
+Default to skepticism.
+Assume the change can fail in subtle, high-cost, or user-visible ways until the evidence says otherwise.
+Do not give credit for good intent, partial fixes, or likely follow-up work.
+If something only works on the happy path, treat that as a real weakness.
+Prioritize the kinds of failures that are expensive, dangerous, or hard to detect:
+- auth, permissions, tenant isolation, and trust boundaries
+- data loss, corruption, duplication, and irreversible state changes
+- rollback safety, retries, partial failure, and idempotency gaps
+- race conditions, ordering assumptions, stale state, and re-entrancy
+- empty-state, null, timeout, and degraded dependency behavior
+- version skew, schema drift, migration hazards, and compatibility regressions
+- observability gaps that would hide failure or make recovery harder
+</operating_stance>
+
+<finding_bar>
+Report only material findings.
+Do not include style feedback, naming feedback, low-value cleanup, or speculative concerns without evidence.
+A finding should answer:
+1. What can go wrong?
+2. Why is this code path vulnerable?
+3. What is the likely impact?
+4. What concrete change would reduce the risk?
+</finding_bar>
+
+<diff>
+{{REVIEW_INPUT}}
+{{OMITTED_DIFFS}}
+</diff>
+
+<structured_output_contract>
+Return only valid JSON matching the provided schema.
+Keep the output compact and specific.
+Use `needs-attention` if there is any material risk worth blocking on.
+Use `approve` only if you cannot support any substantive adversarial finding from your shard.
+Every finding must cite a file from your shard list, `line_start` and `line_end`, a confidence score from 0 to 1, and a concrete recommendation.
+Write the summary like a terse ship/no-ship assessment for THIS shard only.
+</structured_output_contract>

--- a/plugins/codex/schemas/parallel-reduce-output.schema.json
+++ b/plugins/codex/schemas/parallel-reduce-output.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["summary", "assessments", "seam_findings"],
+  "properties": {
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "assessments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "verdict", "note"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "verdict": {
+            "type": "string",
+            "enum": ["CONFIRMED", "SUSPECTED", "REJECTED"]
+          },
+          "note": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "seam_findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "title", "body", "file", "line_start", "line_end", "confidence", "recommendation"],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["critical", "high", "medium", "low"]
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1
+          },
+          "file": {
+            "type": "string",
+            "minLength": 1
+          },
+          "line_start": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "line_end": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "recommendation": {
+            "type": "string"
+          },
+          "related_files": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -98,6 +98,11 @@ const PARALLEL_RESUME_PROMPT =
   "Your previous review turn was interrupted before you produced the final answer. " +
   "Do not start over. Finish the adversarial review of your shard and return only the " +
   "final JSON object required by the structured output contract you were given earlier.";
+const PARALLEL_REDUCE_RESUME_PROMPT =
+  "Your previous integration turn was interrupted before you produced the final answer. " +
+  "Do not start over. Finish the cross-shard integration pass — assess every finding and " +
+  "hunt seam defects that span shards — and return only the final JSON object required by " +
+  "the structured output contract you were given earlier.";
 const DEFAULT_STATUS_WAIT_TIMEOUT_MS = 240000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
 const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
@@ -970,12 +975,16 @@ async function recoverParallelChild({ cwd, workspaceRoot, child, record, reason,
   // prompt and any analysis done before the crash — resume it instead of
   // paying for a fresh start.
   const threadId = storedJob?.threadId ?? null;
+  // The reduce pass and shard reviews have different jobs to finish; resuming
+  // a reduce thread with the shard prompt would tell it to review "your shard"
+  // and abandon the integration pass.
+  const resumePrompt = child.kind === "reduce" ? PARALLEL_REDUCE_RESUME_PROMPT : PARALLEL_RESUME_PROMPT;
   const job = buildTaskJob(workspaceRoot, { title: child.title, summary: child.summary }, false, { resumable: false });
   const request = buildTaskRequest({
     cwd,
     model: child.model,
     effort: child.effort,
-    prompt: threadId ? PARALLEL_RESUME_PROMPT : child.prompt,
+    prompt: threadId ? resumePrompt : child.prompt,
     write: false,
     resumeLast: false,
     jobId: job.id,

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -1314,9 +1314,14 @@ async function executeParallelReviewRun(request) {
       totals: { wallSec: Math.round((Date.now() - startedAt) / 1000), shardCount: plan.shards.length }
     };
     // A shard that completed but produced non-schema output contributed no
-    // findings — that run is incomplete, not successful.
+    // findings, and a reduce turn that failed can still leave parseable
+    // partial output behind — either way the run is incomplete, not
+    // successful.
     const degraded =
-      shardReports.some((report) => report.status !== "completed") || unparsed.length > 0 || Boolean(reduceReport.error);
+      shardReports.some((report) => report.status !== "completed") ||
+      unparsed.length > 0 ||
+      reduceReport.status !== "completed" ||
+      Boolean(reduceReport.error);
 
     return {
       exitStatus: degraded ? 1 : 0,

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -1316,7 +1316,10 @@ async function handleParallelReview(argv) {
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveCommandWorkspace(options);
   ensureCodexAvailable(cwd);
-  ensureGitRepository(cwd);
+  // Git prints root-relative paths, and shard pathspecs plus seam reads
+  // resolve against the run directory — anchor the whole run at the repo root
+  // so invoking from a subdirectory cannot produce empty shard diffs.
+  const repoRoot = ensureGitRepository(cwd);
 
   const model = normalizeRequestedModel(options.model);
   const effort = normalizeReasoningEffort(options.effort);
@@ -1329,11 +1332,11 @@ async function handleParallelReview(argv) {
     ? fs.readFileSync(path.resolve(cwd, options["invariants-file"]), "utf8")
     : "";
 
-  const target = resolveReviewTarget(cwd, {
+  const target = resolveReviewTarget(repoRoot, {
     base: options.base,
     scope: options.scope
   });
-  const files = collectChangedFiles(cwd, target);
+  const files = collectChangedFiles(repoRoot, target);
   if (files.length === 0) {
     throw new Error(`No changes found for ${target.label}.`);
   }
@@ -1355,11 +1358,17 @@ async function handleParallelReview(argv) {
       job,
       (progress) =>
         executeReviewRun({
-          cwd,
+          cwd: repoRoot,
           base: options.base,
           scope: options.scope,
           model,
-          focusText,
+          // The single fallback must still honor the shared invariant list the
+          // sharded path would have given every shard.
+          focusText: invariantsText
+            ? [focusText, `Shared invariants that must hold for this change:\n${invariantsText.trim()}`]
+                .filter(Boolean)
+                .join("\n\n")
+            : focusText,
           reviewName: "Adversarial Review",
           onProgress: progress
         }),
@@ -1381,7 +1390,7 @@ async function handleParallelReview(argv) {
     job,
     (progress) =>
       executeParallelReviewRun({
-        cwd,
+        cwd: repoRoot,
         workspaceRoot,
         target,
         plan,

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -1209,7 +1209,8 @@ async function executeParallelReviewRun(request) {
         retries: child.retries,
         verdict: null,
         summary: null,
-        findingCount: 0
+        findingCount: 0,
+        outOfScope: 0
       };
       shardReports.push(report);
       const extraction = extractJsonPayload(record?.result?.rawOutput ?? "", (parsed) => Array.isArray(parsed.findings));
@@ -1219,9 +1220,18 @@ async function executeParallelReviewRun(request) {
       }
       report.verdict = extraction.payload.verdict ?? null;
       report.summary = extraction.payload.summary ?? null;
-      report.findingCount = extraction.payload.findings.length;
+      // The shard prompt promises findings outside the shard's file list are
+      // discarded; enforce that here so out-of-lane guesses cannot seed
+      // duplicates — cross-file defects are the reduce pass's job.
+      const ownedPaths = new Set(child.shard.files.map((file) => file.path));
       for (const raw of extraction.payload.findings) {
-        rawFindings.push(normalizeShardFinding(raw, child.shard.id));
+        const finding = normalizeShardFinding(raw, child.shard.id);
+        if (!ownedPaths.has(finding.file.replace(/^\.\//, ""))) {
+          report.outOfScope += 1;
+          continue;
+        }
+        report.findingCount += 1;
+        rawFindings.push(finding);
       }
     }
     const findings = assignFindingIds(mergeFindings(rawFindings));
@@ -1314,13 +1324,14 @@ async function executeParallelReviewRun(request) {
       totals: { wallSec: Math.round((Date.now() - startedAt) / 1000), shardCount: plan.shards.length }
     };
     // A shard that completed but produced non-schema output contributed no
-    // findings, and a reduce turn that failed can still leave parseable
-    // partial output behind — either way the run is incomplete, not
-    // successful.
+    // findings, a failed reduce turn can still leave parseable partial output
+    // behind, and a truncated reduce can parse yet skip finding ids — every
+    // one of those runs is incomplete, not successful.
     const degraded =
       shardReports.some((report) => report.status !== "completed") ||
       unparsed.length > 0 ||
       reduceReport.status !== "completed" ||
+      reduceReport.assessed < findings.length ||
       Boolean(reduceReport.error);
 
     return {

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -85,6 +85,7 @@ const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json"
 const PARALLEL_REDUCE_SCHEMA = path.join(ROOT_DIR, "schemas", "parallel-reduce-output.schema.json");
 const PARALLEL_SPAWN_STAGGER_MS = 3000;
 const PARALLEL_POLL_INTERVAL_MS = 15000;
+const PARALLEL_MAX_SHARDS_LIMIT = 8;
 const PARALLEL_STALL_TIMEOUT_MS = 6 * 60_000;
 // Delta notifications are opted out at initialize, so a live turn can
 // legitimately go minutes without log activity while the model reasons;
@@ -1312,7 +1313,10 @@ async function executeParallelReviewRun(request) {
       seams,
       totals: { wallSec: Math.round((Date.now() - startedAt) / 1000), shardCount: plan.shards.length }
     };
-    const degraded = shardReports.some((report) => report.status !== "completed") || Boolean(reduceReport.error);
+    // A shard that completed but produced non-schema output contributed no
+    // findings — that run is incomplete, not successful.
+    const degraded =
+      shardReports.some((report) => report.status !== "completed") || unparsed.length > 0 || Boolean(reduceReport.error);
 
     return {
       exitStatus: degraded ? 1 : 0,
@@ -1363,7 +1367,13 @@ async function handleParallelReview(argv) {
   const model = normalizeRequestedModel(options.model);
   const effort = normalizeReasoningEffort(options.effort);
   const reduceEffort = normalizeReasoningEffort(options["reduce-effort"]) ?? "low";
-  const maxShards = Math.max(2, Number.parseInt(options["max-shards"] ?? `${DEFAULT_MAX_SHARDS}`, 10) || DEFAULT_MAX_SHARDS);
+  // Every shard costs jobs (two attempts each, plus the reduce and the parent
+  // record) against the workspace's 50-slot retention cap; the clamp keeps a
+  // worst-case run well inside it.
+  const maxShards = Math.min(
+    PARALLEL_MAX_SHARDS_LIMIT,
+    Math.max(2, Number.parseInt(options["max-shards"] ?? `${DEFAULT_MAX_SHARDS}`, 10) || DEFAULT_MAX_SHARDS)
+  );
   const timeoutMs =
     Math.max(1, Number.parseInt(options["timeout-min"] ?? `${DEFAULT_PARALLEL_TIMEOUT_MIN}`, 10) || DEFAULT_PARALLEL_TIMEOUT_MIN) * 60_000;
   const focusText = positionals.join(" ").trim();

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -86,6 +86,10 @@ const PARALLEL_REDUCE_SCHEMA = path.join(ROOT_DIR, "schemas", "parallel-reduce-o
 const PARALLEL_SPAWN_STAGGER_MS = 3000;
 const PARALLEL_POLL_INTERVAL_MS = 15000;
 const PARALLEL_STALL_TIMEOUT_MS = 6 * 60_000;
+// Delta notifications are opted out at initialize, so a live turn can
+// legitimately go minutes without log activity while the model reasons;
+// only a much longer silence marks a live-pid worker as hung.
+const PARALLEL_LIVE_STALL_TIMEOUT_MS = 15 * 60_000;
 const PARALLEL_PENDING_GRACE_MS = 90_000;
 const PARALLEL_MAX_RETRIES_PER_SHARD = 1;
 const DEFAULT_PARALLEL_TIMEOUT_MIN = 45;
@@ -336,6 +340,7 @@ function findLatestResumableTaskJob(jobs) {
     jobs.find(
       (job) =>
         job.jobClass === "task" &&
+        job.resumable !== false &&
         job.threadId &&
         job.status !== "queued" &&
         job.status !== "running"
@@ -366,7 +371,9 @@ async function resolveLatestTrackedTaskThread(cwd, options = {}) {
   const sessionId = getCurrentClaudeSessionId();
   const jobs = sortJobsNewestFirst(listJobs(workspaceRoot)).filter((job) => job.id !== options.excludeJobId);
   const visibleJobs = filterJobsForCurrentClaudeSession(jobs);
-  const activeTask = visibleJobs.find((job) => job.jobClass === "task" && (job.status === "queued" || job.status === "running"));
+  const activeTask = visibleJobs.find(
+    (job) => job.jobClass === "task" && job.resumable !== false && (job.status === "queued" || job.status === "running")
+  );
   if (activeTask) {
     throw new Error(`Task ${activeTask.id} is still running. Use /codex:status before continuing it.`);
   }
@@ -523,7 +530,9 @@ async function executeTaskRun(request) {
     ...(request.outputSchema ? { outputSchema: request.outputSchema } : {}),
     onProgress: request.onProgress,
     persistThread: true,
-    threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
+    // Internal jobs (parallel shards/reduce) override the name so the
+    // TASK_THREAD_PREFIX search in findLatestTaskThread never matches them.
+    threadName: resumeThreadId ? null : (request.threadName ?? buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT))
   });
 
   const rawOutput = typeof result.finalMessage === "string" ? result.finalMessage : "";
@@ -599,7 +608,7 @@ function getJobKindLabel(kind, jobClass) {
   return jobClass === "review" ? "review" : "rescue";
 }
 
-function createCompanionJob({ prefix, kind, title, workspaceRoot, jobClass, summary, write = false }) {
+function createCompanionJob({ prefix, kind, title, workspaceRoot, jobClass, summary, write = false, resumable = true }) {
   return createJobRecord({
     id: generateJobId(prefix),
     kind,
@@ -608,7 +617,8 @@ function createCompanionJob({ prefix, kind, title, workspaceRoot, jobClass, summ
     workspaceRoot,
     jobClass,
     summary,
-    write
+    write,
+    ...(resumable ? {} : { resumable: false })
   });
 }
 
@@ -624,7 +634,7 @@ function createTrackedProgress(job, options = {}) {
   };
 }
 
-function buildTaskJob(workspaceRoot, taskMetadata, write) {
+function buildTaskJob(workspaceRoot, taskMetadata, write, options = {}) {
   return createCompanionJob({
     prefix: "task",
     kind: "task",
@@ -632,11 +642,12 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
     workspaceRoot,
     jobClass: "task",
     summary: taskMetadata.summary,
-    write
+    write,
+    resumable: options.resumable ?? true
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId, threadName }) {
   return {
     cwd,
     model,
@@ -644,7 +655,8 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     prompt,
     write,
     resumeLast,
-    jobId
+    jobId,
+    ...(threadName ? { threadName } : {})
   };
 }
 
@@ -957,7 +969,7 @@ async function recoverParallelChild({ cwd, workspaceRoot, child, record, reason,
   // prompt and any analysis done before the crash — resume it instead of
   // paying for a fresh start.
   const threadId = storedJob?.threadId ?? null;
-  const job = buildTaskJob(workspaceRoot, { title: child.title, summary: child.summary }, false);
+  const job = buildTaskJob(workspaceRoot, { title: child.title, summary: child.summary }, false, { resumable: false });
   const request = buildTaskRequest({
     cwd,
     model: child.model,
@@ -965,7 +977,8 @@ async function recoverParallelChild({ cwd, workspaceRoot, child, record, reason,
     prompt: threadId ? PARALLEL_RESUME_PROMPT : child.prompt,
     write: false,
     resumeLast: false,
-    jobId: job.id
+    jobId: job.id,
+    threadName: child.title
   });
   if (threadId) {
     request.resumeThreadId = threadId;
@@ -1022,10 +1035,11 @@ async function superviseParallelJobs({ cwd, workspaceRoot, children, deadline, o
       }
 
       // The job record can say "running" long after the worker died; trust the
-      // OS over the record, and treat a silent log as a hung turn. "queued" is
-      // normally a sub-second window before the worker flips to "running", so a
-      // queued record whose log has been silent this long is a wedged startup
-      // (or a lost status write) and gets the same recovery.
+      // OS over the record. A silent log marks a hung turn, but a live "running"
+      // worker gets the long threshold — reasoning stretches emit no events.
+      // "queued" is normally a sub-second window before the worker flips to
+      // "running", so a queued record silent past the short threshold is a
+      // wedged startup (or a lost status write) and gets recovered sooner.
       const pidDead = record.pid != null && !isPidAlive(record.pid);
       let stalled = false;
       if (
@@ -1034,7 +1048,19 @@ async function superviseParallelJobs({ cwd, workspaceRoot, children, deadline, o
         record.logFile &&
         fs.existsSync(record.logFile)
       ) {
-        stalled = Date.now() - fs.statSync(record.logFile).mtimeMs > PARALLEL_STALL_TIMEOUT_MS;
+        const silentMs = Date.now() - fs.statSync(record.logFile).mtimeMs;
+        const stallLimitMs = record.status === "queued" ? PARALLEL_STALL_TIMEOUT_MS : PARALLEL_LIVE_STALL_TIMEOUT_MS;
+        stalled = silentMs > stallLimitMs;
+        if (!stalled && record.status === "running" && silentMs > PARALLEL_STALL_TIMEOUT_MS) {
+          if (!child.stallWarned) {
+            child.stallWarned = true;
+            onProgress?.({
+              message: `${child.label}: no log progress for ${Math.round(silentMs / 60_000)}m; worker is still alive — recovering only after ${Math.round(PARALLEL_LIVE_STALL_TIMEOUT_MS / 60_000)}m of silence.`
+            });
+          }
+        } else if (silentMs <= PARALLEL_STALL_TIMEOUT_MS) {
+          child.stallWarned = false;
+        }
       }
       if (pidDead || stalled) {
         await recoverParallelChild({
@@ -1123,8 +1149,19 @@ async function executeParallelReviewRun(request) {
       });
       const title = `Codex Parallel Shard ${shard.id}`;
       const summary = `Shard ${shard.id}: ${shard.files.length} files of ${target.label}`;
-      const job = buildTaskJob(workspaceRoot, { title, summary }, false);
-      const taskRequest = buildTaskRequest({ cwd, model, effort, prompt, write: false, resumeLast: false, jobId: job.id });
+      // Shard and reduce jobs are internal to this run; they must never win
+      // the task --resume-last lookup or block it as an active user task.
+      const job = buildTaskJob(workspaceRoot, { title, summary }, false, { resumable: false });
+      const taskRequest = buildTaskRequest({
+        cwd,
+        model,
+        effort,
+        prompt,
+        write: false,
+        resumeLast: false,
+        jobId: job.id,
+        threadName: title
+      });
       taskRequest.outputSchema = shardSchema;
       children.push({
         kind: "shard",
@@ -1203,7 +1240,8 @@ async function executeParallelReviewRun(request) {
     const reduceJob = buildTaskJob(
       workspaceRoot,
       { title: "Codex Parallel Reduce", summary: `Integration pass over ${findings.length} findings` },
-      false
+      false,
+      { resumable: false }
     );
     const reduceRequest = buildTaskRequest({
       cwd,
@@ -1212,7 +1250,8 @@ async function executeParallelReviewRun(request) {
       prompt: reducePrompt,
       write: false,
       resumeLast: false,
-      jobId: reduceJob.id
+      jobId: reduceJob.id,
+      threadName: "Codex Parallel Reduce"
     });
     reduceRequest.outputSchema = reduceSchema;
     const reduceChild = {

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -40,6 +40,7 @@ import {
   mergeFindings,
   normalizeShardFinding,
   planShards,
+  readReviewedFileContent,
   renderParallelReviewResult
 } from "./lib/parallel-review.mjs";
 import {
@@ -1109,19 +1110,9 @@ async function executeParallelReviewRun(request) {
   const seams = extractSeamHints({
     files: plan.files,
     shards: plan.shards,
-    readFileContent: (relativePath) => {
-      try {
-        const absolute = path.join(cwd, relativePath);
-        // Seam scanning is a heuristic; skip pathological files (generated
-        // bundles) rather than loading them whole.
-        if (fs.statSync(absolute).size > 1_000_000) {
-          return null;
-        }
-        return fs.readFileSync(absolute, "utf8");
-      } catch {
-        return null;
-      }
-    }
+    // Read seam inputs from the reviewed snapshot (HEAD for a branch review,
+    // staged + worktree for a working-tree review), matching the shard diffs.
+    readFileContent: (relativePath) => readReviewedFileContent(cwd, target, relativePath)
   });
   const shardSchema = readOutputSchema(REVIEW_SCHEMA);
   const reduceSchema = readOutputSchema(PARALLEL_REDUCE_SCHEMA);

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -1102,7 +1102,13 @@ async function executeParallelReviewRun(request) {
     shards: plan.shards,
     readFileContent: (relativePath) => {
       try {
-        return fs.readFileSync(path.join(cwd, relativePath), "utf8");
+        const absolute = path.join(cwd, relativePath);
+        // Seam scanning is a heuristic; skip pathological files (generated
+        // bundles) rather than loading them whole.
+        if (fs.statSync(absolute).size > 1_000_000) {
+          return null;
+        }
+        return fs.readFileSync(absolute, "utf8");
       } catch {
         return null;
       }
@@ -1213,7 +1219,16 @@ async function executeParallelReviewRun(request) {
         outOfScope: 0
       };
       shardReports.push(report);
-      const extraction = extractJsonPayload(record?.result?.rawOutput ?? "", (parsed) => Array.isArray(parsed.findings));
+      // Mirror the review schema's required contract: a truncated object that
+      // parses but lacks required fields is a dropped shard, not a clean one.
+      const extraction = extractJsonPayload(
+        record?.result?.rawOutput ?? "",
+        (parsed) =>
+          typeof parsed.verdict === "string" &&
+          typeof parsed.summary === "string" &&
+          Array.isArray(parsed.findings) &&
+          Array.isArray(parsed.next_steps)
+      );
       if (!extraction.payload) {
         unparsed.push({ shard: child.shard.id, jobId: child.jobId, error: extraction.error });
         continue;
@@ -1299,9 +1314,12 @@ async function executeParallelReviewRun(request) {
       seamFindingCount: 0
     };
     let seamFindings = [];
+    // The reduce contract requires all three fields; an explicit (possibly
+    // empty) seam_findings array is the evidence the seam hunt actually ran.
     const reduceExtraction = extractJsonPayload(
       reduceRecord?.result?.rawOutput ?? "",
-      (parsed) => Array.isArray(parsed.assessments) || Array.isArray(parsed.seam_findings)
+      (parsed) =>
+        typeof parsed.summary === "string" && Array.isArray(parsed.assessments) && Array.isArray(parsed.seam_findings)
     );
     if (reduceExtraction.payload) {
       const outcome = applyReduceOutcome(findings, reduceExtraction.payload);

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -919,10 +919,25 @@ function isTerminalJobStatus(status) {
   return status === "completed" || status === "failed" || status === "cancelled";
 }
 
-async function recoverParallelChild({ cwd, workspaceRoot, child, record, reason, onProgress }) {
+async function recoverParallelChild({ cwd, workspaceRoot, child, record, reason, onChildrenChanged, onProgress }) {
   if (child.retries >= PARALLEL_MAX_RETRIES_PER_SHARD) {
     child.terminal = true;
     child.finalStatus = `unrecovered (${reason})`;
+    // A stalled worker can still be alive; stop it now instead of letting it
+    // burn tokens until the orchestrator exits.
+    const abandonedJob = record ?? readStoredJob(workspaceRoot, child.jobId);
+    if (abandonedJob && !isTerminalJobStatus(abandonedJob.status)) {
+      try {
+        await cancelJobRecord(
+          cwd,
+          workspaceRoot,
+          abandonedJob,
+          "Cancelled by the parallel-review supervisor after its retry budget was exhausted."
+        );
+      } catch {
+        // Best-effort; the exit teardown sweeps every attempt again.
+      }
+    }
     onProgress?.({ message: `${child.label}: ${reason}; retry budget exhausted.` });
     return;
   }
@@ -956,14 +971,16 @@ async function recoverParallelChild({ cwd, workspaceRoot, child, record, reason,
     request.resumeThreadId = threadId;
   }
   request.outputSchema = child.outputSchema;
-  enqueueBackgroundTask(cwd, job, request);
   child.jobId = job.id;
   child.jobIds.push(job.id);
   child.lastSpawnAt = Date.now();
+  // Persist before the spawn so a cancel can never race it.
+  onChildrenChanged?.();
+  enqueueBackgroundTask(cwd, job, request);
   onProgress?.({ message: `${child.label}: ${threadId ? "resumed its thread" : "respawned fresh"} as ${job.id}.` });
 }
 
-async function superviseParallelJobs({ cwd, workspaceRoot, children, deadline, onProgress }) {
+async function superviseParallelJobs({ cwd, workspaceRoot, children, deadline, onChildrenChanged, onProgress }) {
   for (;;) {
     let active = 0;
     for (const child of children) {
@@ -978,7 +995,15 @@ async function superviseParallelJobs({ cwd, workspaceRoot, children, deadline, o
         if (Date.now() - child.lastSpawnAt < PARALLEL_PENDING_GRACE_MS) {
           active += 1;
         } else {
-          await recoverParallelChild({ cwd, workspaceRoot, child, record: null, reason: "its job record disappeared", onProgress });
+          await recoverParallelChild({
+            cwd,
+            workspaceRoot,
+            child,
+            record: null,
+            reason: "its job record disappeared",
+            onChildrenChanged,
+            onProgress
+          });
           if (!child.terminal) {
             active += 1;
           }
@@ -997,10 +1022,18 @@ async function superviseParallelJobs({ cwd, workspaceRoot, children, deadline, o
       }
 
       // The job record can say "running" long after the worker died; trust the
-      // OS over the record, and treat a silent log as a hung turn.
+      // OS over the record, and treat a silent log as a hung turn. "queued" is
+      // normally a sub-second window before the worker flips to "running", so a
+      // queued record whose log has been silent this long is a wedged startup
+      // (or a lost status write) and gets the same recovery.
       const pidDead = record.pid != null && !isPidAlive(record.pid);
       let stalled = false;
-      if (!pidDead && record.status === "running" && record.logFile && fs.existsSync(record.logFile)) {
+      if (
+        !pidDead &&
+        (record.status === "running" || record.status === "queued") &&
+        record.logFile &&
+        fs.existsSync(record.logFile)
+      ) {
         stalled = Date.now() - fs.statSync(record.logFile).mtimeMs > PARALLEL_STALL_TIMEOUT_MS;
       }
       if (pidDead || stalled) {
@@ -1010,6 +1043,7 @@ async function superviseParallelJobs({ cwd, workspaceRoot, children, deadline, o
           child,
           record,
           reason: pidDead ? "its worker process is dead while the job still reports running" : "it has made no log progress",
+          onChildrenChanged,
           onProgress
         });
         if (!child.terminal) {
@@ -1053,6 +1087,23 @@ async function executeParallelReviewRun(request) {
   const deadline = startedAt + timeoutMs;
   const children = [];
 
+  // /codex:cancel on the orchestrator kills this process before the finally
+  // teardown can run; the persisted list lets cancelJobRecord cascade to the
+  // detached shard/reduce workers instead of orphaning them.
+  const persistChildJobIds = () => {
+    if (!request.jobId) {
+      return;
+    }
+    const stored = readStoredJob(workspaceRoot, request.jobId);
+    if (!stored) {
+      return;
+    }
+    writeJobFile(workspaceRoot, request.jobId, {
+      ...stored,
+      childJobIds: children.flatMap((child) => child.jobIds)
+    });
+  };
+
   onProgress?.({
     message: `Sharding ${plan.fileCount} files (~${plan.totalLines} changed lines) into ${plan.shards.length} concurrent reviews.`,
     phase: "starting"
@@ -1075,7 +1126,6 @@ async function executeParallelReviewRun(request) {
       const job = buildTaskJob(workspaceRoot, { title, summary }, false);
       const taskRequest = buildTaskRequest({ cwd, model, effort, prompt, write: false, resumeLast: false, jobId: job.id });
       taskRequest.outputSchema = shardSchema;
-      enqueueBackgroundTask(cwd, job, taskRequest);
       children.push({
         kind: "shard",
         shard,
@@ -1095,6 +1145,10 @@ async function executeParallelReviewRun(request) {
         finalStatus: null,
         record: null
       });
+      // Persist before the spawn so a cancel can never race it; an id whose
+      // spawn failed has no record and the cascade skips it.
+      persistChildJobIds();
+      enqueueBackgroundTask(cwd, job, taskRequest);
       onProgress?.({ message: `Spawned shard ${shard.id} (${shard.files.length} files, ~${shard.weight} lines) as ${job.id}.` });
       if (shard !== plan.shards[plan.shards.length - 1]) {
         // Concurrent job-state writers race; give each enqueue a head start.
@@ -1102,7 +1156,7 @@ async function executeParallelReviewRun(request) {
       }
     }
 
-    await superviseParallelJobs({ cwd, workspaceRoot, children, deadline, onProgress });
+    await superviseParallelJobs({ cwd, workspaceRoot, children, deadline, onChildrenChanged: persistChildJobIds, onProgress });
 
     const rawFindings = [];
     const unparsed = [];
@@ -1161,7 +1215,6 @@ async function executeParallelReviewRun(request) {
       jobId: reduceJob.id
     });
     reduceRequest.outputSchema = reduceSchema;
-    enqueueBackgroundTask(cwd, reduceJob, reduceRequest);
     const reduceChild = {
       kind: "reduce",
       shard: { id: "reduce", files: [] },
@@ -1182,7 +1235,9 @@ async function executeParallelReviewRun(request) {
       record: null
     };
     children.push(reduceChild);
-    await superviseParallelJobs({ cwd, workspaceRoot, children, deadline, onProgress });
+    persistChildJobIds();
+    enqueueBackgroundTask(cwd, reduceJob, reduceRequest);
+    await superviseParallelJobs({ cwd, workspaceRoot, children, deadline, onChildrenChanged: persistChildJobIds, onProgress });
 
     const reduceRecord = reduceChild.record ?? readStoredJob(workspaceRoot, reduceChild.jobId);
     const reduceReport = {
@@ -1231,16 +1286,18 @@ async function executeParallelReviewRun(request) {
     };
   } finally {
     // Never exit with children still queued or running, whatever went wrong.
+    // Sweep every attempt (child.jobIds), not just the latest: a recovery whose
+    // cancel failed, or a child marked terminal while its worker is still
+    // alive, would otherwise escape teardown.
     for (const child of children) {
-      if (child.terminal) {
-        continue;
-      }
-      const record = readStoredJob(workspaceRoot, child.jobId);
-      if (record && !isTerminalJobStatus(record.status)) {
-        try {
-          await cancelJobRecord(cwd, workspaceRoot, record, "Cancelled because the parallel-review orchestrator exited.");
-        } catch {
-          // Best-effort teardown.
+      for (const attemptJobId of child.jobIds) {
+        const record = readStoredJob(workspaceRoot, attemptJobId);
+        if (record && !isTerminalJobStatus(record.status)) {
+          try {
+            await cancelJobRecord(cwd, workspaceRoot, record, "Cancelled because the parallel-review orchestrator exited.");
+          } catch {
+            // Best-effort teardown.
+          }
         }
       }
     }
@@ -1421,7 +1478,8 @@ function handleTaskResumeCandidate(argv) {
   outputCommandResult(payload, rendered, options.json);
 }
 
-async function cancelJobRecord(cwd, workspaceRoot, job, reason = "Cancelled by user.") {
+async function cancelJobRecord(cwd, workspaceRoot, job, reason = "Cancelled by user.", cancelledIds = new Set()) {
+  cancelledIds.add(job.id);
   const existing = readStoredJob(workspaceRoot, job.id) ?? {};
   const threadId = existing.threadId ?? job.threadId ?? null;
   const turnId = existing.turnId ?? job.turnId ?? null;
@@ -1440,6 +1498,10 @@ async function cancelJobRecord(cwd, workspaceRoot, job, reason = "Cancelled by u
   terminateProcessTree(job.pid ?? existing.pid ?? Number.NaN);
   appendLogLine(logFile, reason);
 
+  // Re-read after the terminate: a parallel-review orchestrator may have
+  // persisted more child job ids between the first read and its death.
+  const latest = readStoredJob(workspaceRoot, job.id) ?? existing;
+
   const completedAt = nowIso();
   const nextJob = {
     ...job,
@@ -1451,7 +1513,7 @@ async function cancelJobRecord(cwd, workspaceRoot, job, reason = "Cancelled by u
   };
 
   writeJobFile(workspaceRoot, job.id, {
-    ...existing,
+    ...latest,
     ...nextJob,
     cancelledAt: completedAt
   });
@@ -1463,6 +1525,24 @@ async function cancelJobRecord(cwd, workspaceRoot, job, reason = "Cancelled by u
     errorMessage: reason,
     completedAt
   });
+
+  // A cancelled parallel-review orchestrator dies before its own teardown can
+  // run, and its shard/reduce workers are detached processes that survive the
+  // tree kill above — cancel them from the persisted child list.
+  const childJobIds = Array.isArray(latest.childJobIds) ? latest.childJobIds : [];
+  for (const childJobId of childJobIds) {
+    if (cancelledIds.has(childJobId)) {
+      continue;
+    }
+    const childRecord = readStoredJob(workspaceRoot, childJobId);
+    if (childRecord && !isTerminalJobStatus(childRecord.status)) {
+      try {
+        await cancelJobRecord(cwd, workspaceRoot, childRecord, "Cancelled with its parallel-review parent.", cancelledIds);
+      } catch {
+        // Best-effort cascade; remaining children stay visible in status.
+      }
+    }
+  }
 
   return { nextJob, interrupt };
 }

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -41,7 +41,8 @@ import {
   normalizeShardFinding,
   planShards,
   readReviewedFileContent,
-  renderParallelReviewResult
+  renderParallelReviewResult,
+  resolveOwnedFindingPath
 } from "./lib/parallel-review.mjs";
 import {
   generateJobId,
@@ -1241,10 +1242,14 @@ async function executeParallelReviewRun(request) {
       const ownedPaths = new Set(child.shard.files.map((file) => file.path));
       for (const raw of extraction.payload.findings) {
         const finding = normalizeShardFinding(raw, child.shard.id);
-        if (!ownedPaths.has(finding.file.replace(/^\.\//, ""))) {
+        const ownedPath = resolveOwnedFindingPath(ownedPaths, finding.file);
+        if (!ownedPath) {
           report.outOfScope += 1;
           continue;
         }
+        // Normalize any diff-prefixed citation back to the owned path so dedupe
+        // and the reduce pass see a consistent path.
+        finding.file = ownedPath;
         report.findingCount += 1;
         rawFindings.push(finding);
       }

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -24,8 +24,24 @@ import {
 import { resolveClaudeSessionPath } from "./lib/claude-session-transfer.mjs";
 import { readStdinIfPiped } from "./lib/fs.mjs";
 import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./lib/git.mjs";
-import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
+import { binaryAvailable, isPidAlive, terminateProcessTree } from "./lib/process.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
+import {
+  applyReduceOutcome,
+  assignFindingIds,
+  buildReducePrompt,
+  buildShardDiff,
+  buildShardPrompt,
+  bySeverityThenConfidence,
+  collectChangedFiles,
+  DEFAULT_MAX_SHARDS,
+  extractJsonPayload,
+  extractSeamHints,
+  mergeFindings,
+  normalizeShardFinding,
+  planShards,
+  renderParallelReviewResult
+} from "./lib/parallel-review.mjs";
 import {
   generateJobId,
   getConfig,
@@ -66,6 +82,17 @@ import {
 
 const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json");
+const PARALLEL_REDUCE_SCHEMA = path.join(ROOT_DIR, "schemas", "parallel-reduce-output.schema.json");
+const PARALLEL_SPAWN_STAGGER_MS = 3000;
+const PARALLEL_POLL_INTERVAL_MS = 15000;
+const PARALLEL_STALL_TIMEOUT_MS = 6 * 60_000;
+const PARALLEL_PENDING_GRACE_MS = 90_000;
+const PARALLEL_MAX_RETRIES_PER_SHARD = 1;
+const DEFAULT_PARALLEL_TIMEOUT_MIN = 45;
+const PARALLEL_RESUME_PROMPT =
+  "Your previous review turn was interrupted before you produced the final answer. " +
+  "Do not start over. Finish the adversarial review of your shard and return only the " +
+  "final JSON object required by the structured output contract you were given earlier.";
 const DEFAULT_STATUS_WAIT_TIMEOUT_MS = 240000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
 const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
@@ -79,6 +106,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
+      "  node scripts/codex-companion.mjs parallel-review [--base <ref>] [--scope <auto|working-tree|branch>] [--max-shards 4] [--invariants-file <path>] [--reduce-effort low] [--timeout-min 45] [focus text]",
       "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
@@ -467,8 +495,11 @@ async function executeTaskRun(request) {
     resumeLast: request.resumeLast
   });
 
-  let resumeThreadId = null;
-  if (request.resumeLast) {
+  // An explicit thread id (e.g. from the parallel-review supervisor resuming a
+  // dead shard) wins over the session-scoped latest-thread lookup, which is
+  // ambiguous when several tasks are in flight.
+  let resumeThreadId = request.resumeThreadId ?? null;
+  if (!resumeThreadId && request.resumeLast) {
     const latestThread = await resolveLatestTrackedTaskThread(workspaceRoot, {
       excludeJobId: request.jobId
     });
@@ -489,6 +520,7 @@ async function executeTaskRun(request) {
     model: request.model,
     effort: request.effort,
     sandbox: request.write ? "workspace-write" : "read-only",
+    ...(request.outputSchema ? { outputSchema: request.outputSchema } : {}),
     onProgress: request.onProgress,
     persistThread: true,
     threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
@@ -560,6 +592,9 @@ function renderQueuedTaskLaunch(payload) {
 function getJobKindLabel(kind, jobClass) {
   if (kind === "adversarial-review") {
     return "adversarial-review";
+  }
+  if (kind === "parallel-review") {
+    return "parallel-review";
   }
   return jobClass === "review" ? "review" : "rescue";
 }
@@ -880,6 +915,432 @@ async function handleTaskWorker(argv) {
   );
 }
 
+function isTerminalJobStatus(status) {
+  return status === "completed" || status === "failed" || status === "cancelled";
+}
+
+async function recoverParallelChild({ cwd, workspaceRoot, child, record, reason, onProgress }) {
+  if (child.retries >= PARALLEL_MAX_RETRIES_PER_SHARD) {
+    child.terminal = true;
+    child.finalStatus = `unrecovered (${reason})`;
+    onProgress?.({ message: `${child.label}: ${reason}; retry budget exhausted.` });
+    return;
+  }
+  child.retries += 1;
+  onProgress?.({ message: `${child.label}: ${reason}; recovering (attempt ${child.retries}/${PARALLEL_MAX_RETRIES_PER_SHARD}).` });
+
+  const storedJob = record ?? readStoredJob(workspaceRoot, child.jobId);
+  if (storedJob) {
+    try {
+      await cancelJobRecord(cwd, workspaceRoot, storedJob, "Cancelled by the parallel-review supervisor after the worker stopped responding.");
+    } catch {
+      // The worker may already be gone; respawning below is what matters.
+    }
+  }
+
+  // A persisted thread id means the Codex thread still holds the original
+  // prompt and any analysis done before the crash — resume it instead of
+  // paying for a fresh start.
+  const threadId = storedJob?.threadId ?? null;
+  const job = buildTaskJob(workspaceRoot, { title: child.title, summary: child.summary }, false);
+  const request = buildTaskRequest({
+    cwd,
+    model: child.model,
+    effort: child.effort,
+    prompt: threadId ? PARALLEL_RESUME_PROMPT : child.prompt,
+    write: false,
+    resumeLast: false,
+    jobId: job.id
+  });
+  if (threadId) {
+    request.resumeThreadId = threadId;
+  }
+  request.outputSchema = child.outputSchema;
+  enqueueBackgroundTask(cwd, job, request);
+  child.jobId = job.id;
+  child.jobIds.push(job.id);
+  child.lastSpawnAt = Date.now();
+  onProgress?.({ message: `${child.label}: ${threadId ? "resumed its thread" : "respawned fresh"} as ${job.id}.` });
+}
+
+async function superviseParallelJobs({ cwd, workspaceRoot, children, deadline, onProgress }) {
+  for (;;) {
+    let active = 0;
+    for (const child of children) {
+      if (child.terminal) {
+        continue;
+      }
+      const record = readStoredJob(workspaceRoot, child.jobId);
+
+      if (!record) {
+        // Right after enqueueing, the detached worker may not have written its
+        // job file yet; that is pending, not dead.
+        if (Date.now() - child.lastSpawnAt < PARALLEL_PENDING_GRACE_MS) {
+          active += 1;
+        } else {
+          await recoverParallelChild({ cwd, workspaceRoot, child, record: null, reason: "its job record disappeared", onProgress });
+          if (!child.terminal) {
+            active += 1;
+          }
+        }
+        continue;
+      }
+
+      if (isTerminalJobStatus(record.status)) {
+        child.terminal = true;
+        child.finalStatus = record.status;
+        child.record = record;
+        const completedAt = record.completedAt ? Date.parse(record.completedAt) : Date.now();
+        child.wallSec = Math.max(0, Math.round((completedAt - child.firstSpawnAt) / 1000));
+        onProgress?.({ message: `${child.label}: ${record.status} after ${child.wallSec}s.` });
+        continue;
+      }
+
+      // The job record can say "running" long after the worker died; trust the
+      // OS over the record, and treat a silent log as a hung turn.
+      const pidDead = record.pid != null && !isPidAlive(record.pid);
+      let stalled = false;
+      if (!pidDead && record.status === "running" && record.logFile && fs.existsSync(record.logFile)) {
+        stalled = Date.now() - fs.statSync(record.logFile).mtimeMs > PARALLEL_STALL_TIMEOUT_MS;
+      }
+      if (pidDead || stalled) {
+        await recoverParallelChild({
+          cwd,
+          workspaceRoot,
+          child,
+          record,
+          reason: pidDead ? "its worker process is dead while the job still reports running" : "it has made no log progress",
+          onProgress
+        });
+        if (!child.terminal) {
+          active += 1;
+        }
+        continue;
+      }
+
+      active += 1;
+    }
+
+    if (active === 0) {
+      return;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        "Parallel review timed out with jobs still active; they are being cancelled. Rerun with a longer --timeout-min or fewer shards."
+      );
+    }
+    await sleep(PARALLEL_POLL_INTERVAL_MS);
+  }
+}
+
+async function executeParallelReviewRun(request) {
+  const { cwd, workspaceRoot, target, plan, focusText, invariantsText, model, effort, reduceEffort, timeoutMs, onProgress } = request;
+  const runLabel = request.jobId ? `parallel-review ${request.jobId}` : "parallel-review";
+  const seams = extractSeamHints({
+    files: plan.files,
+    shards: plan.shards,
+    readFileContent: (relativePath) => {
+      try {
+        return fs.readFileSync(path.join(cwd, relativePath), "utf8");
+      } catch {
+        return null;
+      }
+    }
+  });
+  const shardSchema = readOutputSchema(REVIEW_SCHEMA);
+  const reduceSchema = readOutputSchema(PARALLEL_REDUCE_SCHEMA);
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutMs;
+  const children = [];
+
+  onProgress?.({
+    message: `Sharding ${plan.fileCount} files (~${plan.totalLines} changed lines) into ${plan.shards.length} concurrent reviews.`,
+    phase: "starting"
+  });
+
+  try {
+    for (const shard of plan.shards) {
+      const diff = buildShardDiff(cwd, target, shard);
+      const prompt = buildShardPrompt(ROOT_DIR, {
+        runLabel,
+        shard,
+        shardCount: plan.shards.length,
+        targetLabel: target.label,
+        invariantsText,
+        focusText,
+        diff
+      });
+      const title = `Codex Parallel Shard ${shard.id}`;
+      const summary = `Shard ${shard.id}: ${shard.files.length} files of ${target.label}`;
+      const job = buildTaskJob(workspaceRoot, { title, summary }, false);
+      const taskRequest = buildTaskRequest({ cwd, model, effort, prompt, write: false, resumeLast: false, jobId: job.id });
+      taskRequest.outputSchema = shardSchema;
+      enqueueBackgroundTask(cwd, job, taskRequest);
+      children.push({
+        kind: "shard",
+        shard,
+        label: `Shard ${shard.id}`,
+        title,
+        summary,
+        jobId: job.id,
+        jobIds: [job.id],
+        prompt,
+        outputSchema: shardSchema,
+        model,
+        effort,
+        firstSpawnAt: Date.now(),
+        lastSpawnAt: Date.now(),
+        retries: 0,
+        terminal: false,
+        finalStatus: null,
+        record: null
+      });
+      onProgress?.({ message: `Spawned shard ${shard.id} (${shard.files.length} files, ~${shard.weight} lines) as ${job.id}.` });
+      if (shard !== plan.shards[plan.shards.length - 1]) {
+        // Concurrent job-state writers race; give each enqueue a head start.
+        await sleep(PARALLEL_SPAWN_STAGGER_MS);
+      }
+    }
+
+    await superviseParallelJobs({ cwd, workspaceRoot, children, deadline, onProgress });
+
+    const rawFindings = [];
+    const unparsed = [];
+    const shardReports = [];
+    for (const child of children) {
+      const record = child.record ?? readStoredJob(workspaceRoot, child.jobId);
+      const report = {
+        shard: child.shard.id,
+        jobId: child.jobId,
+        status: child.finalStatus ?? "unknown",
+        wallSec: child.wallSec ?? null,
+        retries: child.retries,
+        verdict: null,
+        summary: null,
+        findingCount: 0
+      };
+      shardReports.push(report);
+      const extraction = extractJsonPayload(record?.result?.rawOutput ?? "", (parsed) => Array.isArray(parsed.findings));
+      if (!extraction.payload) {
+        unparsed.push({ shard: child.shard.id, jobId: child.jobId, error: extraction.error });
+        continue;
+      }
+      report.verdict = extraction.payload.verdict ?? null;
+      report.summary = extraction.payload.summary ?? null;
+      report.findingCount = extraction.payload.findings.length;
+      for (const raw of extraction.payload.findings) {
+        rawFindings.push(normalizeShardFinding(raw, child.shard.id));
+      }
+    }
+    const findings = assignFindingIds(mergeFindings(rawFindings));
+
+    // The reduce pass is mandatory even when every shard approved: a defect
+    // whose cause is in one shard and whose victim is in another is invisible
+    // to both, and only this pass reads across the boundary.
+    onProgress?.({ message: `Merged ${findings.length} findings; starting the cross-shard integration pass.`, phase: "reviewing" });
+    const reducePrompt = buildReducePrompt(ROOT_DIR, {
+      runLabel,
+      targetLabel: target.label,
+      shards: plan.shards,
+      findings,
+      seams,
+      unparsedCount: unparsed.length
+    });
+    const reduceJob = buildTaskJob(
+      workspaceRoot,
+      { title: "Codex Parallel Reduce", summary: `Integration pass over ${findings.length} findings` },
+      false
+    );
+    const reduceRequest = buildTaskRequest({
+      cwd,
+      model,
+      effort: reduceEffort,
+      prompt: reducePrompt,
+      write: false,
+      resumeLast: false,
+      jobId: reduceJob.id
+    });
+    reduceRequest.outputSchema = reduceSchema;
+    enqueueBackgroundTask(cwd, reduceJob, reduceRequest);
+    const reduceChild = {
+      kind: "reduce",
+      shard: { id: "reduce", files: [] },
+      label: "Reduce",
+      title: "Codex Parallel Reduce",
+      summary: `Integration pass over ${findings.length} findings`,
+      jobId: reduceJob.id,
+      jobIds: [reduceJob.id],
+      prompt: reducePrompt,
+      outputSchema: reduceSchema,
+      model,
+      effort: reduceEffort,
+      firstSpawnAt: Date.now(),
+      lastSpawnAt: Date.now(),
+      retries: 0,
+      terminal: false,
+      finalStatus: null,
+      record: null
+    };
+    children.push(reduceChild);
+    await superviseParallelJobs({ cwd, workspaceRoot, children, deadline, onProgress });
+
+    const reduceRecord = reduceChild.record ?? readStoredJob(workspaceRoot, reduceChild.jobId);
+    const reduceReport = {
+      jobId: reduceChild.jobId,
+      status: reduceChild.finalStatus ?? "unknown",
+      wallSec: reduceChild.wallSec ?? null,
+      summary: null,
+      assessed: 0,
+      seamFindingCount: 0
+    };
+    let seamFindings = [];
+    const reduceExtraction = extractJsonPayload(
+      reduceRecord?.result?.rawOutput ?? "",
+      (parsed) => Array.isArray(parsed.assessments) || Array.isArray(parsed.seam_findings)
+    );
+    if (reduceExtraction.payload) {
+      const outcome = applyReduceOutcome(findings, reduceExtraction.payload);
+      seamFindings = outcome.seamFindings;
+      reduceReport.summary = reduceExtraction.payload.summary ?? null;
+      reduceReport.assessed = outcome.assessed;
+      reduceReport.seamFindingCount = seamFindings.length;
+    } else {
+      reduceReport.error = reduceExtraction.error;
+    }
+
+    const payload = {
+      review: "Parallel Review",
+      target,
+      shards: shardReports,
+      reduce: reduceReport,
+      findings: [...findings, ...seamFindings].sort(bySeverityThenConfidence),
+      unparsed,
+      seams,
+      totals: { wallSec: Math.round((Date.now() - startedAt) / 1000), shardCount: plan.shards.length }
+    };
+    const degraded = shardReports.some((report) => report.status !== "completed") || Boolean(reduceReport.error);
+
+    return {
+      exitStatus: degraded ? 1 : 0,
+      payload,
+      rendered: renderParallelReviewResult(payload),
+      summary: reduceReport.summary ?? `Parallel review finished with ${payload.findings.length} findings.`,
+      jobTitle: "Codex Parallel Review",
+      jobClass: "review",
+      targetLabel: target.label
+    };
+  } finally {
+    // Never exit with children still queued or running, whatever went wrong.
+    for (const child of children) {
+      if (child.terminal) {
+        continue;
+      }
+      const record = readStoredJob(workspaceRoot, child.jobId);
+      if (record && !isTerminalJobStatus(record.status)) {
+        try {
+          await cancelJobRecord(cwd, workspaceRoot, record, "Cancelled because the parallel-review orchestrator exited.");
+        } catch {
+          // Best-effort teardown.
+        }
+      }
+    }
+  }
+}
+
+async function handleParallelReview(argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["base", "scope", "model", "effort", "reduce-effort", "max-shards", "invariants-file", "timeout-min", "cwd"],
+    booleanOptions: ["json"],
+    aliasMap: {
+      m: "model"
+    }
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const workspaceRoot = resolveCommandWorkspace(options);
+  ensureCodexAvailable(cwd);
+  ensureGitRepository(cwd);
+
+  const model = normalizeRequestedModel(options.model);
+  const effort = normalizeReasoningEffort(options.effort);
+  const reduceEffort = normalizeReasoningEffort(options["reduce-effort"]) ?? "low";
+  const maxShards = Math.max(2, Number.parseInt(options["max-shards"] ?? `${DEFAULT_MAX_SHARDS}`, 10) || DEFAULT_MAX_SHARDS);
+  const timeoutMs =
+    Math.max(1, Number.parseInt(options["timeout-min"] ?? `${DEFAULT_PARALLEL_TIMEOUT_MIN}`, 10) || DEFAULT_PARALLEL_TIMEOUT_MIN) * 60_000;
+  const focusText = positionals.join(" ").trim();
+  const invariantsText = options["invariants-file"]
+    ? fs.readFileSync(path.resolve(cwd, options["invariants-file"]), "utf8")
+    : "";
+
+  const target = resolveReviewTarget(cwd, {
+    base: options.base,
+    scope: options.scope
+  });
+  const files = collectChangedFiles(cwd, target);
+  if (files.length === 0) {
+    throw new Error(`No changes found for ${target.label}.`);
+  }
+  const plan = planShards(files, maxShards);
+
+  if (plan.mode === "single") {
+    // Below the gate a sharded run costs ~k× tokens with no wall-time win;
+    // run the existing single adversarial review instead.
+    const metadata = buildReviewJobMetadata("Adversarial Review", target);
+    const job = createCompanionJob({
+      prefix: "review",
+      kind: metadata.kind,
+      title: metadata.title,
+      workspaceRoot,
+      jobClass: "review",
+      summary: metadata.summary
+    });
+    await runForegroundCommand(
+      job,
+      (progress) =>
+        executeReviewRun({
+          cwd,
+          base: options.base,
+          scope: options.scope,
+          model,
+          focusText,
+          reviewName: "Adversarial Review",
+          onProgress: progress
+        }),
+      { json: options.json }
+    );
+    return;
+  }
+
+  plan.files = files;
+  const job = createCompanionJob({
+    prefix: "review",
+    kind: "parallel-review",
+    title: "Codex Parallel Review",
+    workspaceRoot,
+    jobClass: "review",
+    summary: `Parallel review ${target.label} (${plan.shards.length} shards)`
+  });
+  await runForegroundCommand(
+    job,
+    (progress) =>
+      executeParallelReviewRun({
+        cwd,
+        workspaceRoot,
+        target,
+        plan,
+        focusText,
+        invariantsText,
+        model,
+        effort,
+        reduceEffort,
+        timeoutMs,
+        jobId: job.id,
+        onProgress: progress
+      }),
+    { json: options.json }
+  );
+}
+
 async function handleStatus(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["cwd", "timeout-ms", "poll-interval-ms"],
@@ -960,31 +1421,24 @@ function handleTaskResumeCandidate(argv) {
   outputCommandResult(payload, rendered, options.json);
 }
 
-async function handleCancel(argv) {
-  const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["cwd"],
-    booleanOptions: ["json"]
-  });
-
-  const cwd = resolveCommandCwd(options);
-  const reference = positionals[0] ?? "";
-  const { workspaceRoot, job } = resolveCancelableJob(cwd, reference, { env: process.env });
+async function cancelJobRecord(cwd, workspaceRoot, job, reason = "Cancelled by user.") {
   const existing = readStoredJob(workspaceRoot, job.id) ?? {};
   const threadId = existing.threadId ?? job.threadId ?? null;
   const turnId = existing.turnId ?? job.turnId ?? null;
+  const logFile = job.logFile ?? existing.logFile ?? null;
 
   const interrupt = await interruptAppServerTurn(cwd, { threadId, turnId });
   if (interrupt.attempted) {
     appendLogLine(
-      job.logFile,
+      logFile,
       interrupt.interrupted
         ? `Requested Codex turn interrupt for ${turnId} on ${threadId}.`
         : `Codex turn interrupt failed${interrupt.detail ? `: ${interrupt.detail}` : "."}`
     );
   }
 
-  terminateProcessTree(job.pid ?? Number.NaN);
-  appendLogLine(job.logFile, "Cancelled by user.");
+  terminateProcessTree(job.pid ?? existing.pid ?? Number.NaN);
+  appendLogLine(logFile, reason);
 
   const completedAt = nowIso();
   const nextJob = {
@@ -993,7 +1447,7 @@ async function handleCancel(argv) {
     phase: "cancelled",
     pid: null,
     completedAt,
-    errorMessage: "Cancelled by user."
+    errorMessage: reason
   };
 
   writeJobFile(workspaceRoot, job.id, {
@@ -1006,9 +1460,23 @@ async function handleCancel(argv) {
     status: "cancelled",
     phase: "cancelled",
     pid: null,
-    errorMessage: "Cancelled by user.",
+    errorMessage: reason,
     completedAt
   });
+
+  return { nextJob, interrupt };
+}
+
+async function handleCancel(argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["cwd"],
+    booleanOptions: ["json"]
+  });
+
+  const cwd = resolveCommandCwd(options);
+  const reference = positionals[0] ?? "";
+  const { workspaceRoot, job } = resolveCancelableJob(cwd, reference, { env: process.env });
+  const { nextJob, interrupt } = await cancelJobRecord(cwd, workspaceRoot, job);
 
   const payload = {
     jobId: job.id,
@@ -1039,6 +1507,9 @@ async function main() {
       await handleReviewCommand(argv, {
         reviewName: "Adversarial Review"
       });
+      break;
+    case "parallel-review":
+      await handleParallelReview(argv);
       break;
     case "task":
       await handleTask(argv);

--- a/plugins/codex/scripts/lib/parallel-review.mjs
+++ b/plugins/codex/scripts/lib/parallel-review.mjs
@@ -149,6 +149,7 @@ export function collectChangedFiles(cwd, target) {
   }
 
   if (target.mode !== "branch") {
+    const existingByPath = new Map(files.map((file) => [file.path, file]));
     for (const filePath of runGit(cwd, ["ls-files", "--others", "--exclude-standard"]).split("\n")) {
       if (!filePath.trim()) {
         continue;
@@ -168,7 +169,20 @@ export function collectChangedFiles(cwd, target) {
       } catch {
         // Unreadable; keep the default weight.
       }
-      files.push({ path: filePath, weight, binary, status: "A", oldPath: null });
+      const existing = existingByPath.get(filePath);
+      if (existing) {
+        // The path is both staged (e.g. a staged `git rm`) and present as an
+        // untracked file — it was deleted in the index and recreated in the
+        // worktree. Keep the single diff entry but flag it so buildShardDiff
+        // also embeds the recreated content instead of showing only the delete.
+        existing.recreated = true;
+        existing.binary = existing.binary || binary;
+        existing.weight += weight;
+        continue;
+      }
+      const entry = { path: filePath, weight, binary, status: "A", oldPath: null };
+      files.push(entry);
+      existingByPath.set(filePath, entry);
     }
   }
 
@@ -347,6 +361,26 @@ export function extractSeamHints({ files, shards, readFileContent }) {
     .slice(0, MAX_SEAM_HINTS);
 }
 
+// Render a worktree file as an inline block (capped, binary-aware) for cases a
+// git diff can't show: a brand-new untracked file, or one recreated after a
+// staged delete. Returns "" when the file is unreadable.
+function embedWorktreeFile(cwd, relativePath, label) {
+  try {
+    const absolute = path.join(cwd, relativePath);
+    const stat = fs.statSync(absolute);
+    if (stat.size <= MAX_UNTRACKED_READ_BYTES) {
+      const content = fs.readFileSync(absolute);
+      if (isProbablyText(content)) {
+        return `--- ${label}: ${relativePath} ---\n${content.toString("utf8")}\n`;
+      }
+      return `--- ${label}: ${relativePath} (binary, content omitted) ---\n`;
+    }
+    return `--- ${label}: ${relativePath} (${stat.size} bytes, content omitted) ---\n`;
+  } catch {
+    return "";
+  }
+}
+
 export function buildShardDiff(cwd, target, shard) {
   const argSets = diffArgSets(target);
   const perFile = shard.files.map((file) => {
@@ -370,20 +404,14 @@ export function buildShardDiff(cwd, target, shard) {
       return { file, text: "", bytes: 0, omit: true };
     }
     if (!text.trim() && file.status === "A") {
-      try {
-        const absolute = path.join(cwd, file.path);
-        const stat = fs.statSync(absolute);
-        if (stat.size <= MAX_UNTRACKED_READ_BYTES) {
-          const content = fs.readFileSync(absolute);
-          if (isProbablyText(content)) {
-            text = `--- new file: ${file.path} ---\n${content.toString("utf8")}\n`;
-          }
-        }
-        if (!text) {
-          text = `--- new file: ${file.path} (${stat.size} bytes, content omitted) ---\n`;
-        }
-      } catch {
-        text = "";
+      text = embedWorktreeFile(cwd, file.path, "new file");
+    }
+    if (file.recreated) {
+      // Staged delete + worktree recreate: the diff legs show only the delete,
+      // so append the recreated content the reviewer would otherwise never see.
+      const recreated = embedWorktreeFile(cwd, file.path, "recreated after staged delete");
+      if (recreated) {
+        text += (text.endsWith("\n") || text === "" ? "" : "\n") + recreated;
       }
     }
     return { file, text, bytes: Buffer.byteLength(text, "utf8"), omit: false };
@@ -620,15 +648,18 @@ export function applyReduceOutcome(findings, reducePayload) {
   const byId = new Map(
     (reducePayload.assessments ?? []).map((assessment) => [String(assessment.id), assessment])
   );
-  // Count only assessments that matched one of our findings: an id the
-  // reducer invented must not compensate for an id it skipped.
+  // Count only assessments that matched one of our findings AND carry a valid
+  // verdict: an id the reducer invented must not compensate for a skipped one,
+  // and an object missing/corrupting its verdict is not a real assessment (the
+  // degraded check compares this count against the finding total).
   let assessed = 0;
   for (const finding of findings) {
     const assessment = byId.get(finding.id);
-    if (assessment) {
+    const validVerdict = REDUCE_VERDICTS.has(assessment?.verdict);
+    if (assessment && validVerdict) {
       assessed += 1;
     }
-    finding.verification = REDUCE_VERDICTS.has(assessment?.verdict) ? assessment.verdict : "SUSPECTED";
+    finding.verification = validVerdict ? assessment.verdict : "SUSPECTED";
     finding.reduceNote = assessment?.note ?? null;
   }
 

--- a/plugins/codex/scripts/lib/parallel-review.mjs
+++ b/plugins/codex/scripts/lib/parallel-review.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { isProbablyText } from "./fs.mjs";
 import { runCommandChecked } from "./process.mjs";
 import { interpolateTemplate, loadPromptTemplate } from "./prompts.mjs";
 
@@ -13,6 +14,9 @@ const TARGET_LINES_PER_SHARD = 400;
 const OVERSIZE_UNIT_RATIO = 1.25;
 const BINARY_FILE_WEIGHT = 20;
 const MAX_SHARD_DIFF_BYTES = 150_000;
+// Same bound lib/git.mjs uses for untracked content: stat before reading so a
+// giant generated artifact can never stall or OOM the orchestrator.
+const MAX_UNTRACKED_READ_BYTES = 24 * 1024;
 const MAX_SEAM_HINTS = 100;
 const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".css", ".scss"]);
@@ -103,12 +107,21 @@ export function collectChangedFiles(cwd, target) {
         continue;
       }
       let weight = BINARY_FILE_WEIGHT;
+      let binary = false;
       try {
-        weight = fs.readFileSync(path.join(cwd, filePath), "utf8").split("\n").length;
+        const absolute = path.join(cwd, filePath);
+        if (fs.statSync(absolute).size <= MAX_UNTRACKED_READ_BYTES) {
+          const content = fs.readFileSync(absolute);
+          if (isProbablyText(content)) {
+            weight = content.toString("utf8").split("\n").length;
+          } else {
+            binary = true;
+          }
+        }
       } catch {
-        // Unreadable or binary; keep the default weight.
+        // Unreadable; keep the default weight.
       }
-      files.push({ path: filePath, weight, binary: false, status: "A", oldPath: null });
+      files.push({ path: filePath, weight, binary, status: "A", oldPath: null });
     }
   }
 
@@ -301,8 +314,17 @@ export function buildShardDiff(cwd, target, shard) {
     }
     if (!text.trim() && file.status === "A") {
       try {
-        const content = fs.readFileSync(path.join(cwd, file.path), "utf8");
-        text = `--- new file: ${file.path} ---\n${content}\n`;
+        const absolute = path.join(cwd, file.path);
+        const stat = fs.statSync(absolute);
+        if (stat.size <= MAX_UNTRACKED_READ_BYTES) {
+          const content = fs.readFileSync(absolute);
+          if (isProbablyText(content)) {
+            text = `--- new file: ${file.path} ---\n${content.toString("utf8")}\n`;
+          }
+        }
+        if (!text) {
+          text = `--- new file: ${file.path} (${stat.size} bytes, content omitted) ---\n`;
+        }
       } catch {
         text = "";
       }

--- a/plugins/codex/scripts/lib/parallel-review.mjs
+++ b/plugins/codex/scripts/lib/parallel-review.mjs
@@ -23,9 +23,18 @@ const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
 const STYLE_EXTENSIONS = new Set([".css", ".scss"]);
 const IMPORT_RESOLVE_SUFFIXES = ["", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".css", "/index.ts", "/index.tsx", "/index.js"];
 
+// Metadata reads (numstat/name-status) can be large on a big diff, so lift the
+// default buffer well above spawnSync's 1MB; per-file diff reads pass a tight
+// bound so an oversized single-file diff is caught instead of read whole.
+const GIT_OUTPUT_MAX_BUFFER = 64 * 1024 * 1024;
+
 // Git is directly executable on Windows. Repository-derived arguments must never pass through a shell.
-function runGit(cwd, args) {
-  return runCommandChecked("git", args, { cwd, shell: false }).stdout;
+function runGit(cwd, args, options = {}) {
+  return runCommandChecked("git", args, {
+    cwd,
+    shell: false,
+    maxBuffer: options.maxBuffer ?? GIT_OUTPUT_MAX_BUFFER
+  }).stdout;
 }
 
 // Working-tree reviews must read HEAD→index (staged) and index→worktree
@@ -305,12 +314,22 @@ export function buildShardDiff(cwd, target, shard) {
   const perFile = shard.files.map((file) => {
     const pathspec = file.oldPath ? [file.oldPath, file.path] : [file.path];
     let text = "";
+    let oversized = false;
     for (const argSet of argSets) {
       try {
-        text += runGit(cwd, ["diff", "-M", ...argSet, "--", ...pathspec]);
-      } catch {
-        // An untracked file has no diff to show; embed its content below.
+        text += runGit(cwd, ["diff", "-M", ...argSet, "--", ...pathspec], { maxBuffer: MAX_SHARD_DIFF_BYTES + 1 });
+      } catch (error) {
+        // A single-file diff larger than a shard can inline overflows the
+        // buffer; route that file to the reviewer to read directly rather than
+        // dropping it silently. Other errors (e.g. an untracked path with no
+        // diff) fall through to the embed handling below.
+        if (error?.code === "ENOBUFS" || /ENOBUFS|maxBuffer/i.test(error?.message ?? "")) {
+          oversized = true;
+        }
       }
+    }
+    if (oversized) {
+      return { file, text: "", bytes: 0, omit: true };
     }
     if (!text.trim() && file.status === "A") {
       try {
@@ -329,17 +348,20 @@ export function buildShardDiff(cwd, target, shard) {
         text = "";
       }
     }
-    return { file, text, bytes: Buffer.byteLength(text, "utf8") };
+    return { file, text, bytes: Buffer.byteLength(text, "utf8"), omit: false };
   });
 
-  const totalBytes = perFile.reduce((sum, entry) => sum + entry.bytes, 0);
+  const forcedOmitted = perFile.filter((entry) => entry.omit).map((entry) => entry.file.path);
+  const inlineable = perFile.filter((entry) => !entry.omit);
+
+  const totalBytes = inlineable.reduce((sum, entry) => sum + entry.bytes, 0);
   if (totalBytes <= MAX_SHARD_DIFF_BYTES) {
-    return { text: perFile.map((entry) => entry.text).join(""), omitted: [] };
+    return { text: inlineable.map((entry) => entry.text).join(""), omitted: forcedOmitted };
   }
 
   // Over budget: keep the heaviest-churn files inline; the reviewer has
   // read-only repository access and can inspect the rest itself.
-  const sorted = [...perFile].sort((a, b) => b.file.weight - a.file.weight);
+  const sorted = [...inlineable].sort((a, b) => b.file.weight - a.file.weight);
   let budget = MAX_SHARD_DIFF_BYTES;
   const keep = new Set();
   for (const entry of sorted) {
@@ -349,8 +371,11 @@ export function buildShardDiff(cwd, target, shard) {
     }
   }
   return {
-    text: perFile.filter((entry) => keep.has(entry.file.path)).map((entry) => entry.text).join(""),
-    omitted: perFile.filter((entry) => !keep.has(entry.file.path)).map((entry) => entry.file.path)
+    text: inlineable.filter((entry) => keep.has(entry.file.path)).map((entry) => entry.text).join(""),
+    omitted: [
+      ...inlineable.filter((entry) => !keep.has(entry.file.path)).map((entry) => entry.file.path),
+      ...forcedOmitted
+    ]
   };
 }
 
@@ -612,6 +637,16 @@ export function renderParallelReviewResult(payload) {
     lines.push(`Warning: ${payload.unparsed.length} shard output(s) could not be parsed; their findings are missing:`);
     for (const entry of payload.unparsed) {
       lines.push(`- ${entry.shard} (${entry.jobId}): ${entry.error}`);
+    }
+  }
+
+  const outOfScope = payload.shards.filter((shard) => shard.outOfScope > 0);
+  if (outOfScope.length > 0) {
+    const total = outOfScope.reduce((sum, shard) => sum + shard.outOfScope, 0);
+    lines.push("");
+    lines.push(`Note: ${total} finding(s) were dropped for citing files outside their shard's ownership:`);
+    for (const shard of outOfScope) {
+      lines.push(`- ${shard.shard}: ${shard.outOfScope} out-of-scope`);
     }
   }
 

--- a/plugins/codex/scripts/lib/parallel-review.mjs
+++ b/plugins/codex/scripts/lib/parallel-review.mjs
@@ -30,8 +30,11 @@ const IMPORT_RESOLVE_SUFFIXES = ["", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".css
 const GIT_OUTPUT_MAX_BUFFER = 64 * 1024 * 1024;
 
 // Git is directly executable on Windows. Repository-derived arguments must never pass through a shell.
+// --literal-pathspecs: shard file paths are literal repo paths, so a filename
+// carrying pathspec magic (`:(glob)`, a leading `:`, etc.) must never be globbed
+// into matching other files the shard does not own.
 function runGit(cwd, args, options = {}) {
-  return runCommandChecked("git", args, {
+  return runCommandChecked("git", ["--literal-pathspecs", ...args], {
     cwd,
     shell: false,
     maxBuffer: options.maxBuffer ?? GIT_OUTPUT_MAX_BUFFER

--- a/plugins/codex/scripts/lib/parallel-review.mjs
+++ b/plugins/codex/scripts/lib/parallel-review.mjs
@@ -467,6 +467,23 @@ export function buildReducePrompt(rootDir, { runLabel, targetLabel, shards, find
   });
 }
 
+// A shard may cite a path the way the git diff header shows it (`a/…` for the
+// old side, `b/…` for the new) or with a `./` or `/` prefix. Resolve it back to
+// the shard's owned path so a valid in-shard finding is not dropped as
+// out-of-scope. The literal path is tried first so a real top-level `a/`- or
+// `b/`-named file is never mis-stripped; returns null when it is truly outside.
+export function resolveOwnedFindingPath(ownedPaths, rawPath) {
+  const stripped = String(rawPath ?? "").replace(/^\.?\//, "");
+  if (ownedPaths.has(stripped)) {
+    return stripped;
+  }
+  const deprefixed = stripped.replace(/^[ab]\//, "");
+  if (deprefixed !== stripped && ownedPaths.has(deprefixed)) {
+    return deprefixed;
+  }
+  return null;
+}
+
 export function normalizeShardFinding(raw, shardId) {
   const title = String(raw.title ?? "(untitled)");
   const lineStart = Number.isFinite(raw.line_start) ? raw.line_start : 1;

--- a/plugins/codex/scripts/lib/parallel-review.mjs
+++ b/plugins/codex/scripts/lib/parallel-review.mjs
@@ -19,8 +19,9 @@ const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs",
 const STYLE_EXTENSIONS = new Set([".css", ".scss"]);
 const IMPORT_RESOLVE_SUFFIXES = ["", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".css", "/index.ts", "/index.tsx", "/index.js"];
 
+// Git is directly executable on Windows. Repository-derived arguments must never pass through a shell.
 function runGit(cwd, args) {
-  return runCommandChecked("git", args, { cwd }).stdout;
+  return runCommandChecked("git", args, { cwd, shell: false }).stdout;
 }
 
 function diffRangeArgs(target) {

--- a/plugins/codex/scripts/lib/parallel-review.mjs
+++ b/plugins/codex/scripts/lib/parallel-review.mjs
@@ -18,6 +18,7 @@ const MAX_SHARD_DIFF_BYTES = 150_000;
 // giant generated artifact can never stall or OOM the orchestrator.
 const MAX_UNTRACKED_READ_BYTES = 24 * 1024;
 const MAX_SEAM_HINTS = 100;
+const MAX_SEAM_READ_BYTES = 1_000_000;
 const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".css", ".scss"]);
 const STYLE_EXTENSIONS = new Set([".css", ".scss"]);
@@ -42,6 +43,43 @@ function runGit(cwd, args, options = {}) {
 // is invisible to a single `git diff HEAD`.
 function diffArgSets(target) {
   return target.mode === "branch" ? [[`${target.baseRef}...HEAD`]] : [["--cached"], []];
+}
+
+function gitShowOrNull(cwd, ref) {
+  try {
+    return runGit(cwd, ["show", ref], { maxBuffer: MAX_SEAM_READ_BYTES + 1 });
+  } catch {
+    // The path is absent from that snapshot (untracked, unstaged-only, deleted)
+    // or larger than the seam-scan bound; the caller falls back or skips it.
+    return null;
+  }
+}
+
+// Seam hints must reflect the snapshot under review, not whatever the worktree
+// happens to hold. A branch review is HEAD (the worktree may carry unrelated
+// uncommitted edits); a working-tree review covers both the staged and unstaged
+// legs, so scan the staged blob and the worktree file together — a seam
+// introduced in either leg (including a staged change whose worktree copy was
+// reverted) is then still seen. Returns null when nothing readable exists.
+export function readReviewedFileContent(cwd, target, relativePath) {
+  if (target.mode === "branch") {
+    return gitShowOrNull(cwd, `HEAD:${relativePath}`);
+  }
+
+  const parts = [];
+  const staged = gitShowOrNull(cwd, `:${relativePath}`);
+  if (staged != null) {
+    parts.push(staged);
+  }
+  try {
+    const absolute = path.join(cwd, relativePath);
+    if (fs.statSync(absolute).size <= MAX_SEAM_READ_BYTES) {
+      parts.push(fs.readFileSync(absolute, "utf8"));
+    }
+  } catch {
+    // Untracked or deleted in the worktree; a staged copy (if any) still scanned.
+  }
+  return parts.length > 0 ? parts.join("\n") : null;
 }
 
 // `--numstat -M` renders renames as either `old => new` or `pre{old => new}post`.

--- a/plugins/codex/scripts/lib/parallel-review.mjs
+++ b/plugins/codex/scripts/lib/parallel-review.mjs
@@ -76,7 +76,10 @@ export function readReviewedFileContent(cwd, target, relativePath) {
   }
   try {
     const absolute = path.join(cwd, relativePath);
-    if (fs.statSync(absolute).size <= MAX_SEAM_READ_BYTES) {
+    // lstat, never stat: a symlink has no imports/tokens to scan and following
+    // it could read a file outside the repo into the seam inputs.
+    const stat = fs.lstatSync(absolute);
+    if (!stat.isSymbolicLink() && stat.isFile() && stat.size <= MAX_SEAM_READ_BYTES) {
       parts.push(fs.readFileSync(absolute, "utf8"));
     }
   } catch {
@@ -204,7 +207,10 @@ export function collectChangedFiles(cwd, target) {
       let binary = false;
       try {
         const absolute = path.join(cwd, filePath);
-        if (fs.statSync(absolute).size <= MAX_UNTRACKED_READ_BYTES) {
+        const stat = fs.lstatSync(absolute); // no-follow: don't dereference symlinks
+        if (stat.isSymbolicLink()) {
+          weight = 1; // a symlink's content is just its short target path
+        } else if (stat.isFile() && stat.size <= MAX_UNTRACKED_READ_BYTES) {
           const content = fs.readFileSync(absolute);
           if (isProbablyText(content)) {
             weight = content.toString("utf8").split("\n").length;
@@ -413,7 +419,15 @@ export function extractSeamHints({ files, shards, readFileContent }) {
 function embedWorktreeFile(cwd, relativePath, label) {
   try {
     const absolute = path.join(cwd, relativePath);
-    const stat = fs.statSync(absolute);
+    // lstat, never stat: a symlink's reviewable content is its target path (git
+    // stores exactly that), and following it could embed a file outside the repo.
+    const stat = fs.lstatSync(absolute);
+    if (stat.isSymbolicLink()) {
+      return `--- ${label} (symlink): ${relativePath} -> ${fs.readlinkSync(absolute)} ---\n`;
+    }
+    if (!stat.isFile()) {
+      return "";
+    }
     if (stat.size <= MAX_UNTRACKED_READ_BYTES) {
       const content = fs.readFileSync(absolute);
       if (isProbablyText(content)) {

--- a/plugins/codex/scripts/lib/parallel-review.mjs
+++ b/plugins/codex/scripts/lib/parallel-review.mjs
@@ -85,18 +85,75 @@ export function readReviewedFileContent(cwd, target, relativePath) {
   return parts.length > 0 ? parts.join("\n") : null;
 }
 
-// `--numstat -M` renders renames as either `old => new` or `pre{old => new}post`.
-export function normalizeRenamePath(rawPath) {
-  if (rawPath.includes("{")) {
-    return rawPath
-      .replace(/\{([^{}]*) => ([^{}]*)\}/g, (_, _from, to) => to)
-      .replace(/\/{2,}/g, "/")
-      .replace(/^\.\//, "");
+// NUL-terminated parsers. `-z` prints pathnames verbatim (no quoting, no
+// `old => new` rewriting), so a filename containing ` => `, tabs, quotes, or
+// non-ASCII bytes is handled correctly instead of being mis-parsed as a rename.
+
+// `--name-status -M -z`: `<status>\0<path>\0`, or `R<score>\0<old>\0<new>\0`.
+export function parseNameStatusZ(output) {
+  const tokens = output.split("\0");
+  const byPath = new Map();
+  let i = 0;
+  while (i < tokens.length) {
+    const status = tokens[i];
+    if (!status) {
+      i += 1;
+      continue;
+    }
+    const code = status[0];
+    if (code === "R" || code === "C") {
+      const oldPath = tokens[i + 1] ?? null;
+      const newPath = tokens[i + 2];
+      i += 3;
+      if (newPath && !byPath.has(newPath)) {
+        byPath.set(newPath, { code, oldPath });
+      }
+    } else {
+      const filePath = tokens[i + 1];
+      i += 2;
+      if (filePath && !byPath.has(filePath)) {
+        byPath.set(filePath, { code, oldPath: null });
+      }
+    }
   }
-  if (rawPath.includes(" => ")) {
-    return rawPath.split(" => ").pop();
+  return byPath;
+}
+
+// `--numstat -M -z`: `<added>\t<deleted>\t<path>\0`, or for a rename
+// `<added>\t<deleted>\t\0<old>\0<new>\0` (empty path field, then old + new).
+export function parseNumstatZ(output) {
+  const tokens = output.split("\0");
+  const entries = [];
+  let i = 0;
+  while (i < tokens.length) {
+    const head = tokens[i];
+    if (!head) {
+      i += 1;
+      continue;
+    }
+    const firstTab = head.indexOf("\t");
+    const secondTab = head.indexOf("\t", firstTab + 1);
+    if (firstTab === -1 || secondTab === -1) {
+      i += 1;
+      continue;
+    }
+    const added = head.slice(0, firstTab);
+    const deleted = head.slice(firstTab + 1, secondTab);
+    const pathField = head.slice(secondTab + 1);
+    let filePath;
+    if (pathField === "") {
+      // Rename/copy: the new path is the second following token.
+      filePath = tokens[i + 2];
+      i += 3;
+    } else {
+      filePath = pathField;
+      i += 1;
+    }
+    if (filePath) {
+      entries.push({ added, deleted, path: filePath });
+    }
   }
-  return rawPath;
+  return entries;
 }
 
 export function collectChangedFiles(cwd, target) {
@@ -106,30 +163,16 @@ export function collectChangedFiles(cwd, target) {
   // status even when an unstaged edit also touches it.
   const statusByPath = new Map();
   for (const argSet of argSets) {
-    for (const line of runGit(cwd, ["diff", "--name-status", "-M", ...argSet]).split("\n")) {
-      if (!line.trim()) {
-        continue;
-      }
-      const parts = line.split("\t");
-      const code = parts[0];
-      const filePath = code.startsWith("R") || code.startsWith("C") ? parts[2] : parts[1];
+    for (const [filePath, info] of parseNameStatusZ(runGit(cwd, ["diff", "--name-status", "-M", "-z", ...argSet]))) {
       if (!statusByPath.has(filePath)) {
-        statusByPath.set(filePath, {
-          code: code[0],
-          oldPath: code.startsWith("R") || code.startsWith("C") ? parts[1] : null
-        });
+        statusByPath.set(filePath, info);
       }
     }
   }
 
   const churnByPath = new Map();
   for (const argSet of argSets) {
-    for (const line of runGit(cwd, ["diff", "--numstat", "-M", ...argSet]).split("\n")) {
-      if (!line.trim()) {
-        continue;
-      }
-      const [added, deleted, ...rest] = line.split("\t");
-      const filePath = normalizeRenamePath(rest.join("\t"));
+    for (const { added, deleted, path: filePath } of parseNumstatZ(runGit(cwd, ["diff", "--numstat", "-M", "-z", ...argSet]))) {
       const binary = added === "-" || deleted === "-";
       const legWeight = binary ? BINARY_FILE_WEIGHT : Number.parseInt(added, 10) + Number.parseInt(deleted, 10);
       const entry = churnByPath.get(filePath) ?? { weight: 0, binary: false };
@@ -153,8 +196,8 @@ export function collectChangedFiles(cwd, target) {
 
   if (target.mode !== "branch") {
     const existingByPath = new Map(files.map((file) => [file.path, file]));
-    for (const filePath of runGit(cwd, ["ls-files", "--others", "--exclude-standard"]).split("\n")) {
-      if (!filePath.trim()) {
+    for (const filePath of runGit(cwd, ["ls-files", "--others", "--exclude-standard", "-z"]).split("\0")) {
+      if (!filePath) {
         continue;
       }
       let weight = BINARY_FILE_WEIGHT;

--- a/plugins/codex/scripts/lib/parallel-review.mjs
+++ b/plugins/codex/scripts/lib/parallel-review.mjs
@@ -1,0 +1,582 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { runCommandChecked } from "./process.mjs";
+import { interpolateTemplate, loadPromptTemplate } from "./prompts.mjs";
+
+export const PARALLEL_GATE_MIN_LINES = 300;
+export const PARALLEL_GATE_MIN_FILES = 8;
+export const DEFAULT_MAX_SHARDS = 4;
+export const REDUCE_VERDICTS = new Set(["CONFIRMED", "SUSPECTED", "REJECTED"]);
+
+const TARGET_LINES_PER_SHARD = 400;
+const OVERSIZE_UNIT_RATIO = 1.25;
+const BINARY_FILE_WEIGHT = 20;
+const MAX_SHARD_DIFF_BYTES = 150_000;
+const MAX_SEAM_HINTS = 100;
+const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".css", ".scss"]);
+const STYLE_EXTENSIONS = new Set([".css", ".scss"]);
+const IMPORT_RESOLVE_SUFFIXES = ["", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".css", "/index.ts", "/index.tsx", "/index.js"];
+
+function runGit(cwd, args) {
+  return runCommandChecked("git", args, { cwd }).stdout;
+}
+
+function diffRangeArgs(target) {
+  return target.mode === "branch" ? [`${target.baseRef}...HEAD`] : ["HEAD"];
+}
+
+// `--numstat -M` renders renames as either `old => new` or `pre{old => new}post`.
+export function normalizeRenamePath(rawPath) {
+  if (rawPath.includes("{")) {
+    return rawPath
+      .replace(/\{([^{}]*) => ([^{}]*)\}/g, (_, _from, to) => to)
+      .replace(/\/{2,}/g, "/")
+      .replace(/^\.\//, "");
+  }
+  if (rawPath.includes(" => ")) {
+    return rawPath.split(" => ").pop();
+  }
+  return rawPath;
+}
+
+export function collectChangedFiles(cwd, target) {
+  const rangeArgs = diffRangeArgs(target);
+
+  const statusByPath = new Map();
+  for (const line of runGit(cwd, ["diff", "--name-status", "-M", ...rangeArgs]).split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    const parts = line.split("\t");
+    const code = parts[0];
+    if (code.startsWith("R") || code.startsWith("C")) {
+      statusByPath.set(parts[2], { code: code[0], oldPath: parts[1] });
+    } else {
+      statusByPath.set(parts[1], { code: code[0], oldPath: null });
+    }
+  }
+
+  const files = [];
+  for (const line of runGit(cwd, ["diff", "--numstat", "-M", ...rangeArgs]).split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    const [added, deleted, ...rest] = line.split("\t");
+    const filePath = normalizeRenamePath(rest.join("\t"));
+    const binary = added === "-" || deleted === "-";
+    const weight = binary ? BINARY_FILE_WEIGHT : Number.parseInt(added, 10) + Number.parseInt(deleted, 10);
+    const status = statusByPath.get(filePath) ?? { code: "M", oldPath: null };
+    files.push({
+      path: filePath,
+      weight: Number.isFinite(weight) ? weight : BINARY_FILE_WEIGHT,
+      binary,
+      status: status.code,
+      oldPath: status.oldPath
+    });
+  }
+
+  if (target.mode !== "branch") {
+    for (const filePath of runGit(cwd, ["ls-files", "--others", "--exclude-standard"]).split("\n")) {
+      if (!filePath.trim()) {
+        continue;
+      }
+      let weight = BINARY_FILE_WEIGHT;
+      try {
+        weight = fs.readFileSync(path.join(cwd, filePath), "utf8").split("\n").length;
+      } catch {
+        // Unreadable or binary; keep the default weight.
+      }
+      files.push({ path: filePath, weight, binary: false, status: "A", oldPath: null });
+    }
+  }
+
+  return files;
+}
+
+export function planShards(files, maxShards = DEFAULT_MAX_SHARDS) {
+  const totalLines = files.reduce((sum, file) => sum + file.weight, 0);
+  const metrics = {
+    fileCount: files.length,
+    totalLines,
+    gate: { minLines: PARALLEL_GATE_MIN_LINES, minFiles: PARALLEL_GATE_MIN_FILES }
+  };
+
+  if (totalLines < PARALLEL_GATE_MIN_LINES || files.length < PARALLEL_GATE_MIN_FILES) {
+    return {
+      mode: "single",
+      ...metrics,
+      reason: `Below the parallel gate (${totalLines} changed lines / ${files.length} files); one review is cheaper and just as thorough.`
+    };
+  }
+
+  // Shard by directory boundary first; fall back to per-file units when the
+  // whole diff lives in one directory.
+  const unitMap = new Map();
+  for (const file of files) {
+    const key = path.posix.dirname(file.path);
+    const unit = unitMap.get(key) ?? { key, files: [], weight: 0 };
+    unit.files.push(file);
+    unit.weight += file.weight;
+    unitMap.set(key, unit);
+  }
+  let units = [...unitMap.values()];
+  if (units.length < 2) {
+    units = files.map((file) => ({ key: file.path, files: [file], weight: file.weight }));
+  }
+
+  // A single directory that dwarfs the others would become the bottleneck
+  // shard and erase the parallel speedup — split oversized units to files.
+  const targetShardCount = Math.max(2, Math.min(maxShards, Math.ceil(totalLines / TARGET_LINES_PER_SHARD)));
+  const oversizeThreshold = (totalLines / targetShardCount) * OVERSIZE_UNIT_RATIO;
+  units = units.flatMap((unit) =>
+    unit.weight > oversizeThreshold && unit.files.length > 1
+      ? unit.files.map((file) => ({ key: file.path, files: [file], weight: file.weight }))
+      : [unit]
+  );
+
+  const shardCount = Math.max(2, Math.min(maxShards, units.length, Math.ceil(totalLines / TARGET_LINES_PER_SHARD)));
+
+  const bins = Array.from({ length: shardCount }, () => ({ weight: 0, files: [], dirs: [] }));
+  units.sort((a, b) => b.weight - a.weight);
+  for (const unit of units) {
+    bins.sort((a, b) => a.weight - b.weight);
+    bins[0].weight += unit.weight;
+    bins[0].files.push(...unit.files);
+    bins[0].dirs.push(unit.key);
+  }
+
+  bins.sort((a, b) => b.weight - a.weight);
+  const shards = bins
+    .filter((bin) => bin.files.length > 0)
+    .map((bin, index) => ({
+      id: `s${index + 1}`,
+      weight: bin.weight,
+      dirs: [...bin.dirs].sort(),
+      files: [...bin.files].sort((a, b) => b.weight - a.weight)
+    }));
+
+  return { mode: "parallel", ...metrics, shards };
+}
+
+function resolveImportTarget(fromFile, specifier, changedSet) {
+  let candidateBase;
+  if (specifier.startsWith("@/")) {
+    candidateBase = path.posix.join("src", specifier.slice(2));
+  } else if (specifier.startsWith(".")) {
+    candidateBase = path.posix.normalize(path.posix.join(path.posix.dirname(fromFile), specifier));
+  } else {
+    return null;
+  }
+  for (const suffix of IMPORT_RESOLVE_SUFFIXES) {
+    const candidate = candidateBase + suffix;
+    if (changedSet.has(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+// Mechanical hints for the reduce pass: contracts that cross shard
+// boundaries, which no single shard can judge alone. `readFileContent` is
+// injected so the planner stays testable without a repository.
+export function extractSeamHints({ files, shards, readFileContent }) {
+  const shardByFile = new Map();
+  for (const shard of shards) {
+    for (const file of shard.files) {
+      shardByFile.set(file.path, shard.id);
+    }
+  }
+  const changedSet = new Set(shardByFile.keys());
+  const seams = [];
+  const cssTokenDefinitions = new Map();
+  const contents = new Map();
+
+  for (const file of files) {
+    if (file.status === "D" || file.binary || !SOURCE_EXTENSIONS.has(path.posix.extname(file.path))) {
+      continue;
+    }
+    const content = readFileContent(file.path);
+    if (typeof content === "string") {
+      contents.set(file.path, content);
+    }
+  }
+
+  for (const [filePath, content] of contents) {
+    if (!STYLE_EXTENSIONS.has(path.posix.extname(filePath))) {
+      continue;
+    }
+    for (const match of content.matchAll(/--([\w-]+)\s*:/g)) {
+      if (!cssTokenDefinitions.has(match[1])) {
+        cssTokenDefinitions.set(match[1], filePath);
+      }
+    }
+    if (/:root|\[data-theme|@theme/.test(content)) {
+      seams.push({
+        kind: "global-style",
+        file: filePath,
+        shard: shardByFile.get(filePath),
+        note: "Global stylesheet/theme tokens changed; every UI shard consumes these values, including through utility classes that never mention the token by name."
+      });
+    }
+  }
+
+  for (const [filePath, content] of contents) {
+    const fromShard = shardByFile.get(filePath);
+
+    for (const match of content.matchAll(/(?:from\s+|require\()["']([^"']+)["']/g)) {
+      const target = resolveImportTarget(filePath, match[1], changedSet);
+      if (target && shardByFile.get(target) !== fromShard) {
+        seams.push({
+          kind: "import",
+          from: filePath,
+          fromShard,
+          to: target,
+          toShard: shardByFile.get(target),
+          specifier: match[1]
+        });
+      }
+    }
+
+    for (const match of content.matchAll(/var\(--([\w-]+)\)/g)) {
+      const definedIn = cssTokenDefinitions.get(match[1]);
+      if (definedIn && definedIn !== filePath && shardByFile.get(definedIn) !== fromShard) {
+        seams.push({
+          kind: "css-token",
+          token: match[1],
+          definedIn,
+          definedShard: shardByFile.get(definedIn),
+          usedIn: filePath,
+          usedShard: fromShard
+        });
+      }
+    }
+  }
+
+  const seen = new Set();
+  return seams
+    .filter((seam) => {
+      const key = JSON.stringify(seam);
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
+    .slice(0, MAX_SEAM_HINTS);
+}
+
+export function buildShardDiff(cwd, target, shard) {
+  const rangeArgs = diffRangeArgs(target);
+  const perFile = shard.files.map((file) => {
+    const pathspec = file.oldPath ? [file.oldPath, file.path] : [file.path];
+    let text = "";
+    try {
+      text = runGit(cwd, ["diff", "-M", ...rangeArgs, "--", ...pathspec]);
+    } catch {
+      // An untracked file has no diff against HEAD; embed its content instead.
+    }
+    if (!text.trim() && file.status === "A") {
+      try {
+        const content = fs.readFileSync(path.join(cwd, file.path), "utf8");
+        text = `--- new file: ${file.path} ---\n${content}\n`;
+      } catch {
+        text = "";
+      }
+    }
+    return { file, text, bytes: Buffer.byteLength(text, "utf8") };
+  });
+
+  const totalBytes = perFile.reduce((sum, entry) => sum + entry.bytes, 0);
+  if (totalBytes <= MAX_SHARD_DIFF_BYTES) {
+    return { text: perFile.map((entry) => entry.text).join(""), omitted: [] };
+  }
+
+  // Over budget: keep the heaviest-churn files inline; the reviewer has
+  // read-only repository access and can inspect the rest itself.
+  const sorted = [...perFile].sort((a, b) => b.file.weight - a.file.weight);
+  let budget = MAX_SHARD_DIFF_BYTES;
+  const keep = new Set();
+  for (const entry of sorted) {
+    if (entry.bytes <= budget) {
+      keep.add(entry.file.path);
+      budget -= entry.bytes;
+    }
+  }
+  return {
+    text: perFile.filter((entry) => keep.has(entry.file.path)).map((entry) => entry.text).join(""),
+    omitted: perFile.filter((entry) => !keep.has(entry.file.path)).map((entry) => entry.file.path)
+  };
+}
+
+function describeShardFile(file) {
+  return `- ${file.path} (${file.status}${file.binary ? ", binary" : `, ~${file.weight} changed lines`})`;
+}
+
+export function buildShardPrompt(rootDir, { runLabel, shard, shardCount, targetLabel, invariantsText, focusText, diff }) {
+  const omittedBlock = diff.omitted.length
+    ? `Diffs omitted for size — inspect these files yourself with read-only git commands:\n${diff.omitted.map((file) => `- ${file}`).join("\n")}`
+    : "";
+  return interpolateTemplate(loadPromptTemplate(rootDir, "parallel-shard-review"), {
+    RUN_LABEL: runLabel,
+    SHARD_ID: shard.id,
+    SHARD_COUNT: String(shardCount),
+    TARGET_LABEL: targetLabel,
+    FILE_LIST: shard.files.map(describeShardFile).join("\n"),
+    SHARED_INVARIANTS: invariantsText.trim() || "No run-specific invariants were provided; derive the change's implicit contracts from the diff itself.",
+    USER_FOCUS: focusText.trim() || "No extra focus provided.",
+    REVIEW_INPUT: diff.text.trimEnd(),
+    OMITTED_DIFFS: omittedBlock
+  });
+}
+
+export function buildReducePrompt(rootDir, { runLabel, targetLabel, shards, findings, seams, unparsedCount }) {
+  const shardMap = shards
+    .map((shard) => `${shard.id}:\n${shard.files.map((file) => `  - ${file.path}`).join("\n")}`)
+    .join("\n");
+  const compactFindings = findings.map((finding) => ({
+    id: finding.id,
+    severity: finding.severity,
+    confidence: finding.confidence,
+    title: finding.title,
+    file: finding.file,
+    line_start: finding.line_start,
+    line_end: finding.line_end,
+    shards: finding.shards,
+    body: finding.body.slice(0, 600),
+    recommendation: finding.recommendation.slice(0, 300)
+  }));
+  return interpolateTemplate(loadPromptTemplate(rootDir, "parallel-reduce"), {
+    RUN_LABEL: runLabel,
+    TARGET_LABEL: targetLabel,
+    SHARD_COUNT: String(shards.length),
+    SHARD_MAP: shardMap,
+    MERGED_FINDINGS: JSON.stringify(compactFindings, null, 2),
+    SEAM_HINTS: JSON.stringify(seams, null, 2),
+    UNPARSED_NOTE: unparsedCount > 0
+      ? `Note: ${unparsedCount} shard output(s) failed to parse, so some findings may be missing from the list.`
+      : ""
+  });
+}
+
+export function normalizeShardFinding(raw, shardId) {
+  const title = String(raw.title ?? "(untitled)");
+  const lineStart = Number.isFinite(raw.line_start) ? raw.line_start : 1;
+  return {
+    severity: SEVERITY_RANK[raw.severity] ? raw.severity : "medium",
+    title,
+    body: String(raw.body ?? ""),
+    file: String(raw.file ?? "(unknown)"),
+    line_start: lineStart,
+    line_end: Number.isFinite(raw.line_end) ? raw.line_end : lineStart,
+    confidence: Number.isFinite(raw.confidence) ? raw.confidence : 0.5,
+    recommendation: String(raw.recommendation ?? ""),
+    shards: [shardId],
+    sources: [{ shard: shardId, title }]
+  };
+}
+
+export function bySeverityThenConfidence(a, b) {
+  return (
+    (SEVERITY_RANK[b.severity] ?? 0) - (SEVERITY_RANK[a.severity] ?? 0) ||
+    (b.confidence ?? 0) - (a.confidence ?? 0)
+  );
+}
+
+function titleTokens(title) {
+  return new Set(
+    String(title ?? "")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((token) => token.length > 2)
+  );
+}
+
+function titleSimilarity(a, b) {
+  const tokensA = titleTokens(a);
+  const tokensB = titleTokens(b);
+  if (tokensA.size === 0 || tokensB.size === 0) {
+    return 0;
+  }
+  let shared = 0;
+  for (const token of tokensA) {
+    if (tokensB.has(token)) {
+      shared += 1;
+    }
+  }
+  return shared / (tokensA.size + tokensB.size - shared);
+}
+
+function rangesRelated(a, b) {
+  const gap = 5;
+  return a.line_start <= b.line_end + gap && b.line_start <= a.line_end + gap;
+}
+
+function absorbFinding(target, incoming) {
+  if ((SEVERITY_RANK[incoming.severity] ?? 0) > (SEVERITY_RANK[target.severity] ?? 0)) {
+    target.severity = incoming.severity;
+  }
+  target.confidence = Math.max(target.confidence ?? 0, incoming.confidence ?? 0);
+  if (String(incoming.body ?? "").length > String(target.body ?? "").length) {
+    target.body = incoming.body;
+  }
+  if (String(incoming.recommendation ?? "").length > String(target.recommendation ?? "").length) {
+    target.recommendation = incoming.recommendation;
+  }
+  target.line_start = Math.min(target.line_start, incoming.line_start);
+  target.line_end = Math.max(target.line_end, incoming.line_end);
+  for (const shard of incoming.shards) {
+    if (!target.shards.includes(shard)) {
+      target.shards.push(shard);
+    }
+  }
+  target.sources.push(...incoming.sources);
+}
+
+export function mergeFindings(findings) {
+  const merged = [];
+  for (const finding of findings) {
+    const existing = merged.find(
+      (candidate) =>
+        candidate.file === finding.file &&
+        (rangesRelated(candidate, finding)
+          ? titleSimilarity(candidate.title, finding.title) >= 0.3
+          : titleSimilarity(candidate.title, finding.title) >= 0.6)
+    );
+    if (existing) {
+      absorbFinding(existing, finding);
+    } else {
+      merged.push(finding);
+    }
+  }
+  merged.sort(bySeverityThenConfidence);
+  return merged;
+}
+
+// Ids must be assigned once, after merging, and stay stable: the reduce turn
+// receives them in its prompt and its verdicts are joined back on the same ids.
+export function assignFindingIds(findings) {
+  findings.forEach((finding, index) => {
+    finding.id = `f${index + 1}`;
+  });
+  return findings;
+}
+
+export function extractJsonPayload(rawOutput, isValid) {
+  if (!rawOutput || !rawOutput.trim()) {
+    return { error: "empty output" };
+  }
+  const candidates = [];
+  const fenced = rawOutput.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenced) {
+    candidates.push(fenced[1]);
+  }
+  candidates.push(rawOutput.trim());
+  const first = rawOutput.indexOf("{");
+  const last = rawOutput.lastIndexOf("}");
+  if (first !== -1 && last > first) {
+    candidates.push(rawOutput.slice(first, last + 1));
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === "object" && isValid(parsed)) {
+        return { payload: parsed };
+      }
+    } catch {
+      // Try the next candidate shape.
+    }
+  }
+  return { error: "no schema-shaped JSON object found in the output" };
+}
+
+export function applyReduceOutcome(findings, reducePayload) {
+  const byId = new Map(
+    (reducePayload.assessments ?? []).map((assessment) => [String(assessment.id), assessment])
+  );
+  for (const finding of findings) {
+    const assessment = byId.get(finding.id);
+    finding.verification = REDUCE_VERDICTS.has(assessment?.verdict) ? assessment.verdict : "SUSPECTED";
+    finding.reduceNote = assessment?.note ?? null;
+  }
+
+  const seamFindings = (reducePayload.seam_findings ?? []).map((raw, index) => {
+    const normalized = normalizeShardFinding(raw, "reduce");
+    normalized.id = `sf${index + 1}`;
+    normalized.origin = "reduce";
+    normalized.verification = "SUSPECTED";
+    normalized.relatedFiles = Array.isArray(raw.related_files) ? raw.related_files : [];
+    return normalized;
+  });
+
+  return { seamFindings, assessed: byId.size };
+}
+
+function formatFindingLine(finding) {
+  const verification = finding.verification ? ` [${finding.verification}]` : "";
+  const origin = finding.origin === "reduce" ? "reduce" : finding.shards.join("+");
+  const confidence = Math.round((finding.confidence ?? 0) * 100);
+  return [
+    `- (${finding.severity}/${confidence}%)${verification} ${finding.file}:${finding.line_start} — ${finding.title} (${origin})`,
+    finding.body ? `  ${finding.body.split("\n").join("\n  ")}` : null,
+    finding.recommendation ? `  Fix: ${finding.recommendation.split("\n").join("\n  ")}` : null,
+    finding.reduceNote ? `  Integration note: ${finding.reduceNote}` : null
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function renderParallelReviewResult(payload) {
+  const lines = [];
+  lines.push(`Parallel review of ${payload.target.label}: ${payload.shards.length} shards + 1 integration pass.`);
+  lines.push("");
+  if (payload.reduce?.summary) {
+    lines.push(`Integration verdict: ${payload.reduce.summary}`);
+    lines.push("");
+  }
+
+  const active = payload.findings.filter((finding) => finding.verification !== "REJECTED");
+  const rejected = payload.findings.filter((finding) => finding.verification === "REJECTED");
+
+  if (active.length === 0) {
+    lines.push("No findings survived the shard reviews and the integration pass.");
+  } else {
+    lines.push(`Findings (${active.length}, ranked):`);
+    for (const finding of active) {
+      lines.push(formatFindingLine(finding));
+    }
+  }
+
+  if (rejected.length > 0) {
+    lines.push("");
+    lines.push(`Disproven by the integration pass (${rejected.length}):`);
+    for (const finding of rejected) {
+      lines.push(`- ${finding.file}:${finding.line_start} — ${finding.title}${finding.reduceNote ? ` (${finding.reduceNote})` : ""}`);
+    }
+  }
+
+  if (payload.unparsed.length > 0) {
+    lines.push("");
+    lines.push(`Warning: ${payload.unparsed.length} shard output(s) could not be parsed; their findings are missing:`);
+    for (const entry of payload.unparsed) {
+      lines.push(`- ${entry.shard} (${entry.jobId}): ${entry.error}`);
+    }
+  }
+
+  lines.push("");
+  lines.push("Wall times:");
+  for (const shard of payload.shards) {
+    const retries = shard.retries > 0 ? `, ${shard.retries} recovery` : "";
+    lines.push(`- ${shard.shard}: ${shard.status}${shard.wallSec != null ? ` in ${shard.wallSec}s` : ""}${retries}`);
+  }
+  if (payload.reduce) {
+    lines.push(`- reduce: ${payload.reduce.status}${payload.reduce.wallSec != null ? ` in ${payload.reduce.wallSec}s` : ""}`);
+  }
+  if (payload.totals?.wallSec != null) {
+    lines.push(`- total: ${payload.totals.wallSec}s end-to-end`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/plugins/codex/scripts/lib/parallel-review.mjs
+++ b/plugins/codex/scripts/lib/parallel-review.mjs
@@ -24,8 +24,11 @@ function runGit(cwd, args) {
   return runCommandChecked("git", args, { cwd, shell: false }).stdout;
 }
 
-function diffRangeArgs(target) {
-  return target.mode === "branch" ? [`${target.baseRef}...HEAD`] : ["HEAD"];
+// Working-tree reviews must read HEAD→index (staged) and index→worktree
+// (unstaged) as separate legs: a staged edit whose worktree copy reverts it
+// is invisible to a single `git diff HEAD`.
+function diffArgSets(target) {
+  return target.mode === "branch" ? [[`${target.baseRef}...HEAD`]] : [["--cached"], []];
 }
 
 // `--numstat -M` renders renames as either `old => new` or `pre{old => new}post`.
@@ -43,36 +46,52 @@ export function normalizeRenamePath(rawPath) {
 }
 
 export function collectChangedFiles(cwd, target) {
-  const rangeArgs = diffRangeArgs(target);
+  const argSets = diffArgSets(target);
 
+  // The staged leg runs first, so a path staged as a rename/add keeps that
+  // status even when an unstaged edit also touches it.
   const statusByPath = new Map();
-  for (const line of runGit(cwd, ["diff", "--name-status", "-M", ...rangeArgs]).split("\n")) {
-    if (!line.trim()) {
-      continue;
+  for (const argSet of argSets) {
+    for (const line of runGit(cwd, ["diff", "--name-status", "-M", ...argSet]).split("\n")) {
+      if (!line.trim()) {
+        continue;
+      }
+      const parts = line.split("\t");
+      const code = parts[0];
+      const filePath = code.startsWith("R") || code.startsWith("C") ? parts[2] : parts[1];
+      if (!statusByPath.has(filePath)) {
+        statusByPath.set(filePath, {
+          code: code[0],
+          oldPath: code.startsWith("R") || code.startsWith("C") ? parts[1] : null
+        });
+      }
     }
-    const parts = line.split("\t");
-    const code = parts[0];
-    if (code.startsWith("R") || code.startsWith("C")) {
-      statusByPath.set(parts[2], { code: code[0], oldPath: parts[1] });
-    } else {
-      statusByPath.set(parts[1], { code: code[0], oldPath: null });
+  }
+
+  const churnByPath = new Map();
+  for (const argSet of argSets) {
+    for (const line of runGit(cwd, ["diff", "--numstat", "-M", ...argSet]).split("\n")) {
+      if (!line.trim()) {
+        continue;
+      }
+      const [added, deleted, ...rest] = line.split("\t");
+      const filePath = normalizeRenamePath(rest.join("\t"));
+      const binary = added === "-" || deleted === "-";
+      const legWeight = binary ? BINARY_FILE_WEIGHT : Number.parseInt(added, 10) + Number.parseInt(deleted, 10);
+      const entry = churnByPath.get(filePath) ?? { weight: 0, binary: false };
+      entry.weight += Number.isFinite(legWeight) ? legWeight : BINARY_FILE_WEIGHT;
+      entry.binary = entry.binary || binary;
+      churnByPath.set(filePath, entry);
     }
   }
 
   const files = [];
-  for (const line of runGit(cwd, ["diff", "--numstat", "-M", ...rangeArgs]).split("\n")) {
-    if (!line.trim()) {
-      continue;
-    }
-    const [added, deleted, ...rest] = line.split("\t");
-    const filePath = normalizeRenamePath(rest.join("\t"));
-    const binary = added === "-" || deleted === "-";
-    const weight = binary ? BINARY_FILE_WEIGHT : Number.parseInt(added, 10) + Number.parseInt(deleted, 10);
+  for (const [filePath, churn] of churnByPath) {
     const status = statusByPath.get(filePath) ?? { code: "M", oldPath: null };
     files.push({
       path: filePath,
-      weight: Number.isFinite(weight) ? weight : BINARY_FILE_WEIGHT,
-      binary,
+      weight: churn.weight,
+      binary: churn.binary,
       status: status.code,
       oldPath: status.oldPath
     });
@@ -269,14 +288,16 @@ export function extractSeamHints({ files, shards, readFileContent }) {
 }
 
 export function buildShardDiff(cwd, target, shard) {
-  const rangeArgs = diffRangeArgs(target);
+  const argSets = diffArgSets(target);
   const perFile = shard.files.map((file) => {
     const pathspec = file.oldPath ? [file.oldPath, file.path] : [file.path];
     let text = "";
-    try {
-      text = runGit(cwd, ["diff", "-M", ...rangeArgs, "--", ...pathspec]);
-    } catch {
-      // An untracked file has no diff against HEAD; embed its content instead.
+    for (const argSet of argSets) {
+      try {
+        text += runGit(cwd, ["diff", "-M", ...argSet, "--", ...pathspec]);
+      } catch {
+        // An untracked file has no diff to show; embed its content below.
+      }
     }
     if (!text.trim() && file.status === "A") {
       try {
@@ -497,8 +518,14 @@ export function applyReduceOutcome(findings, reducePayload) {
   const byId = new Map(
     (reducePayload.assessments ?? []).map((assessment) => [String(assessment.id), assessment])
   );
+  // Count only assessments that matched one of our findings: an id the
+  // reducer invented must not compensate for an id it skipped.
+  let assessed = 0;
   for (const finding of findings) {
     const assessment = byId.get(finding.id);
+    if (assessment) {
+      assessed += 1;
+    }
     finding.verification = REDUCE_VERDICTS.has(assessment?.verdict) ? assessment.verdict : "SUSPECTED";
     finding.reduceNote = assessment?.note ?? null;
   }
@@ -512,7 +539,7 @@ export function applyReduceOutcome(findings, reducePayload) {
     return normalized;
   });
 
-  return { seamFindings, assessed: byId.size };
+  return { seamFindings, assessed };
 }
 
 function formatFindingLine(finding) {

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -50,6 +50,22 @@ export function binaryAvailable(command, versionArgs = ["--version"], options = 
   return { available: true, detail: result.stdout.trim() || result.stderr.trim() || "ok" };
 }
 
+// A job record can say "running" long after its worker died (host timeouts,
+// broker teardown, SIGKILL); signal 0 asks the OS whether the pid still exists.
+export function isPidAlive(pid, options = {}) {
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return false;
+  }
+  const killImpl = options.killImpl ?? process.kill.bind(process);
+  try {
+    killImpl(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists but belongs to another user.
+    return error.code === "EPERM";
+  }
+}
+
 function looksLikeMissingProcessMessage(text) {
   return /not found|no running instance|cannot find|does not exist|no such process/i.test(text);
 }

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -114,10 +114,29 @@ function writeFileAtomic(targetPath, content) {
   }
 }
 
-export function saveState(cwd, state) {
+export function saveState(cwd, state, options = {}) {
   const previousJobs = loadState(cwd).jobs;
   ensureStateDir(cwd);
-  const nextJobs = pruneJobs(state.jobs ?? []);
+
+  let jobs = state.jobs ?? [];
+  if (options.reconcile) {
+    // Concurrent detached workers each load/mutate/save this shared file. Rebase
+    // only the jobs this mutation actually changed onto the authoritative
+    // previousJobs read (the very read the delete loop below uses), so a
+    // concurrent writer's added or completed job is neither reverted to a stale
+    // status nor deleted. updateState's mutators (upsertJob, setConfig) only add
+    // or update the single job they target, so every other job is taken fresh
+    // from disk. `baseById` holds each job's pre-mutation JSON.
+    const baseById = options.baseById ?? new Map();
+    const changed = jobs.filter((job) => baseById.get(job.id) !== JSON.stringify(job));
+    const merged = new Map(previousJobs.map((job) => [job.id, job]));
+    for (const job of changed) {
+      merged.set(job.id, job);
+    }
+    jobs = [...merged.values()];
+  }
+
+  const nextJobs = pruneJobs(jobs);
   const nextState = {
     version: STATE_VERSION,
     config: {
@@ -142,23 +161,13 @@ export function saveState(cwd, state) {
 
 export function updateState(cwd, mutate) {
   const state = loadState(cwd);
+  // Snapshot each job before mutating so saveState can tell which jobs this
+  // mutation changed and rebase just those onto the latest on-disk state,
+  // instead of overwriting a concurrent writer's changes. Direct saveState
+  // callers that intend to remove jobs (session teardown) skip reconciliation.
+  const baseById = new Map(state.jobs.map((job) => [job.id, JSON.stringify(job)]));
   mutate(state);
-
-  // Concurrent detached workers each run load/mutate/save on this file, so a
-  // stale snapshot at save time could drop — and then saveState could delete
-  // the files of — a live job another worker added after our load. The
-  // mutators routed through updateState (upsertJob, setConfig) only add or
-  // update, never remove, so any job still active on disk that is missing from
-  // our result was added concurrently: merge it back. Direct saveState callers
-  // that intend to remove active jobs (session teardown) are unaffected.
-  const resultIds = new Set(state.jobs.map((job) => job.id));
-  for (const job of loadState(cwd).jobs) {
-    if (!resultIds.has(job.id) && (job.status === "queued" || job.status === "running")) {
-      state.jobs.push(job);
-    }
-  }
-
-  return saveState(cwd, state);
+  return saveState(cwd, state, { reconcile: true, baseById });
 }
 
 export function generateJobId(prefix = "job") {

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -143,6 +143,21 @@ export function saveState(cwd, state) {
 export function updateState(cwd, mutate) {
   const state = loadState(cwd);
   mutate(state);
+
+  // Concurrent detached workers each run load/mutate/save on this file, so a
+  // stale snapshot at save time could drop — and then saveState could delete
+  // the files of — a live job another worker added after our load. The
+  // mutators routed through updateState (upsertJob, setConfig) only add or
+  // update, never remove, so any job still active on disk that is missing from
+  // our result was added concurrently: merge it back. Direct saveState callers
+  // that intend to remove active jobs (session teardown) are unaffected.
+  const resultIds = new Set(state.jobs.map((job) => job.id));
+  for (const job of loadState(cwd).jobs) {
+    if (!resultIds.has(job.id) && (job.status === "queued" || job.status === "running")) {
+      state.jobs.push(job);
+    }
+  }
+
   return saveState(cwd, state);
 }
 

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -77,9 +77,19 @@ export function loadState(cwd) {
   }
 }
 
+// Status, cancel, and the parallel-review supervisor all depend on the job
+// files of in-flight jobs; rank active jobs ahead of recency so retention
+// pruning cannot delete a running job's record mid-flight.
 function pruneJobs(jobs) {
+  const isActive = (job) => job.status === "queued" || job.status === "running";
   return [...jobs]
-    .sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")))
+    .sort((left, right) => {
+      const activeDelta = Number(isActive(right)) - Number(isActive(left));
+      if (activeDelta !== 0) {
+        return activeDelta;
+      }
+      return String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? ""));
+    })
     .slice(0, MAX_JOBS);
 }
 

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -99,6 +99,21 @@ function removeFileIfExists(filePath) {
   }
 }
 
+// Concurrent detached workers read these files while others rewrite them; a
+// plain writeFileSync truncates in place, so a reader can catch a half-written
+// file. Write to a sibling temp file and rename (atomic on the same
+// filesystem) so every reader sees a complete old or new file.
+function writeFileAtomic(targetPath, content) {
+  const tempPath = `${targetPath}.tmp-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  try {
+    fs.writeFileSync(tempPath, content, "utf8");
+    fs.renameSync(tempPath, targetPath);
+  } catch (error) {
+    removeFileIfExists(tempPath);
+    throw error;
+  }
+}
+
 export function saveState(cwd, state) {
   const previousJobs = loadState(cwd).jobs;
   ensureStateDir(cwd);
@@ -121,7 +136,7 @@ export function saveState(cwd, state) {
     removeFileIfExists(job.logFile);
   }
 
-  fs.writeFileSync(resolveStateFile(cwd), `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
+  writeFileAtomic(resolveStateFile(cwd), `${JSON.stringify(nextState, null, 2)}\n`);
   return nextState;
 }
 
@@ -176,7 +191,7 @@ export function getConfig(cwd) {
 export function writeJobFile(cwd, jobId, payload) {
   ensureStateDir(cwd);
   const jobFile = resolveJobFile(cwd, jobId);
-  fs.writeFileSync(jobFile, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  writeFileAtomic(jobFile, `${JSON.stringify(payload, null, 2)}\n`);
   return jobFile;
 }
 

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -75,6 +75,7 @@ test("continue is not exposed as a user-facing command", () => {
   assert.deepEqual(commandFiles, [
     "adversarial-review.md",
     "cancel.md",
+    "parallel-review.md",
     "rescue.md",
     "result.md",
     "review.md",

--- a/tests/parallel-review.test.mjs
+++ b/tests/parallel-review.test.mjs
@@ -360,3 +360,42 @@ test("resolveOwnedFindingPath rescues diff-prefixed and ./-prefixed shard paths"
   assert.equal(resolveOwnedFindingPath(owned, "other/bar.ts"), null);
   assert.equal(resolveOwnedFindingPath(owned, "b/other/bar.ts"), null);
 });
+
+test("applyReduceOutcome does not count an assessment that lacks a valid verdict", () => {
+  const findings = assignFindingIds(
+    mergeFindings([
+      normalizeShardFinding({ severity: "high", title: "A", file: "a.ts", line_start: 1, line_end: 1, confidence: 0.9, body: "a", recommendation: "r" }, "s1"),
+      normalizeShardFinding({ severity: "low", title: "B", file: "b.ts", line_start: 2, line_end: 2, confidence: 0.5, body: "b", recommendation: "r" }, "s2")
+    ])
+  );
+  const { assessed } = applyReduceOutcome(findings, {
+    assessments: [
+      { id: "f1", verdict: "CONFIRMED" },
+      { id: "f2" } // present for every id but missing its verdict
+    ],
+    seam_findings: []
+  });
+
+  assert.equal(assessed, 1, "an assessment missing a valid verdict must not count toward completion");
+  assert.equal(findings[0].verification, "CONFIRMED");
+  assert.equal(findings[1].verification, "SUSPECTED");
+});
+
+test("collectChangedFiles reconciles a staged delete recreated in the worktree into one embedded entry", () => {
+  const repo = makeTempDir();
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "f.txt"), "original\n", "utf8");
+  run("git", ["add", "."], { cwd: repo });
+  run("git", ["commit", "-m", "base"], { cwd: repo });
+  run("git", ["rm", "f.txt"], { cwd: repo }); // stage the deletion, remove the worktree copy
+  fs.writeFileSync(path.join(repo, "f.txt"), "recreated content\n", "utf8"); // recreate (now untracked)
+
+  const target = { mode: "working-tree", label: "working tree" };
+  const entries = collectChangedFiles(repo, target).filter((file) => file.path === "f.txt");
+  assert.equal(entries.length, 1, "a staged delete recreated in the worktree must be one entry, not two");
+  assert.equal(entries[0].recreated, true);
+
+  const diff = buildShardDiff(repo, target, { id: "A", files: entries });
+  assert.match(diff.text, /recreated after staged delete/);
+  assert.match(diff.text, /recreated content/, "the recreated worktree content must be embedded");
+});

--- a/tests/parallel-review.test.mjs
+++ b/tests/parallel-review.test.mjs
@@ -15,7 +15,8 @@ import {
   normalizeRenamePath,
   normalizeShardFinding,
   planShards,
-  renderParallelReviewResult
+  renderParallelReviewResult,
+  resolveOwnedFindingPath
 } from "../plugins/codex/scripts/lib/parallel-review.mjs";
 import { isPidAlive } from "../plugins/codex/scripts/lib/process.mjs";
 import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
@@ -338,4 +339,24 @@ test("readReviewedFileContent reads the reviewed snapshot, not a dirty worktree 
   fs.writeFileSync(path.join(repo, rel), "export const committed = 1;\n", "utf8");
   const wtContent = readReviewedFileContent(repo, { mode: "working-tree", label: "working tree" }, rel);
   assert.match(wtContent, /token/, "working-tree review must scan staged content even when the worktree reverted it");
+});
+
+test("resolveOwnedFindingPath rescues diff-prefixed and ./-prefixed shard paths", () => {
+  const owned = new Set(["src/foo.ts", "a/real.ts"]);
+
+  // Plain, ./, and / prefixes resolve to the owned path.
+  assert.equal(resolveOwnedFindingPath(owned, "src/foo.ts"), "src/foo.ts");
+  assert.equal(resolveOwnedFindingPath(owned, "./src/foo.ts"), "src/foo.ts");
+  assert.equal(resolveOwnedFindingPath(owned, "/src/foo.ts"), "src/foo.ts");
+
+  // Git diff header prefixes (b/ for the new side, a/ for deletions) resolve.
+  assert.equal(resolveOwnedFindingPath(owned, "b/src/foo.ts"), "src/foo.ts");
+  assert.equal(resolveOwnedFindingPath(owned, "a/src/foo.ts"), "src/foo.ts");
+
+  // A real top-level a/-named file matches literally and is not mis-stripped.
+  assert.equal(resolveOwnedFindingPath(owned, "a/real.ts"), "a/real.ts");
+
+  // A genuinely out-of-scope path stays unresolved.
+  assert.equal(resolveOwnedFindingPath(owned, "other/bar.ts"), null);
+  assert.equal(resolveOwnedFindingPath(owned, "b/other/bar.ts"), null);
 });

--- a/tests/parallel-review.test.mjs
+++ b/tests/parallel-review.test.mjs
@@ -454,3 +454,24 @@ test("buildShardDiff treats a shard path with glob characters as a literal file"
   assert.match(diff.text, /STAR_LITERAL_MARKER/);
   assert.equal(/DATA_LEAK_MARKER/.test(diff.text), false, "a glob-like filename must not pull in other files");
 });
+
+test("buildShardDiff renders an untracked symlink as its target, not the linked file's contents", () => {
+  const repo = makeTempDir();
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "base.txt"), "base\n", "utf8");
+  run("git", ["add", "-A"], { cwd: repo });
+  run("git", ["commit", "-m", "base"], { cwd: repo });
+
+  // A file the symlink points at; its contents must never be embedded.
+  fs.writeFileSync(path.join(repo, "secret.txt"), "TOP_SECRET_CONTENTS\n", "utf8");
+  fs.symlinkSync("secret.txt", path.join(repo, "link.txt")); // untracked symlink
+
+  const target = { mode: "working-tree", label: "working tree" };
+  const linkEntry = collectChangedFiles(repo, target).find((file) => file.path === "link.txt");
+  assert.ok(linkEntry, "the untracked symlink should be collected");
+  assert.equal(linkEntry.binary, false);
+
+  const diff = buildShardDiff(repo, target, { id: "A", files: [linkEntry] });
+  assert.match(diff.text, /symlink.*secret\.txt/);
+  assert.equal(/TOP_SECRET_CONTENTS/.test(diff.text), false, "must not dereference the symlink into the target's contents");
+});

--- a/tests/parallel-review.test.mjs
+++ b/tests/parallel-review.test.mjs
@@ -292,3 +292,24 @@ test("collectChangedFiles caps untracked reads and flags binary content", () => 
   const diff = buildShardDiff(repo, target, { id: "A", files: [byPath.get("huge.txt")] });
   assert.match(diff.text, /content omitted/);
 });
+
+test("buildShardDiff omits an oversized single-file diff instead of dropping it silently", () => {
+  const repo = makeTempDir();
+  initGitRepo(repo);
+  const filePath = path.join(repo, "big.txt");
+  // A committed file whose full rewrite produces a diff well over the shard
+  // inline budget (~150KB): ~6000 lines each replaced.
+  const original = Array.from({ length: 6000 }, (_, i) => `original line ${i} ${"x".repeat(20)}`).join("\n");
+  fs.writeFileSync(filePath, `${original}\n`, "utf8");
+  run("git", ["add", "."], { cwd: repo });
+  run("git", ["commit", "-m", "base"], { cwd: repo });
+  const rewritten = Array.from({ length: 6000 }, (_, i) => `changed line ${i} ${"y".repeat(20)}`).join("\n");
+  fs.writeFileSync(filePath, `${rewritten}\n`, "utf8");
+
+  const target = { mode: "working-tree", label: "working tree" };
+  const file = { path: "big.txt", weight: 12000, binary: false, status: "M", oldPath: null };
+  const diff = buildShardDiff(repo, target, { id: "A", files: [file] });
+
+  assert.deepEqual(diff.omitted, ["big.txt"]);
+  assert.equal(diff.text.includes("changed line"), false, "oversized diff must not be inlined");
+});

--- a/tests/parallel-review.test.mjs
+++ b/tests/parallel-review.test.mjs
@@ -12,8 +12,9 @@ import {
   extractJsonPayload,
   extractSeamHints,
   mergeFindings,
-  normalizeRenamePath,
   normalizeShardFinding,
+  parseNameStatusZ,
+  parseNumstatZ,
   planShards,
   renderParallelReviewResult,
   resolveOwnedFindingPath
@@ -76,11 +77,44 @@ test("planShards splits an oversized directory so it cannot become the bottlenec
   assert.ok(heaviest < total * 0.5, `oversized dir must be split (heaviest shard ${heaviest} of ${total})`);
 });
 
-test("normalizeRenamePath handles both numstat rename spellings", () => {
-  assert.equal(normalizeRenamePath("src/{old.ts => new.ts}"), "src/new.ts");
-  assert.equal(normalizeRenamePath("a/{b => c}/d.ts"), "a/c/d.ts");
-  assert.equal(normalizeRenamePath("old.ts => new.ts"), "new.ts");
-  assert.equal(normalizeRenamePath("plain/path.ts"), "plain/path.ts");
+test("parseNameStatusZ reads statuses and rename old/new paths verbatim", () => {
+  // A\0added\0 M\0mod\0 D\0gone\0 R100\0old\0new\0 — with a literal ' => ' in a name.
+  const output = "A\x00added.txt\x00M\x00weird => name.txt\x00D\x00gone.txt\x00R100\x00old.ts\x00new.ts\x00";
+  const byPath = parseNameStatusZ(output);
+
+  assert.equal(byPath.get("added.txt").code, "A");
+  assert.equal(byPath.get("weird => name.txt").code, "M");
+  assert.equal(byPath.get("gone.txt").code, "D");
+  assert.deepEqual(byPath.get("new.ts"), { code: "R", oldPath: "old.ts" });
+  assert.equal(byPath.has("old.ts"), false, "the old rename path is not a changed file");
+});
+
+test("parseNumstatZ reads churn and does not mistake ' => ' in a name for a rename", () => {
+  const output = "1\t2\tweird => name.txt\x00-\t-\tbin.dat\x000\t0\t\x00old.ts\x00new.ts\x00";
+  const entries = parseNumstatZ(output);
+
+  assert.deepEqual(entries[0], { added: "1", deleted: "2", path: "weird => name.txt" });
+  assert.deepEqual(entries[1], { added: "-", deleted: "-", path: "bin.dat" });
+  assert.deepEqual(entries[2], { added: "0", deleted: "0", path: "new.ts" });
+});
+
+test("collectChangedFiles keeps a literal ' => ' filename intact", () => {
+  const repo = makeTempDir();
+  initGitRepo(repo);
+  const literalName = "weird => name.txt";
+  fs.writeFileSync(path.join(repo, literalName), "original\n", "utf8");
+  run("git", ["add", "-A"], { cwd: repo });
+  run("git", ["commit", "-m", "base"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, literalName), "changed\n", "utf8");
+
+  const target = { mode: "working-tree", label: "working tree" };
+  const files = collectChangedFiles(repo, target);
+  const entry = files.find((file) => file.path === literalName);
+  assert.ok(entry, "a modified file whose name contains ' => ' must be recorded under its real name");
+  assert.equal(entry.status, "M");
+
+  const diff = buildShardDiff(repo, target, { id: "A", files: [entry] });
+  assert.match(diff.text, /changed/, "the shard diff must contain the real file's change");
 });
 
 test("extractSeamHints reports imports, css tokens, and global styles crossing shards", () => {

--- a/tests/parallel-review.test.mjs
+++ b/tests/parallel-review.test.mjs
@@ -399,3 +399,24 @@ test("collectChangedFiles reconciles a staged delete recreated in the worktree i
   assert.match(diff.text, /recreated after staged delete/);
   assert.match(diff.text, /recreated content/, "the recreated worktree content must be embedded");
 });
+
+test("buildShardDiff treats a shard path with glob characters as a literal file", () => {
+  const repo = makeTempDir();
+  initGitRepo(repo);
+  fs.mkdirSync(path.join(repo, "sub"), { recursive: true });
+  fs.writeFileSync(path.join(repo, "sub", "data.txt"), "data original\n", "utf8");
+  fs.writeFileSync(path.join(repo, "sub", "*.txt"), "star original\n", "utf8"); // a file literally named *.txt
+  run("git", ["add", "-A"], { cwd: repo });
+  run("git", ["commit", "-m", "base"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "sub", "data.txt"), "DATA_LEAK_MARKER\n", "utf8");
+  fs.writeFileSync(path.join(repo, "sub", "*.txt"), "STAR_LITERAL_MARKER\n", "utf8");
+
+  const target = { mode: "working-tree", label: "working tree" };
+  // The shard owns only the literal "sub/*.txt"; without literal pathspecs its
+  // name would glob and pull in sub/data.txt too.
+  const file = { path: "sub/*.txt", weight: 1, binary: false, status: "M", oldPath: null };
+  const diff = buildShardDiff(repo, target, { id: "A", files: [file] });
+
+  assert.match(diff.text, /STAR_LITERAL_MARKER/);
+  assert.equal(/DATA_LEAK_MARKER/.test(diff.text), false, "a glob-like filename must not pull in other files");
+});

--- a/tests/parallel-review.test.mjs
+++ b/tests/parallel-review.test.mjs
@@ -1,0 +1,221 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applyReduceOutcome,
+  assignFindingIds,
+  extractJsonPayload,
+  extractSeamHints,
+  mergeFindings,
+  normalizeRenamePath,
+  normalizeShardFinding,
+  planShards,
+  renderParallelReviewResult
+} from "../plugins/codex/scripts/lib/parallel-review.mjs";
+import { isPidAlive } from "../plugins/codex/scripts/lib/process.mjs";
+
+function makeFile(filePath, weight, overrides = {}) {
+  return { path: filePath, weight, binary: false, status: "M", oldPath: null, ...overrides };
+}
+
+test("planShards gates small diffs to a single review", () => {
+  const files = [makeFile("src/a.ts", 120), makeFile("src/b.ts", 90)];
+  const plan = planShards(files, 4);
+
+  assert.equal(plan.mode, "single");
+  assert.match(plan.reason, /parallel gate/i);
+});
+
+test("planShards keeps directory units together and balances shard weight", () => {
+  const files = [
+    makeFile("client/one.ts", 100),
+    makeFile("client/two.ts", 100),
+    makeFile("server/one.ts", 100),
+    makeFile("server/two.ts", 100),
+    makeFile("styles/app.css", 100),
+    makeFile("routes/index.ts", 100),
+    makeFile("lib/util.ts", 100),
+    makeFile("tests/app.test.ts", 100)
+  ];
+  const plan = planShards(files, 4);
+
+  assert.equal(plan.mode, "parallel");
+  assert.equal(plan.shards.length, 2);
+  const weights = plan.shards.map((shard) => shard.weight);
+  assert.equal(Math.max(...weights) - Math.min(...weights), 0);
+  for (const shard of plan.shards) {
+    const dirs = new Set(shard.files.map((file) => file.path.split("/")[0]));
+    for (const dir of dirs) {
+      const dirFiles = files.filter((file) => file.path.startsWith(`${dir}/`));
+      const inShard = shard.files.filter((file) => file.path.startsWith(`${dir}/`));
+      assert.equal(inShard.length, dirFiles.length, `directory ${dir} must not be split across shards`);
+    }
+  }
+});
+
+test("planShards splits an oversized directory so it cannot become the bottleneck", () => {
+  const files = [
+    ...Array.from({ length: 10 }, (_, index) => makeFile(`big/file-${index}.ts`, 140)),
+    makeFile("small/a.ts", 60),
+    makeFile("small/b.ts", 60),
+    makeFile("other/c.ts", 60)
+  ];
+  const plan = planShards(files, 4);
+
+  assert.equal(plan.mode, "parallel");
+  assert.equal(plan.shards.length, 4);
+  const heaviest = Math.max(...plan.shards.map((shard) => shard.weight));
+  const total = files.reduce((sum, file) => sum + file.weight, 0);
+  assert.ok(heaviest < total * 0.5, `oversized dir must be split (heaviest shard ${heaviest} of ${total})`);
+});
+
+test("normalizeRenamePath handles both numstat rename spellings", () => {
+  assert.equal(normalizeRenamePath("src/{old.ts => new.ts}"), "src/new.ts");
+  assert.equal(normalizeRenamePath("a/{b => c}/d.ts"), "a/c/d.ts");
+  assert.equal(normalizeRenamePath("old.ts => new.ts"), "new.ts");
+  assert.equal(normalizeRenamePath("plain/path.ts"), "plain/path.ts");
+});
+
+test("extractSeamHints reports imports, css tokens, and global styles crossing shards", () => {
+  const files = [
+    makeFile("src/styles/app.css", 50),
+    makeFile("src/ui/button.tsx", 50),
+    makeFile("src/lib/util.ts", 50)
+  ];
+  const shards = [
+    { id: "s1", files: [files[0]] },
+    { id: "s2", files: [files[1], files[2]] }
+  ];
+  const contents = {
+    "src/styles/app.css": ":root {\n  --color-accent: oklch(60% 0.1 200 / 0.5);\n}\n",
+    "src/ui/button.tsx": "import { helper } from \"../lib/util\";\nconst style = { color: \"var(--color-accent)\" };\n",
+    "src/lib/util.ts": "export function helper() {}\n"
+  };
+  const seams = extractSeamHints({ files, shards, readFileContent: (p) => contents[p] ?? null });
+
+  const kinds = seams.map((seam) => seam.kind).sort();
+  assert.deepEqual([...new Set(kinds)], ["css-token", "global-style"]);
+  const token = seams.find((seam) => seam.kind === "css-token");
+  assert.equal(token.token, "color-accent");
+  assert.equal(token.definedShard, "s1");
+  assert.equal(token.usedShard, "s2");
+  // button.tsx imports util.ts, but both live in s2 — no seam.
+  assert.equal(seams.some((seam) => seam.kind === "import"), false);
+});
+
+test("extractSeamHints resolves relative imports that cross shards", () => {
+  const files = [makeFile("src/ui/button.tsx", 50), makeFile("src/lib/util.ts", 50)];
+  const shards = [
+    { id: "s1", files: [files[0]] },
+    { id: "s2", files: [files[1]] }
+  ];
+  const contents = {
+    "src/ui/button.tsx": "import { helper } from \"../lib/util\";\n",
+    "src/lib/util.ts": "export function helper() {}\n"
+  };
+  const seams = extractSeamHints({ files, shards, readFileContent: (p) => contents[p] ?? null });
+
+  assert.equal(seams.length, 1);
+  assert.equal(seams[0].kind, "import");
+  assert.equal(seams[0].from, "src/ui/button.tsx");
+  assert.equal(seams[0].to, "src/lib/util.ts");
+});
+
+test("mergeFindings dedupes overlapping findings and keeps the worst severity", () => {
+  const findings = [
+    normalizeShardFinding(
+      { severity: "medium", title: "Token alpha stacks with modifier", file: "app.css", line_start: 10, line_end: 14, confidence: 0.7, body: "short", recommendation: "fix" },
+      "s1"
+    ),
+    normalizeShardFinding(
+      { severity: "high", title: "Alpha token stacks with opacity modifier", file: "app.css", line_start: 12, line_end: 16, confidence: 0.9, body: "a longer explanation of the same defect", recommendation: "fix it properly" },
+      "s2"
+    ),
+    normalizeShardFinding(
+      { severity: "low", title: "Unrelated finding", file: "other.ts", line_start: 1, line_end: 2, confidence: 0.5, body: "x", recommendation: "y" },
+      "s1"
+    )
+  ];
+  const merged = assignFindingIds(mergeFindings(findings));
+
+  assert.equal(merged.length, 2);
+  assert.equal(merged[0].severity, "high");
+  assert.equal(merged[0].confidence, 0.9);
+  assert.deepEqual([...merged[0].shards].sort(), ["s1", "s2"]);
+  assert.equal(merged[0].id, "f1");
+  assert.equal(merged[0].sources.length, 2);
+});
+
+test("applyReduceOutcome joins verdicts by id and defaults unassessed findings to SUSPECTED", () => {
+  const findings = assignFindingIds(
+    mergeFindings([
+      normalizeShardFinding({ severity: "high", title: "A", file: "a.ts", line_start: 1, line_end: 1, confidence: 0.9, body: "a", recommendation: "r" }, "s1"),
+      normalizeShardFinding({ severity: "low", title: "B", file: "b.ts", line_start: 1, line_end: 1, confidence: 0.5, body: "b", recommendation: "r" }, "s2")
+    ])
+  );
+  const { seamFindings, assessed } = applyReduceOutcome(findings, {
+    summary: "verdict",
+    assessments: [{ id: "f1", verdict: "REJECTED", note: "disproven" }],
+    seam_findings: [
+      { severity: "high", title: "Cross-shard defect", body: "spans two shards", file: "a.ts", line_start: 5, line_end: 6, confidence: 0.8, recommendation: "fix", related_files: ["b.ts"] }
+    ]
+  });
+
+  assert.equal(assessed, 1);
+  assert.equal(findings[0].verification, "REJECTED");
+  assert.equal(findings[0].reduceNote, "disproven");
+  assert.equal(findings[1].verification, "SUSPECTED");
+  assert.equal(seamFindings.length, 1);
+  assert.equal(seamFindings[0].id, "sf1");
+  assert.equal(seamFindings[0].origin, "reduce");
+  assert.deepEqual(seamFindings[0].relatedFiles, ["b.ts"]);
+});
+
+test("extractJsonPayload tolerates fences and surrounding prose", () => {
+  const valid = (parsed) => Array.isArray(parsed.findings);
+  const object = { verdict: "approve", summary: "ok", findings: [], next_steps: [] };
+
+  assert.deepEqual(extractJsonPayload(JSON.stringify(object), valid).payload, object);
+  assert.deepEqual(extractJsonPayload("```json\n" + JSON.stringify(object) + "\n```", valid).payload, object);
+  assert.deepEqual(extractJsonPayload("Here is my verdict:\n" + JSON.stringify(object) + "\nDone.", valid).payload, object);
+  assert.match(extractJsonPayload("no json here", valid).error, /no schema-shaped/i);
+  assert.match(extractJsonPayload("", valid).error, /empty/i);
+});
+
+test("renderParallelReviewResult separates active and rejected findings", () => {
+  const findings = assignFindingIds(
+    mergeFindings([
+      normalizeShardFinding({ severity: "high", title: "Real defect", file: "a.ts", line_start: 1, line_end: 1, confidence: 0.9, body: "explanation", recommendation: "fix" }, "s1"),
+      normalizeShardFinding({ severity: "low", title: "False alarm", file: "b.ts", line_start: 2, line_end: 2, confidence: 0.4, body: "meh", recommendation: "" }, "s2")
+    ])
+  );
+  applyReduceOutcome(findings, {
+    summary: "one real issue",
+    assessments: [
+      { id: "f1", verdict: "CONFIRMED", note: "verified" },
+      { id: "f2", verdict: "REJECTED", note: "not reachable" }
+    ],
+    seam_findings: []
+  });
+  const rendered = renderParallelReviewResult({
+    target: { label: "base main...HEAD" },
+    shards: [{ shard: "s1", status: "completed", wallSec: 100, retries: 0 }],
+    reduce: { status: "completed", wallSec: 40, summary: "one real issue" },
+    findings,
+    unparsed: [],
+    totals: { wallSec: 150, shardCount: 1 }
+  });
+
+  assert.match(rendered, /Real defect/);
+  assert.match(rendered, /\[CONFIRMED\]/);
+  assert.match(rendered, /Disproven by the integration pass \(1\)/);
+  assert.match(rendered, /not reachable/);
+  assert.match(rendered, /total: 150s end-to-end/);
+});
+
+test("isPidAlive distinguishes the current process from a dead pid", () => {
+  assert.equal(isPidAlive(process.pid), true);
+  assert.equal(isPidAlive(2 ** 30), false);
+  assert.equal(isPidAlive(Number.NaN), false);
+  assert.equal(isPidAlive(-1), false);
+});

--- a/tests/parallel-review.test.mjs
+++ b/tests/parallel-review.test.mjs
@@ -8,6 +8,7 @@ import {
   assignFindingIds,
   buildShardDiff,
   collectChangedFiles,
+  readReviewedFileContent,
   extractJsonPayload,
   extractSeamHints,
   mergeFindings,
@@ -312,4 +313,29 @@ test("buildShardDiff omits an oversized single-file diff instead of dropping it 
 
   assert.deepEqual(diff.omitted, ["big.txt"]);
   assert.equal(diff.text.includes("changed line"), false, "oversized diff must not be inlined");
+});
+
+test("readReviewedFileContent reads the reviewed snapshot, not a dirty worktree or a reverted stage", () => {
+  const repo = makeTempDir();
+  initGitRepo(repo);
+  const rel = "src/mod.ts";
+  fs.mkdirSync(path.join(repo, "src"), { recursive: true });
+  fs.writeFileSync(path.join(repo, rel), "export const committed = 1;\n", "utf8");
+  run("git", ["add", "."], { cwd: repo });
+  run("git", ["commit", "-m", "base"], { cwd: repo });
+
+  // Branch review: the reviewed content is HEAD, even with an unrelated dirty
+  // worktree edit on top.
+  fs.writeFileSync(path.join(repo, rel), "export const dirtyWorktree = 2;\n", "utf8");
+  const branchContent = readReviewedFileContent(repo, { mode: "branch", baseRef: "main" }, rel);
+  assert.match(branchContent, /committed/);
+  assert.equal(/dirtyWorktree/.test(branchContent), false, "branch review must not read uncommitted worktree edits");
+
+  // Working-tree review: a staged change whose worktree copy was reverted must
+  // still be visible (scanned from the index), so its seams are not missed.
+  fs.writeFileSync(path.join(repo, rel), "import { token } from './staged';\n", "utf8");
+  run("git", ["add", rel], { cwd: repo });
+  fs.writeFileSync(path.join(repo, rel), "export const committed = 1;\n", "utf8");
+  const wtContent = readReviewedFileContent(repo, { mode: "working-tree", label: "working tree" }, rel);
+  assert.match(wtContent, /token/, "working-tree review must scan staged content even when the worktree reverted it");
 });

--- a/tests/parallel-review.test.mjs
+++ b/tests/parallel-review.test.mjs
@@ -1,9 +1,13 @@
+import fs from "node:fs";
+import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
   applyReduceOutcome,
   assignFindingIds,
+  buildShardDiff,
+  collectChangedFiles,
   extractJsonPayload,
   extractSeamHints,
   mergeFindings,
@@ -13,6 +17,7 @@ import {
   renderParallelReviewResult
 } from "../plugins/codex/scripts/lib/parallel-review.mjs";
 import { isPidAlive } from "../plugins/codex/scripts/lib/process.mjs";
+import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
 
 function makeFile(filePath, weight, overrides = {}) {
   return { path: filePath, weight, binary: false, status: "M", oldPath: null, ...overrides };
@@ -218,4 +223,48 @@ test("isPidAlive distinguishes the current process from a dead pid", () => {
   assert.equal(isPidAlive(2 ** 30), false);
   assert.equal(isPidAlive(Number.NaN), false);
   assert.equal(isPidAlive(-1), false);
+});
+
+test("working-tree collection sees staged edits a worktree revert hides", () => {
+  const repo = makeTempDir();
+  initGitRepo(repo);
+  const filePath = path.join(repo, "src", "a.txt");
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, "original\n", "utf8");
+  run("git", ["add", "."], { cwd: repo });
+  run("git", ["commit", "-m", "base"], { cwd: repo });
+
+  // Stage an edit, then revert the worktree copy: `git diff HEAD` is empty
+  // for this path, but committing now would still land the staged edit.
+  fs.writeFileSync(filePath, "staged edit\n", "utf8");
+  run("git", ["add", "src/a.txt"], { cwd: repo });
+  fs.writeFileSync(filePath, "original\n", "utf8");
+
+  const target = { mode: "working-tree", label: "working tree" };
+  const files = collectChangedFiles(repo, target);
+  const entry = files.find((file) => file.path === "src/a.txt");
+  assert.ok(entry, "expected the staged-but-reverted file to be collected");
+
+  const diff = buildShardDiff(repo, target, { id: "A", files: [entry] });
+  assert.match(diff.text, /staged edit/);
+});
+
+test("applyReduceOutcome does not count assessments for unknown ids", () => {
+  const findings = assignFindingIds(
+    mergeFindings([
+      normalizeShardFinding({ severity: "high", title: "A", file: "a.ts", line_start: 1, line_end: 1, confidence: 0.9, body: "a", recommendation: "r" }, "s1"),
+      normalizeShardFinding({ severity: "low", title: "B", file: "b.ts", line_start: 5, line_end: 5, confidence: 0.5, body: "b", recommendation: "r" }, "s2")
+    ])
+  );
+  const { assessed } = applyReduceOutcome(findings, {
+    assessments: [
+      { id: "f1", verdict: "CONFIRMED", note: "checked" },
+      { id: "f9", verdict: "REJECTED", note: "hallucinated id" }
+    ],
+    seam_findings: []
+  });
+
+  assert.equal(assessed, 1);
+  assert.equal(findings[0].verification, "CONFIRMED");
+  assert.equal(findings[1].verification, "SUSPECTED");
 });

--- a/tests/parallel-review.test.mjs
+++ b/tests/parallel-review.test.mjs
@@ -268,3 +268,27 @@ test("applyReduceOutcome does not count assessments for unknown ids", () => {
   assert.equal(findings[0].verification, "CONFIRMED");
   assert.equal(findings[1].verification, "SUSPECTED");
 });
+
+test("collectChangedFiles caps untracked reads and flags binary content", () => {
+  const repo = makeTempDir();
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "base.txt"), "base\n", "utf8");
+  run("git", ["add", "."], { cwd: repo });
+  run("git", ["commit", "-m", "base"], { cwd: repo });
+
+  fs.writeFileSync(path.join(repo, "small.txt"), "one\ntwo\nthree\n", "utf8");
+  fs.writeFileSync(path.join(repo, "blob.bin"), Buffer.from([0, 1, 2, 0, 3]));
+  fs.writeFileSync(path.join(repo, "huge.txt"), "x".repeat(30 * 1024), "utf8");
+
+  const target = { mode: "working-tree", label: "working tree" };
+  const files = collectChangedFiles(repo, target);
+  const byPath = new Map(files.map((file) => [file.path, file]));
+
+  assert.equal(byPath.get("small.txt").weight, 4);
+  assert.equal(byPath.get("blob.bin").binary, true);
+  // Oversized content is never read; the default weight stands in.
+  assert.equal(byPath.get("huge.txt").weight, byPath.get("blob.bin").weight);
+
+  const diff = buildShardDiff(repo, target, { id: "A", files: [byPath.get("huge.txt")] });
+  assert.match(diff.text, /content omitted/);
+});

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -5,7 +5,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { makeTempDir } from "./helpers.mjs";
-import { resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState } from "../plugins/codex/scripts/lib/state.mjs";
+import { readJobFile, resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState, writeJobFile } from "../plugins/codex/scripts/lib/state.mjs";
 
 test("resolveStateDir uses a temp-backed per-workspace directory", () => {
   const workspace = makeTempDir();
@@ -102,4 +102,16 @@ test("saveState prunes dropped job artifacts when indexed jobs exceed the cap", 
       .flatMap((jobId) => [`${jobId}.json`, `${jobId}.log`])
       .sort()
   );
+});
+
+test("writeJobFile writes atomically and leaves no temp files behind", () => {
+  const workspace = makeTempDir();
+  const jobId = "job-atomic";
+  writeJobFile(workspace, jobId, { id: jobId, status: "running", note: "payload" });
+
+  const jobFile = resolveJobFile(workspace, jobId);
+  assert.deepEqual(readJobFile(jobFile), { id: jobId, status: "running", note: "payload" });
+
+  const leftovers = fs.readdirSync(path.dirname(jobFile)).filter((name) => name.includes(".tmp-"));
+  assert.deepEqual(leftovers, [], "no temp files should survive an atomic write");
 });

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -5,7 +5,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { makeTempDir } from "./helpers.mjs";
-import { readJobFile, resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState, writeJobFile } from "../plugins/codex/scripts/lib/state.mjs";
+import { readJobFile, resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState, updateState, writeJobFile } from "../plugins/codex/scripts/lib/state.mjs";
 
 test("resolveStateDir uses a temp-backed per-workspace directory", () => {
   const workspace = makeTempDir();
@@ -114,4 +114,46 @@ test("writeJobFile writes atomically and leaves no temp files behind", () => {
 
   const leftovers = fs.readdirSync(path.dirname(jobFile)).filter((name) => name.includes(".tmp-"));
   assert.deepEqual(leftovers, [], "no temp files should survive an atomic write");
+});
+
+test("updateState re-adds an active job missing from a stale mutation, but a direct saveState can still remove it", () => {
+  const workspace = makeTempDir();
+
+  // Seed two active jobs on disk with files + logs.
+  const liveIds = ["job-live-a", "job-live-b"];
+  for (const id of liveIds) {
+    writeJobFile(workspace, id, { id, status: "running" });
+    fs.writeFileSync(resolveJobLogFile(workspace, id), `log ${id}\n`, "utf8");
+  }
+  saveState(workspace, {
+    version: 1,
+    config: { stopReviewGate: false },
+    jobs: liveIds.map((id) => ({ id, status: "running", logFile: resolveJobLogFile(workspace, id) }))
+  });
+
+  // A mutation that drops an active job (standing in for a stale snapshot from
+  // a concurrent worker) must not lose it: updateState re-adds it and its files
+  // survive.
+  updateState(workspace, (state) => {
+    state.jobs = state.jobs.filter((job) => job.id !== "job-live-b");
+  });
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-live-b")), true, "dropped live job file must not be deleted");
+  assert.equal(fs.existsSync(resolveJobLogFile(workspace, "job-live-b")), true, "dropped live job log must not be deleted");
+  assert.ok(
+    JSON.parse(fs.readFileSync(resolveStateFile(workspace), "utf8")).jobs.some((job) => job.id === "job-live-b"),
+    "dropped live job must be merged back into the index"
+  );
+
+  // A direct saveState (session teardown) that intends to remove an active job
+  // must still succeed — the reconciliation only guards updateState mutators.
+  saveState(workspace, {
+    version: 1,
+    config: { stopReviewGate: false },
+    jobs: [{ id: "job-live-a", status: "running", logFile: resolveJobLogFile(workspace, "job-live-a") }]
+  });
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-live-b")), false, "direct saveState removal must delete the job file");
+  assert.ok(
+    !JSON.parse(fs.readFileSync(resolveStateFile(workspace), "utf8")).jobs.some((job) => job.id === "job-live-b"),
+    "direct saveState removal must drop the job from the index"
+  );
 });

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -116,10 +116,9 @@ test("writeJobFile writes atomically and leaves no temp files behind", () => {
   assert.deepEqual(leftovers, [], "no temp files should survive an atomic write");
 });
 
-test("updateState re-adds an active job missing from a stale mutation, but a direct saveState can still remove it", () => {
+test("updateState re-adds a job missing from a stale mutation, but a direct saveState can still remove it", () => {
   const workspace = makeTempDir();
 
-  // Seed two active jobs on disk with files + logs.
   const liveIds = ["job-live-a", "job-live-b"];
   for (const id of liveIds) {
     writeJobFile(workspace, id, { id, status: "running" });
@@ -131,21 +130,20 @@ test("updateState re-adds an active job missing from a stale mutation, but a dir
     jobs: liveIds.map((id) => ({ id, status: "running", logFile: resolveJobLogFile(workspace, id) }))
   });
 
-  // A mutation that drops an active job (standing in for a stale snapshot from
-  // a concurrent worker) must not lose it: updateState re-adds it and its files
-  // survive.
+  // A mutation that drops a job (standing in for a stale concurrent snapshot)
+  // must not lose it: updateState rebases only its own changes onto disk, so
+  // the untouched job survives.
   updateState(workspace, (state) => {
     state.jobs = state.jobs.filter((job) => job.id !== "job-live-b");
   });
-  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-live-b")), true, "dropped live job file must not be deleted");
-  assert.equal(fs.existsSync(resolveJobLogFile(workspace, "job-live-b")), true, "dropped live job log must not be deleted");
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-live-b")), true, "dropped job file must not be deleted");
   assert.ok(
     JSON.parse(fs.readFileSync(resolveStateFile(workspace), "utf8")).jobs.some((job) => job.id === "job-live-b"),
-    "dropped live job must be merged back into the index"
+    "dropped job must be preserved in the index"
   );
 
-  // A direct saveState (session teardown) that intends to remove an active job
-  // must still succeed — the reconciliation only guards updateState mutators.
+  // A direct saveState (session teardown) that intends to remove a job must
+  // still succeed — reconciliation only guards updateState mutators.
   saveState(workspace, {
     version: 1,
     config: { stopReviewGate: false },
@@ -156,4 +154,41 @@ test("updateState re-adds an active job missing from a stale mutation, but a dir
     !JSON.parse(fs.readFileSync(resolveStateFile(workspace), "utf8")).jobs.some((job) => job.id === "job-live-b"),
     "direct saveState removal must drop the job from the index"
   );
+});
+
+test("reconciling a stale mutation keeps a concurrently completed job's terminal status and files", () => {
+  const workspace = makeTempDir();
+
+  // On disk, job B has already completed (a concurrent worker finished it).
+  writeJobFile(workspace, "job-b", { id: "job-b", status: "completed" });
+  fs.writeFileSync(resolveJobLogFile(workspace, "job-b"), "log b\n", "utf8");
+  saveState(workspace, {
+    version: 1,
+    config: { stopReviewGate: false },
+    jobs: [{ id: "job-b", status: "completed", logFile: resolveJobLogFile(workspace, "job-b") }]
+  });
+
+  // A stale updater still thinks B is running and only means to add its own job
+  // A. baseById marks B as unchanged by this mutation (still running), so the
+  // reconcile path must take B fresh from disk (completed), not write it back
+  // as running or delete it.
+  const baseById = new Map([["job-b", JSON.stringify({ id: "job-b", status: "running" })]]);
+  saveState(
+    workspace,
+    {
+      version: 1,
+      config: { stopReviewGate: false },
+      jobs: [
+        { id: "job-b", status: "running" },
+        { id: "job-a", status: "running" }
+      ]
+    },
+    { reconcile: true, baseById }
+  );
+
+  const saved = JSON.parse(fs.readFileSync(resolveStateFile(workspace), "utf8"));
+  const savedB = saved.jobs.find((job) => job.id === "job-b");
+  assert.equal(savedB.status, "completed", "concurrently completed job must not be reverted to running");
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-b")), true, "completed job file must not be deleted");
+  assert.ok(saved.jobs.some((job) => job.id === "job-a"), "the mutation's own new job must be written");
 });


### PR DESCRIPTION
Implements the proposal in #585: a `parallel-review` companion subcommand that shards a large diff into concurrent background review tasks (map), supervises them against silent worker death, then runs one mandatory cross-shard integration pass (reduce) and returns a single merged, ranked report.

## Why

A single review of a large multi-workstream diff is single-threaded end-to-end and fragile: on a real 24-file / ~1.8k-changed-line diff, one run took 40+ minutes and its worker died silently mid-run — total loss (#517 / #540 / #509 describe the death modes; #68 asks for parallel reviews directly). The same diff through this design: **9.4 minutes end-to-end (~4.3×), with a SIGKILLed worker auto-recovered mid-run** (measured with a behavior-identical prototype orchestrating the current companion CLI from the outside; happy to share the raw run data on the issue).

## How it works

```
parallel-review [--base <ref>] [--scope auto|working-tree|branch] [--max-shards 4]
                [--invariants-file <path>] [--reduce-effort low] [--timeout-min 45] [focus text]
```

1. **Gate.** Below ~300 changed lines or 8 files the command falls back to the existing single adversarial review — sharding costs ~k× tokens and earns nothing on small diffs.
2. **Shard planning** (`lib/parallel-review.mjs`, pure + unit-tested). Changed files are grouped by directory, oversized directories are split per-file so no shard becomes the bottleneck, and units are LPT-balanced into ≤ `--max-shards` shards.
3. **Map.** Each shard becomes a `task`-class background job through the existing `enqueueBackgroundTask` path, with: only its own hunks inline (read-only repo access for anything else), the full shared invariant list (`--invariants-file`), and the existing `review-output` schema **enforced natively** via a new `request.outputSchema` passthrough — shard outputs parse deterministically instead of by convention. Spawns are staggered 3s apart because concurrent state writers race (#286).
4. **Supervision.** The orchestrator polls per-job files and trusts the OS over the record: a job that says "running" whose pid is dead (new `isPidAlive` in `lib/process.mjs`), whose log has stalled, or whose record disappeared is cancelled and **resumed on its original thread** via a new `request.resumeThreadId` — the analysis done before the crash is kept, and recovery does not depend on the session-scoped `--resume-last` lookup (which is ambiguous with several tasks in flight). One retry per shard.
5. **Reduce (mandatory).** One `--reduce-effort low` task receives the merged findings (stable ids), mechanical seam hints extracted from the diff (imports and CSS tokens crossing shard boundaries), and a fixed seam checklist. It must assess every finding (CONFIRMED / SUSPECTED / REJECTED, schema-enforced via `schemas/parallel-reduce-output.schema.json`) and hunt cross-shard defects no single shard could see whole. In the measured run, the highest-value defect was exactly this class: a global CSS token made translucent in one shard silently breaking `bg-*/NN` consumers owned by other shards.
6. **Report.** Findings are deduped (file + line-overlap + title similarity), ranked by severity × confidence, tagged with origin shards and verification, followed by a disproven list, unparsed-shard warnings, and per-shard wall times.
7. **Teardown.** A `finally` block cancels every non-terminal child on any exit path, so the orchestrator can never leave orphaned jobs behind. Children run in the caller's session, so they stay visible in `/codex:status`, cancellable via `/codex:cancel`, and covered by the existing SessionEnd cleanup.

## Changes

- **`plugins/codex/scripts/lib/parallel-review.mjs`** (new): shard planner, seam-hint extraction, finding merge/dedupe/rank, reduce-verdict join, prompt builders, report renderer. Pure logic with injected I/O — covered by `tests/parallel-review.test.mjs`.
- **`plugins/codex/scripts/codex-companion.mjs`**: `parallel-review` handler + orchestrator; two small task-request extensions used by it (`resumeThreadId` — explicit thread resume wins over the ambiguous latest-thread lookup; `outputSchema` — passthrough to `runAppServerTurn`); `handleCancel`'s core extracted into a reusable `cancelJobRecord` (behavior unchanged) so the supervisor can cancel dead children with a proper interrupt + record update.
- **`plugins/codex/scripts/lib/process.mjs`**: `isPidAlive` (signal-0 probe, EPERM counts as alive).
- **`plugins/codex/prompts/parallel-shard-review.md`**, **`parallel-reduce.md`** (new): shard and integration prompts, same adversarial stance and structured-output conventions as `adversarial-review.md`.
- **`plugins/codex/schemas/parallel-reduce-output.schema.json`** (new): reduce output contract.
- **`plugins/codex/commands/parallel-review.md`** (new): `/codex:parallel-review`, review-only, always run as a Claude background task, with an explicit ~k×-token cost confirmation rule.
- **`tests/parallel-review.test.mjs`** (new): gate behavior, directory cohesion + weight balance, oversize splitting, rename-path normalization, cross-shard seam extraction (imports, CSS tokens, global styles), merge/dedupe severity semantics, reduce-verdict join incl. SUSPECTED default, tolerant JSON extraction, renderer sections, `isPidAlive`.

No existing behavior changes: `review`, `adversarial-review`, `task`, `status`, `result`, `cancel` are untouched except the extracted-but-equivalent cancel core and the two opt-in task-request fields (absent in all existing requests).

## Testing

- `npm test`: 101/102 locally — every suite green including the new `parallel-review` tests. The one failure (`git.test.mjs` "skips untracked directories") is a pre-existing environment artifact on my machine: a global gitignore that ignores `.claude/` makes the fixture's untracked dir invisible to git; it fails identically on a pristine `main` checkout and should be green in CI.
- End-to-end behavior (concurrency through the broker-busy fallback, SIGKILL recovery via thread resume, zero orphaned jobs/processes after teardown) was validated with the behavior-identical external prototype against a real repository; run data in #585.

## Deliberate scope cuts (follow-ups if wanted)

- A user-facing `task --resume <thread-id>` flag (the plumbing now exists as `request.resumeThreadId`).
- pid-liveness surfaced in `status` output for all jobs (#517).
- Atomic/locked `state.json` writes (#286, #517) — the stagger reduces but does not eliminate the race.
