### PR TITLE
Fix transfer resolution after Claude session forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Examples:
 /codex:transfer --source ~/.claude/projects/-Users-me-repo/<session-id>.jsonl
 ```
 
-The plugin's existing `SessionStart` hook supplies the current transcript path automatically; `--source` is available as a manual override. The transfer uses Codex's external-agent session importer, so it follows the same conversion rules as importing Claude history in the Codex App and creates visible turns that can be continued in the App or TUI. The source must be under `~/.claude/projects`, and older Codex versions that do not expose session import must be upgraded before using this command.
+The plugin's existing `SessionStart` hook supplies the current transcript path automatically. If that hook state is missing or stale after Claude forks a session during compaction, transfer resolves Claude's current session ID to a unique transcript under `~/.claude/projects`. `--source` is available as a manual override and is required when multiple transcripts share the same session ID. The transfer uses Codex's external-agent session importer, so it follows the same conversion rules as importing Claude history in the Codex App and creates visible turns that can be continued in the App or TUI. The source must be under `~/.claude/projects`, and older Codex versions that do not expose session import must be upgraded before using this command.
 
 ### `/codex:status`
 

--- a/plugins/codex/scripts/lib/claude-session-transfer.mjs
+++ b/plugins/codex/scripts/lib/claude-session-transfer.mjs
@@ -5,6 +5,8 @@ import path from "node:path";
 import { ensureAbsolutePath } from "./fs.mjs";
 
 export const TRANSCRIPT_PATH_ENV = "CODEX_COMPANION_TRANSCRIPT_PATH";
+const CLAUDE_SESSION_ID_ENV = "CLAUDE_CODE_SESSION_ID";
+const COMPANION_SESSION_ID_ENV = "CODEX_COMPANION_SESSION_ID";
 const CLAUDE_PROJECTS_DIR = path.join(os.homedir(), ".claude", "projects");
 
 function resolveUserPath(cwd, value) {
@@ -17,12 +19,51 @@ function resolveUserPath(cwd, value) {
   return ensureAbsolutePath(cwd, value);
 }
 
-export function resolveClaudeSessionPath(cwd, options = {}) {
-  const requestedPath = options.source || process.env[TRANSCRIPT_PATH_ENV];
-  if (!requestedPath) {
-    throw new Error("Could not identify the current Claude transcript. Retry with --source <path-to-claude-jsonl>.");
+function findSessionTranscripts(sessionId) {
+  if (!sessionId || !/^[a-zA-Z0-9_-]+$/.test(sessionId)) {
+    return [];
   }
 
+  const filename = `${sessionId}.jsonl`;
+  const matches = [];
+  const pending = [CLAUDE_PROJECTS_DIR];
+
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(directory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(entryPath);
+      } else if (entry.isFile() && entry.name === filename) {
+        matches.push(entryPath);
+      }
+    }
+  }
+
+  return matches;
+}
+
+function resolveSessionIdPath(cwd, sessionId) {
+  const matches = findSessionTranscripts(sessionId);
+  if (matches.length === 0) {
+    return null;
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Multiple Claude transcripts matched session ${sessionId}. Retry with --source <path-to-claude-jsonl>.`
+    );
+  }
+  return resolveTranscriptPath(cwd, matches[0]);
+}
+
+function resolveTranscriptPath(cwd, requestedPath) {
   const sourcePath = resolveUserPath(cwd, requestedPath);
   if (path.extname(sourcePath) !== ".jsonl") {
     throw new Error(`Claude session source must be a JSONL file: ${sourcePath}`);
@@ -41,4 +82,41 @@ export function resolveClaudeSessionPath(cwd, options = {}) {
     throw new Error(`Codex can import Claude sessions only from ${CLAUDE_PROJECTS_DIR}: ${source}`);
   }
   return source;
+}
+
+export function resolveClaudeSessionPath(cwd, options = {}) {
+  if (options.source) {
+    return resolveTranscriptPath(cwd, options.source);
+  }
+
+  const claudeSessionId = process.env[CLAUDE_SESSION_ID_ENV];
+  if (claudeSessionId) {
+    const source = resolveSessionIdPath(cwd, claudeSessionId);
+    if (source) {
+      return source;
+    }
+  }
+
+  const requestedPath = process.env[TRANSCRIPT_PATH_ENV];
+  if (requestedPath) {
+    try {
+      return resolveTranscriptPath(cwd, requestedPath);
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.startsWith("Claude session file not found:")) {
+        throw error;
+      }
+    }
+  }
+
+  const companionSessionId = process.env[COMPANION_SESSION_ID_ENV];
+  if (companionSessionId && companionSessionId !== claudeSessionId) {
+    const source = resolveSessionIdPath(cwd, companionSessionId);
+    if (source) {
+      return source;
+    }
+  }
+
+  throw new Error(
+    "Could not identify the current Claude transcript. Retry with --source <path-to-claude-jsonl>."
+  );
 }

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -221,7 +221,7 @@ test("transfer delegates the current Claude session directly to native import", 
       ...buildEnv(binDir),
       HOME: home,
       CODEX_HOME: path.join(home, ".codex"),
-      CODEX_COMPANION_TRANSCRIPT_PATH: sourcePath
+      CLAUDE_CODE_SESSION_ID: sessionId
     }
   });
 
@@ -242,6 +242,79 @@ test("transfer delegates the current Claude session directly to native import", 
     fakeState.threads[0].visibleMessages.map((message) => message.text),
     ["Initial request", "Initial answer", "/codex:transfer"]
   );
+});
+
+test("transfer prefers Claude's current session id over stale companion hook state", () => {
+  const home = makeTempDir();
+  const repo = path.join(home, "repo");
+  const binDir = makeTempDir();
+  const currentSessionId = "sess-current-fork";
+  const staleSessionId = "sess-stale-parent";
+  const projectDir = path.join(home, ".claude", "projects", "-repo");
+  const currentSourcePath = path.join(projectDir, `${currentSessionId}.jsonl`);
+  const staleSourcePath = path.join(projectDir, `${staleSessionId}.jsonl`);
+  fs.mkdirSync(repo, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  fs.writeFileSync(
+    currentSourcePath,
+    `${JSON.stringify({ type: "user", cwd: repo, message: { role: "user", content: "Current fork" } })}\n`,
+    "utf8"
+  );
+  fs.writeFileSync(
+    staleSourcePath,
+    `${JSON.stringify({ type: "user", cwd: repo, message: { role: "user", content: "Stale parent" } })}\n`,
+    "utf8"
+  );
+
+  const result = run("node", [SCRIPT, "transfer", "--json"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      HOME: home,
+      CODEX_HOME: path.join(home, ".codex"),
+      CLAUDE_CODE_SESSION_ID: currentSessionId,
+      CODEX_COMPANION_SESSION_ID: staleSessionId,
+      CODEX_COMPANION_TRANSCRIPT_PATH: staleSourcePath
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.sessionId, currentSessionId);
+  assert.equal(payload.sourcePath, fs.realpathSync(currentSourcePath));
+});
+
+test("transfer requires an explicit source when a session id matches multiple transcripts", () => {
+  const home = makeTempDir();
+  const repo = path.join(home, "repo");
+  const binDir = makeTempDir();
+  const sessionId = "sess-ambiguous";
+  fs.mkdirSync(repo, { recursive: true });
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  for (const project of ["-repo", "-repo-worktree"]) {
+    const projectDir = path.join(home, ".claude", "projects", project);
+    fs.mkdirSync(projectDir, { recursive: true });
+    fs.writeFileSync(path.join(projectDir, `${sessionId}.jsonl`), "{}\n", "utf8");
+  }
+
+  const result = run("node", [SCRIPT, "transfer"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      HOME: home,
+      CODEX_HOME: path.join(home, ".codex"),
+      CLAUDE_CODE_SESSION_ID: sessionId
+    }
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Multiple Claude transcripts matched session sess-ambiguous/);
+  assert.match(result.stderr, /--source <path-to-claude-jsonl>/);
 });
 
 test("transfer reports an actionable upgrade error when native import is unsupported", () => {


### PR DESCRIPTION
## Summary

- resolve `/codex:transfer` from Claude Code's current `CLAUDE_CODE_SESSION_ID`
- prefer the current fork after compaction over stale companion hook state
- reject duplicate session-ID matches and preserve `--source` as the explicit override

## Root cause

Claude Code can mint a new session ID when compaction resumes through a fork. Fresh tool shells expose the new ID through `CLAUDE_CODE_SESSION_ID`, but the plugin currently relies on `CODEX_COMPANION_TRANSCRIPT_PATH` persisted by its `SessionStart` hook. That hook state can be missing or can still identify the parent session, causing transfer to fail or import stale history.

The same lookup also resolves worktree path drift: the current session ID is matched to the unique JSONL anywhere beneath `~/.claude/projects`.

## Issues

Closes #502.

Related to #514: this fixes its no-argument transcript-identification failure when Claude exposes `CLAUDE_CODE_SESSION_ID`, but not the separate Windows post-import ledger lookup failure.

Related upstream: anthropics/claude-code#79830 tracks the underlying compact/fork lifecycle mismatch.

## Behavior

1. An explicit `--source` remains authoritative.
2. Otherwise, the current native Claude session ID is resolved first.
3. The existing companion transcript path and companion session ID remain fallbacks.
4. Ambiguous session-ID matches fail closed and request `--source`.
5. The existing realpath containment check still requires the source to live under `~/.claude/projects`.

## Validation

- `node --test --test-name-pattern='transfer' tests/runtime.test.mjs`
- `npm test`: 92/93 passed; the unrelated background-worker status test observed `running` before completion
- isolated rerun of `task --background enqueues a detached worker and exposes per-job status`: passed
- structured Codex autoreview: no actionable findings; patch assessed correct at 0.9 confidence
- reproduced against a real compact-fork pair where native session `3aab…` superseded stale companion session `1cde…`
