### PR TITLE
fix(rescue): await the delegated Codex result instead of returning a placeholder

### DIFF
--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -20,8 +20,9 @@ Selection guidance:
 Forwarding rules:
 
 - Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ...`.
-- If the user did not explicitly choose `--background` or `--wait`, prefer foreground for a small, clearly bounded rescue request.
-- If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution.
+- Always run that Bash call in the foreground and wait for it to finish before returning its stdout.
+  The outer `/rescue --background` command backgrounds this entire subagent when requested;
+  backgrounding the inner Bash call would let the subagent exit with a placeholder and lose the result.
 - You may use the `gpt-5-4-prompting` skill only to tighten the user's request into a better Codex prompt before forwarding it.
 - Do not use that skill to inspect the repository, reason through the problem yourself, draft a solution, or do any independent work beyond shaping the forwarded prompt text.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -25,6 +25,8 @@ Execution rules:
 
 Command selection:
 - Use exactly one `task` invocation per rescue handoff.
+- Always run that Bash call in the foreground. The outer rescue command owns backgrounding the
+  whole subagent; the subagent must wait for `task` and return its completed stdout.
 - If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only. Strip it before calling `task`, and do not treat it as part of the natural-language task text.
 - If the forwarded request includes `--model`, normalize `spark` to `gpt-5.3-codex-spark` and pass it through to `task`.
 - If the forwarded request includes `--effort`, pass it through to `task`.

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -127,8 +127,9 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(agent, /--resume/);
   assert.match(agent, /--fresh/);
   assert.match(agent, /thin forwarding wrapper/i);
-  assert.match(agent, /prefer foreground for a small, clearly bounded rescue request/i);
-  assert.match(agent, /If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution/i);
+  assert.match(agent, /always run that Bash call in the foreground/i);
+  assert.doesNotMatch(agent, /prefer background execution/i);
+  assert.match(runtimeSkill, /always run that Bash call in the foreground/i);
   assert.match(agent, /Use exactly one `Bash` call/i);
   assert.match(agent, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(agent, /Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`/i);


### PR DESCRIPTION
## The bug

`codex-rescue` can exit with a placeholder instead of the delegated result.

The agent definition currently tells the subagent to choose foreground vs background for its single `codex-companion.mjs task ...` call, and to "prefer background execution" when the task looks complicated, open-ended, or long-running. When it takes that branch, the subagent returns as soon as the job is queued — so the caller receives something like *"I'll wait for the background task…"* or a bare run id, and never the actual Codex output. The work may complete fine; the result is simply lost.

## The fix

Keep the subagent's sole `Bash` invocation in the foreground and wait for it, so it returns completed stdout.

This does not remove background execution. Backgrounding is already owned one level up: `/rescue --background` backgrounds the *entire* subagent. It is only the inner `task` call that must not be backgrounded — doing so is what lets the subagent exit early with a placeholder while the outer command believes it finished.

Three files:
- `plugins/codex/agents/codex-rescue.md` — replace the foreground/background selection guidance with an unconditional foreground rule, and state why (the outer command owns backgrounding).
- `plugins/codex/skills/codex-cli-runtime/SKILL.md` — same rule in the runtime skill, so the two documents cannot drift.
- `tests/commands.test.mjs` — assert the new rule in both files, plus `assert.doesNotMatch(agent, /prefer background execution/i)` so the old guidance cannot silently return.

+8 / -4 across 3 files. Documentation and one test; no runtime code changes.

## Verification

Merges cleanly onto `main` @ `db52e28`.

`npm test` was run on this branch **and** on a pristine clone of upstream `main`. The failures in `tests/state.test.mjs` are **pre-existing and identical in both** — that suite needs live Codex job state on the host ("No finished Codex jobs found for this repository yet", "Active jobs:"), which a clean environment does not have. This change neither causes nor fixes them. `tests/commands.test.mjs`, the suite this change actually touches, passes.

## Why it matters beyond convenience

A subagent that returns a placeholder while reporting success is worse than one that fails: the caller records a completed delegation that never delivered. We hit exactly this downstream — a review task came back marked complete, exit 0, in ~7 seconds with zero tool calls, and was very nearly accepted as a genuine second opinion. Making the wait unconditional removes the branch where that can happen.

Happy to adjust the wording or split the test change if you'd prefer it separately.
