### PR TITLE
fix: lower the SessionEnd hook timeout to Codex CLI's 3s cap

### DIFF
--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -18,7 +18,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-lifecycle-hook.mjs\" SessionEnd",
-            "timeout": 5
+            "timeout": 3
           }
         ]
       }

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -208,6 +208,8 @@ test("hooks keep session-end cleanup and stop gating enabled", () => {
   assert.match(source, /SessionEnd/);
   assert.match(source, /stop-review-gate-hook\.mjs/);
   assert.match(source, /session-lifecycle-hook\.mjs/);
+  const sessionEndTimeout = JSON.parse(source).hooks.SessionEnd[0].hooks[0].timeout;
+  assert.ok(sessionEndTimeout <= 3, "SessionEnd timeout must not exceed Codex CLI's 3s cap");
 });
 
 test("setup command can offer Codex install and still points users to codex login", () => {


### PR DESCRIPTION
## Summary

Codex CLI clamps `SessionEnd` hook timeouts to 3 seconds (`SESSION_END_MAX_TIMEOUT_SEC` in `codex-rs/hooks/src/events/session_end.rs`) and prints a warning on every startup when a manifest declares more:

```text
warning: clamping SessionEnd hook timeout to 3s in .../plugins/cache/openai-codex/codex/1.0.6/hooks/hooks.json
```

The bundled manifest declares 5 seconds, so every session that loads the plugin starts with this warning while the hook runs under a 3-second budget anyway. This lowers the declared timeout to 3 so the manifest matches what actually runs. The `SessionStart` and `Stop` timeouts are untouched — Codex does not clamp those.

Fixes #582

## Validation

- `node --test tests/commands.test.mjs` — 8 passed, including a new assertion that the `SessionEnd` timeout stays within the 3-second cap
- `npm test` — 87 passed; the 4 failures (`status`/`result`/`resolveStateDir` tests) fail identically on a clean checkout of `main` in this environment
- `npm run check-version` — all version metadata matches 1.0.6