### PR TITLE
fix: render status actions without raw HTML in the table cell

### DIFF
--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -116,7 +116,7 @@ function appendActiveJobsTable(lines, jobs) {
       actions.push(`/codex:cancel ${job.id}`);
     }
     lines.push(
-      `| ${escapeMarkdownCell(job.id)} | ${escapeMarkdownCell(job.kindLabel)} | ${escapeMarkdownCell(job.status)} | ${escapeMarkdownCell(job.phase ?? "")} | ${escapeMarkdownCell(job.elapsed ?? "")} | ${escapeMarkdownCell(job.threadId ?? "")} | ${escapeMarkdownCell(job.summary ?? "")} | ${actions.map((action) => `\`${action}\``).join("<br>")} |`
+      `| ${escapeMarkdownCell(job.id)} | ${escapeMarkdownCell(job.kindLabel)} | ${escapeMarkdownCell(job.status)} | ${escapeMarkdownCell(job.phase ?? "")} | ${escapeMarkdownCell(job.elapsed ?? "")} | ${escapeMarkdownCell(job.threadId ?? "")} | ${escapeMarkdownCell(job.summary ?? "")} | ${actions.map((action) => `\`${action}\``).join(" ")} |`
     );
   }
 }

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1145,7 +1145,7 @@ test("status shows phases, hints, and the latest finished job", () => {
   assert.match(result.stdout, /Active jobs:/);
   assert.match(result.stdout, /\| Job \| Kind \| Status \| Phase \| Elapsed \| Codex Session ID \| Summary \| Actions \|/);
   assert.match(result.stdout, /\| review-live \| review \| running \| reviewing \| .* \| thr_1 \| Review working tree diff \|/);
-  assert.match(result.stdout, /`\/codex:status review-live`<br>`\/codex:cancel review-live`/);
+  assert.match(result.stdout, /`\/codex:status review-live` `\/codex:cancel review-live`/);
   assert.match(result.stdout, /Live details:/);
   assert.match(result.stdout, /Latest finished:/);
   assert.match(result.stdout, /Progress:/);


### PR DESCRIPTION
The Actions column of the `/codex:status` job table joins each action with a literal `<br>`, which Claude Code's markdown table renderer prints as text instead of interpreting as a line break.

```
| ... | `/codex:status review-live`<br>`/codex:cancel review-live` |
```

A hard line break can't survive a GFM table cell regardless — `escapeMarkdownCell` a few lines above already collapses newlines to spaces — so the issue's literal "Expected" output isn't reachable without moving the actions out of the table entirely. That felt like a UI change rather than a bug fix, so this takes the first option from the issue's own suggested fix and joins with a space:

```
| ... | `/codex:status review-live` `/codex:cancel review-live` |
```

One line of production code. The existing `status shows phases, hints, and the latest finished job` test asserted the `<br>` form and now asserts the space-joined one, so a regression in the separator fails the suite.

Happy to switch to a nested list outside the cell instead if you'd rather have the actions on genuinely separate lines.

Fixes #495
