### PR TITLE
fix: saveState merges with on-disk jobs so stale snapshots cannot destroy concurrent writes

### DIFF
--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -89,10 +89,36 @@ function removeFileIfExists(filePath) {
   }
 }
 
-export function saveState(cwd, state) {
+function isNewerJob(candidate, incumbent) {
+  return String(candidate.updatedAt ?? "").localeCompare(String(incumbent.updatedAt ?? "")) > 0;
+}
+
+export function saveState(cwd, state, options = {}) {
   const previousJobs = loadState(cwd).jobs;
   ensureStateDir(cwd);
-  const nextJobs = pruneJobs(state.jobs ?? []);
+
+  // Merge with the current on-disk jobs so a stale snapshot never destroys
+  // records written by a concurrent process. A job disappears only when the
+  // caller removed it explicitly (removedJobIds) or the prune cap drops it.
+  const removedJobIds = new Set(options.removedJobIds ?? []);
+  const mergedById = new Map((state.jobs ?? []).map((job) => [job.id, job]));
+  for (const job of previousJobs) {
+    const snapshotJob = mergedById.get(job.id);
+    if (!snapshotJob || isNewerJob(job, snapshotJob)) {
+      mergedById.set(job.id, job);
+    }
+  }
+
+  const droppedById = new Map();
+  for (const jobId of removedJobIds) {
+    const job = mergedById.get(jobId);
+    if (job) {
+      droppedById.set(jobId, job);
+      mergedById.delete(jobId);
+    }
+  }
+
+  const nextJobs = pruneJobs([...mergedById.values()]);
   const nextState = {
     version: STATE_VERSION,
     config: {
@@ -103,10 +129,12 @@ export function saveState(cwd, state) {
   };
 
   const retainedIds = new Set(nextJobs.map((job) => job.id));
-  for (const job of previousJobs) {
-    if (retainedIds.has(job.id)) {
-      continue;
+  for (const job of mergedById.values()) {
+    if (!retainedIds.has(job.id)) {
+      droppedById.set(job.id, job);
     }
+  }
+  for (const job of droppedById.values()) {
     removeJobFile(resolveJobFile(cwd, job.id));
     removeFileIfExists(job.logFile);
   }
@@ -115,10 +143,10 @@ export function saveState(cwd, state) {
   return nextState;
 }
 
-export function updateState(cwd, mutate) {
+export function updateState(cwd, mutate, options = {}) {
   const state = loadState(cwd);
   mutate(state);
-  return saveState(cwd, state);
+  return saveState(cwd, state, options);
 }
 
 export function generateJobId(prefix = "job") {

--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -68,10 +68,14 @@ function cleanupSessionJobs(cwd, sessionId) {
     }
   }
 
-  saveState(workspaceRoot, {
-    ...state,
-    jobs: state.jobs.filter((job) => job.sessionId !== sessionId)
-  });
+  saveState(
+    workspaceRoot,
+    {
+      ...state,
+      jobs: state.jobs.filter((job) => job.sessionId !== sessionId)
+    },
+    { removedJobIds: removedJobs.map((job) => job.id) }
+  );
 }
 
 function handleSessionStart(input) {

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -5,7 +5,16 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { makeTempDir } from "./helpers.mjs";
-import { resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState } from "../plugins/codex/scripts/lib/state.mjs";
+import {
+  loadState,
+  resolveJobFile,
+  resolveJobLogFile,
+  resolveStateDir,
+  resolveStateFile,
+  saveState,
+  upsertJob,
+  writeJobFile
+} from "../plugins/codex/scripts/lib/state.mjs";
 
 test("resolveStateDir uses a temp-backed per-workspace directory", () => {
   const workspace = makeTempDir();
@@ -102,4 +111,66 @@ test("saveState prunes dropped job artifacts when indexed jobs exceed the cap", 
       .flatMap((jobId) => [`${jobId}.json`, `${jobId}.log`])
       .sort()
   );
+});
+
+test("saveState with a stale snapshot does not destroy a concurrently written job", () => {
+  const workspace = makeTempDir();
+
+  // Process A: seed job-A and load a snapshot that only knows about it.
+  upsertJob(workspace, {
+    id: "job-A",
+    status: "completed",
+    logFile: resolveJobLogFile(workspace, "job-A")
+  });
+  const staleSnapshot = loadState(workspace);
+
+  // Process B: record job-B along with its result and log files.
+  const jobBLogFile = resolveJobLogFile(workspace, "job-B");
+  fs.writeFileSync(jobBLogFile, "log job-B\n", "utf8");
+  writeJobFile(workspace, "job-B", { id: "job-B", status: "completed" });
+  upsertJob(workspace, {
+    id: "job-B",
+    status: "completed",
+    logFile: jobBLogFile
+  });
+
+  // Process A saves its stale snapshot; job-B must survive untouched.
+  saveState(workspace, staleSnapshot);
+
+  const savedState = JSON.parse(fs.readFileSync(resolveStateFile(workspace), "utf8"));
+  assert.deepEqual(savedState.jobs.map((job) => job.id).sort(), ["job-A", "job-B"]);
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-B")), true);
+  assert.equal(fs.existsSync(jobBLogFile), true);
+});
+
+test("saveState removes ledger entries and artifacts for explicitly removed jobs", () => {
+  const workspace = makeTempDir();
+
+  for (const jobId of ["job-keep", "job-drop"]) {
+    const logFile = resolveJobLogFile(workspace, jobId);
+    fs.writeFileSync(logFile, `log ${jobId}\n`, "utf8");
+    writeJobFile(workspace, jobId, { id: jobId, status: "completed" });
+    upsertJob(workspace, {
+      id: jobId,
+      status: "completed",
+      logFile
+    });
+  }
+
+  const state = loadState(workspace);
+  saveState(
+    workspace,
+    {
+      ...state,
+      jobs: state.jobs.filter((job) => job.id !== "job-drop")
+    },
+    { removedJobIds: ["job-drop"] }
+  );
+
+  const savedState = JSON.parse(fs.readFileSync(resolveStateFile(workspace), "utf8"));
+  assert.deepEqual(savedState.jobs.map((job) => job.id), ["job-keep"]);
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-drop")), false);
+  assert.equal(fs.existsSync(resolveJobLogFile(workspace, "job-drop")), false);
+  assert.equal(fs.existsSync(resolveJobFile(workspace, "job-keep")), true);
+  assert.equal(fs.existsSync(resolveJobLogFile(workspace, "job-keep")), true);
 });


### PR DESCRIPTION
`saveState` treats its in-memory snapshot as authoritative: it prunes any job present on disk but absent from the snapshot and unlinks that job's result file and log. Under concurrent same-workspace use (process A loads state; process B records job-B; process A saves), job-B's ledger entry, .json, and .log are destroyed. Reproduced directly; the included regression test fails on baseline and passes with the fix. Fix: merge the snapshot with the current on-disk jobs list by id (newer updatedAt wins, matching pruneJobs' idiom). Intentional removal is preserved via an explicit removedJobIds option (session-end cleanup updated); MAX_JOBS pruning unchanged. Dependency-free and cross-platform.