### PR TITLE
feat: accept max and ultra reasoning efforts

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Ask Codex to redesign the database connection to be more resilient.
 **Notes:**
 
 - if you do not pass `--model` or `--effort`, Codex chooses its own defaults.
+- `--effort` accepts `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, and `ultra`. Which of those a given model actually supports is decided by Codex, not by the plugin — run `codex debug models` to see the reasoning levels each model advertises.
 - if you say `spark`, the plugin maps that to `gpt-5.3-codex-spark`
 - follow-up rescue requests can continue the latest Codex task in the repo
 

--- a/plugins/codex/commands/rescue.md
+++ b/plugins/codex/commands/rescue.md
@@ -1,6 +1,6 @@
 ---
 description: Delegate investigation, an explicit fix request, or follow-up rescue work to the Codex rescue subagent
-argument-hint: "[--background|--wait] [--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [what Codex should investigate, solve, or continue]"
+argument-hint: "[--background|--wait] [--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh|max|ultra>] [what Codex should investigate, solve, or continue]"
 allowed-tools: Bash(node:*), AskUserQuestion, Agent
 ---
 

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -68,7 +68,16 @@ const ROOT_DIR = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const REVIEW_SCHEMA = path.join(ROOT_DIR, "schemas", "review-output.schema.json");
 const DEFAULT_STATUS_WAIT_TIMEOUT_MS = 240000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS = 2000;
-const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh"]);
+const VALID_REASONING_EFFORTS = new Set([
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra"
+]);
 const MODEL_ALIASES = new Map([["spark", "gpt-5.3-codex-spark"]]);
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
 
@@ -79,7 +88,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh|max|ultra>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
@@ -121,7 +130,7 @@ function normalizeReasoningEffort(effort) {
   }
   if (!VALID_REASONING_EFFORTS.has(normalized)) {
     throw new Error(
-      `Unsupported reasoning effort "${effort}". Use one of: none, minimal, low, medium, high, xhigh.`
+      `Unsupported reasoning effort "${effort}". Use one of: none, minimal, low, medium, high, xhigh, max, ultra.`
     );
   }
   return normalized;

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -32,7 +32,7 @@ Command selection:
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.
 - `--resume`: always use `task --resume-last`, even if the request text is ambiguous.
 - `--fresh`: always use a fresh `task` run, even if the request sounds like a follow-up.
-- `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`.
+- `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`. Not every model supports every value; Codex validates the value against the reasoning levels the selected model advertises.
 - `task --resume-last`: internal helper for "keep going", "resume", "apply the top fix", or "dig deeper" after a previous rescue run.
 
 Safety rules:

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -104,7 +104,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /--background\|--wait/);
   assert.match(rescue, /--resume\|--fresh/);
   assert.match(rescue, /--model <model\|spark>/);
-  assert.match(rescue, /--effort <none\|minimal\|low\|medium\|high\|xhigh>/);
+  assert.match(rescue, /--effort <none\|minimal\|low\|medium\|high\|xhigh\|max\|ultra>/);
   assert.match(rescue, /task-resume-candidate --json/);
   assert.match(rescue, /AskUserQuestion/);
   assert.match(rescue, /Continue current Codex thread/);
@@ -150,7 +150,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /Map `spark` to `--model gpt-5\.3-codex-spark`/i);
   assert.match(runtimeSkill, /If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only/i);
   assert.match(runtimeSkill, /Strip it before calling `task`/i);
-  assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`/i);
+  assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`/i);
   assert.match(runtimeSkill, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
   assert.match(readme, /`codex:codex-rescue` subagent/i);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -784,6 +784,46 @@ test("task forwards model selection and reasoning effort to app-server turn/star
   assert.equal(fakeState.lastTurnStart.effort, "low");
 });
 
+for (const effort of ["max", "ultra"]) {
+  test(`task forwards ${effort} reasoning effort to app-server turn/start`, () => {
+    const repo = makeTempDir();
+    const binDir = makeTempDir();
+    const statePath = path.join(binDir, "fake-codex-state.json");
+    installFakeCodex(binDir);
+    initGitRepo(repo);
+    fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+    run("git", ["add", "README.md"], { cwd: repo });
+    run("git", ["commit", "-m", "init"], { cwd: repo });
+
+    const result = run("node", [SCRIPT, "task", "--effort", effort, "diagnose the failing test"], {
+      cwd: repo,
+      env: buildEnv(binDir)
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+    assert.equal(fakeState.lastTurnStart.effort, effort);
+  });
+}
+
+test("task rejects an unknown reasoning effort", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "--effort", "supreme", "diagnose the failing test"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unsupported reasoning effort "supreme"/);
+});
+
 test("task logs reasoning summaries and assistant messages to the job log", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
## Summary

`--effort max` and `--effort ultra` are rejected by the companion even though Codex supports both:

```
$ node plugins/codex/scripts/codex-companion.mjs task --effort max "reply OK"
Unsupported reasoning effort "max". Use one of: none, minimal, low, medium, high, xhigh.
```

`VALID_REASONING_EFFORTS` in `plugins/codex/scripts/codex-companion.mjs` has been a hardcoded list since the initial commit and has drifted from Codex. This PR adds `max` and `ultra` to it, and updates the usage string, error message, `argument-hint`, runtime skill, README, and tests to match.

## Why these values are valid

**1. The models advertise them.** From `codex debug models` (codex-cli 0.146.1):

| model | advertised reasoning levels |
|---|---|
| `gpt-5.6-sol` | low, medium, high, xhigh, **max**, **ultra** |
| `gpt-5.6-terra` | low, medium, high, xhigh, **max**, **ultra** |
| `gpt-5.6-luna` | low, medium, high, xhigh, **max** |
| `gpt-5.5` | low, medium, high, xhigh |
| `gpt-5.4`, `gpt-5.4-mini` | low, medium, high, xhigh |
| `gpt-5.3-codex-spark` | low, medium, high, xhigh |

Codex's own instructions agree: *"GPT-5.6 supports `none`, `low`, `medium`, `high`, `xhigh`, and `max`. If omitted, GPT-5.6 defaults to `medium`."*

**2. The app-server protocol does not model effort as a closed enum.** From `codex app-server generate-ts`:

```ts
// v2/TurnStartParams.ts
effort?: ReasoningEffort | null

// ReasoningEffort.ts
export type ReasoningEffort = string;
```

Effort is an open string, and Codex validates it against the reasoning levels the selected model advertises. A hardcoded allowlist in the plugin is therefore guaranteed to fall behind — and it already has, in both directions: it still accepts `none` and `minimal`, which no model in the current catalog advertises, while rejecting `max` and `ultra`, which the current models do.

**3. Verified end to end** against a real Codex run through the app-server path this plugin uses:

```
$ node plugins/codex/scripts/codex-companion.mjs task \
    --model gpt-5.6-luna --effort max "Reply with exactly: OK"
[codex] Starting Codex task thread.
[codex] Thread ready (019fe094-6c30-7461-b323-4b2a29c29bd7).
[codex] Turn started (019fe094-74f9-7301-84a6-853dae641467).
[codex] Assistant message captured: OK
[codex] Turn completed.
OK
```

## Note on #99

#99 (closing #77) changed the README example from `model_reasoning_effort = "xhigh"` to `"high"` on the grounds that `xhigh` was unsupported. `xhigh` is in fact advertised by every model in the catalog above, including the `gpt-5.4` generation current at the time. That change is unrelated to this PR's diff, but it's the same root cause: the effort list has never tracked upstream. Happy to send a follow-up restoring that example if you'd like.

## Design choice

Per-model validation stays with Codex, which is where the model catalog lives. The companion's list only rejects values Codex has no variant for at all, so `--effort ultra` on a model that does not advertise `ultra` is Codex's error to raise, not the plugin's.

If you'd prefer the stricter version, I can narrow this to `max` only and drop `ultra`. If you'd prefer the looser one, dropping the allowlist entirely and forwarding any non-empty string is the option that matches the protocol's own design most closely — say the word and I'll rework it.

## Tests

Added to `tests/runtime.test.mjs`:
- `max` and `ultra` are forwarded to app-server `turn/start` (table-driven over both values)
- an unknown effort is still rejected

Updated the `--effort` assertions in `tests/commands.test.mjs`.

`npm test` from a clean state: **90 pass, 4 fail**. The 4 failures (`resolveStateDir uses a temp-backed per-workspace directory`, `status shows phases, hints, and the latest finished job`, `status preserves adversarial review kind labels`, `result returns the stored output for the latest finished job by default`) reproduce identically on `main` with this branch stashed, so they are pre-existing on my machine and not introduced here. Two contributing factors I found while bisecting, in case they're useful:

- The `setup`/`status`/`result` tests run with `cwd: ROOT` and leave plugin state (`broker.json`, `jobs/`) in the repository's own state directory. A second `npm test` run in the same checkout then sees a registered shared runtime, and five `setup` tests flip to `ready: true`. Deleting the state directory restores them.
- `resolveStateDir uses a temp-backed per-workspace directory` fails whenever `CLAUDE_PLUGIN_DATA` is set in the environment, which it is when the suite is run from inside Claude Code with this plugin installed. It passes under `env -u CLAUDE_PLUGIN_DATA`.

Both are out of scope here; I can open separate issues.
