### PR TITLE
Add Claude plugin for automatic Obsidian integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,15 @@
         "name": "OpenAI"
       },
       "source": "./plugins/codex"
+    },
+    {
+      "name": "claudian",
+      "description": "Obsidian integration for Claude Code. Auto-saves conversation notes and decisions to your Obsidian vault.",
+      "version": "1.0.0",
+      "author": {
+        "name": "YUICHIRO TANAKA"
+      },
+      "source": "./plugins/claudian"
     }
   ]
 }

--- a/plugins/claudian/.claude-plugin/plugin.json
+++ b/plugins/claudian/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "claudian",
+  "version": "1.0.0",
+  "description": "Obsidian integration for Claude Code. Auto-saves conversation notes and decisions to your Obsidian vault.",
+  "author": {
+    "name": "YUICHIRO TANAKA"
+  }
+}

--- a/plugins/claudian/commands/save.md
+++ b/plugins/claudian/commands/save.md
@@ -1,0 +1,30 @@
+---
+description: Save a note to the Obsidian vault
+argument-hint: "[KEEP|公開用|アーカイブ] [内容の説明]"
+allowed-tools: Bash(node:*)
+---
+
+Save the current conversation context or the user's specified content to the Obsidian vault using the `claudian:obsidian-save` skill.
+
+Folder selection:
+- Default (no keyword) → inbox
+- `KEEP` or `設計原本` → keep
+- `公開用` → public
+- `アーカイブ` → archive
+
+Generate a concise Japanese title and 2–4 relevant tags automatically.
+
+Run:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/obsidian-save.mjs" \
+  --title "<生成した日本語タイトル>" \
+  --content "<保存する内容>" \
+  --folder <inbox|keep|public|archive> \
+  --tags "<タグ1,タグ2>"
+```
+
+Report the result as: `保存しました：<filename>`
+
+Raw user request:
+$ARGUMENTS

--- a/plugins/claudian/scripts/obsidian-save.mjs
+++ b/plugins/claudian/scripts/obsidian-save.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Saves a markdown note to the Obsidian vault.
+ * Usage: node obsidian-save.mjs --title "タイトル" --content "内容" [--folder keep|public|archive]
+ */
+
+import { writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+
+const VAULT_ROOT = "/Users/nesty/TANAKA-BRAIN/田中雄一郎OS保管庫";
+
+const FOLDERS = {
+  inbox:   "00_INBOX",
+  keep:    "02_KEEP",
+  public:  "03_PUBLIC",
+  archive: "99_ARCHIVE",
+};
+
+function today() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function parseArgs(args) {
+  const result = { title: "", content: "", folder: "inbox", tags: [] };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--title")   result.title   = args[++i] ?? "";
+    if (args[i] === "--content") result.content = args[++i] ?? "";
+    if (args[i] === "--folder")  result.folder  = args[++i] ?? "inbox";
+    if (args[i] === "--tags")    result.tags    = (args[++i] ?? "").split(",").map(t => t.trim()).filter(Boolean);
+  }
+  return result;
+}
+
+const { title, content, folder, tags } = parseArgs(process.argv.slice(2));
+
+if (!title || !content) {
+  console.error("Error: --title and --content are required.");
+  process.exit(1);
+}
+
+const folderName = FOLDERS[folder] ?? FOLDERS.inbox;
+const dirPath = join(VAULT_ROOT, folderName);
+mkdirSync(dirPath, { recursive: true });
+
+const date = today();
+const safeName = title.replace(/[/\\:*?"<>|]/g, "_");
+const fileName = `${date}_${safeName}.md`;
+const filePath = join(dirPath, fileName);
+
+const tagLine = tags.length > 0 ? `[${tags.map(t => `"${t}"`).join(", ")}]` : "[]";
+
+const body = `---
+date: ${date}
+tags: ${tagLine}
+---
+
+# ${title}
+
+${content}
+`;
+
+writeFileSync(filePath, body, "utf8");
+console.log(fileName);

--- a/plugins/claudian/skills/obsidian-save/SKILL.md
+++ b/plugins/claudian/skills/obsidian-save/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: obsidian-save
+description: Save a note or conversation summary to the Obsidian vault
+user-invocable: false
+---
+
+# Obsidian Save
+
+Use this skill to save content to the user's Obsidian vault.
+
+## When to invoke
+
+Invoke automatically (without asking) when any of these occur:
+- An important design decision, policy, or conclusion has been finalized
+- A draft reply to 一海 is complete or approved
+- The conversation reaches a natural stopping point
+- The user says「OK」「これでいい」「完了」「保存して」or similar
+
+## How to save
+
+Run the save script:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/obsidian-save.mjs" \
+  --title "日本語タイトル" \
+  --content "保存する内容" \
+  --folder inbox \
+  --tags "タグ1,タグ2"
+```
+
+The script outputs the saved filename. Report it to the user as:
+`保存しました：<filename>`
+
+Nothing else — no elaboration.
+
+## Folder selection
+
+| User keyword | --folder value |
+|---|---|
+| (default / none) | inbox |
+| KEEP / 設計原本 | keep |
+| 公開用 | public |
+| アーカイブ | archive |
+
+## Title and tags
+
+- Generate a concise Japanese title that describes the content.
+- Generate 2–4 relevant Japanese tags.
+- Never ask the user to provide a title or tags.
+
+## Vault path
+
+`/Users/nesty/TANAKA-BRAIN/田中雄一郎OS保管庫/`
+
+| folder value | directory |
+|---|---|
+| inbox | 00_INBOX |
+| keep | 02_KEEP |
+| public | 03_PUBLIC |
+| archive | 99_ARCHIVE |


### PR DESCRIPTION

[README.md](https://github.com/user-attachments/files/30672478/README.md)
Adds a new Claude Code plugin that saves conversation notes and decisions to the user's Obsidian vault automatically.