### PR TITLE
Suppress dynamic tool progress in stderr

### DIFF
--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -252,7 +252,7 @@ function describeStartedItem(state, item) {
     case "mcpToolCall":
       return { message: `Calling ${item.server}/${item.tool}.`, phase: "investigating" };
     case "dynamicToolCall":
-      return { message: `Running tool: ${item.tool}.`, phase: "investigating" };
+      return { message: `Running tool: ${item.tool}.`, phase: "investigating", hideFromStderr: true };
     case "collabAgentToolCall": {
       const subagents = (item.receiverThreadIds ?? []).map((threadId) => labelForThread(state, threadId) ?? threadId);
       const summary =
@@ -283,7 +283,7 @@ function describeCompletedItem(state, item) {
     case "mcpToolCall":
       return { message: `Tool ${item.server}/${item.tool} ${item.status}.`, phase: "investigating" };
     case "dynamicToolCall":
-      return { message: `Tool ${item.tool} ${item.status}.`, phase: "investigating" };
+      return { message: `Tool ${item.tool} ${item.status}.`, phase: "investigating", hideFromStderr: true };
     case "collabAgentToolCall": {
       const subagents = (item.receiverThreadIds ?? []).map((threadId) => labelForThread(state, threadId) ?? threadId);
       const summary =
@@ -524,14 +524,18 @@ function applyTurnNotification(state, message) {
       recordItem(state, message.params.item, "started", message.params.threadId ?? null);
       {
         const update = describeStartedItem(state, message.params.item);
-        emitProgress(state.onProgress, update?.message, update?.phase ?? null);
+        emitProgress(state.onProgress, update?.message, update?.phase ?? null, {
+          hideFromStderr: update?.hideFromStderr === true
+        });
       }
       break;
     case "item/completed":
       recordItem(state, message.params.item, "completed", message.params.threadId ?? null);
       {
         const update = describeCompletedItem(state, message.params.item);
-        emitProgress(state.onProgress, update?.message, update?.phase ?? null);
+        emitProgress(state.onProgress, update?.message, update?.phase ?? null, {
+          hideFromStderr: update?.hideFromStderr === true
+        });
       }
       break;
     case "error":

--- a/plugins/codex/scripts/lib/tracked-jobs.mjs
+++ b/plugins/codex/scripts/lib/tracked-jobs.mjs
@@ -16,6 +16,7 @@ function normalizeProgressEvent(value) {
       phase: typeof value.phase === "string" && value.phase.trim() ? value.phase.trim() : null,
       threadId: typeof value.threadId === "string" && value.threadId.trim() ? value.threadId.trim() : null,
       turnId: typeof value.turnId === "string" && value.turnId.trim() ? value.turnId.trim() : null,
+      hideFromStderr: value.hideFromStderr === true,
       stderrMessage: value.stderrMessage == null ? null : String(value.stderrMessage).trim(),
       logTitle: typeof value.logTitle === "string" && value.logTitle.trim() ? value.logTitle.trim() : null,
       logBody: value.logBody == null ? null : String(value.logBody).trimEnd()
@@ -27,6 +28,7 @@ function normalizeProgressEvent(value) {
     phase: null,
     threadId: null,
     turnId: null,
+    hideFromStderr: false,
     stderrMessage: String(value ?? "").trim(),
     logTitle: null,
     logBody: null
@@ -122,7 +124,7 @@ export function createProgressReporter({ stderr = false, logFile = null, onEvent
   return (eventOrMessage) => {
     const event = normalizeProgressEvent(eventOrMessage);
     const stderrMessage = event.stderrMessage ?? event.message;
-    if (stderr && stderrMessage) {
+    if (stderr && !event.hideFromStderr && stderrMessage) {
       process.stderr.write(`[codex] ${stderrMessage}\n`);
     }
     appendLogLine(logFile, event.message);

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -568,6 +568,22 @@ rl.on("line", (line) => {
         }
 
         const items = [
+          ...(BEHAVIOR === "noisy-tool-progress"
+            ? Array.from({ length: 100 }, (_, index) => ({
+                started: {
+                  type: "dynamicToolCall",
+                  id: "tool_started_" + turnId + "_" + index,
+                  tool: index % 2 === 0 ? "Read" : "Bash",
+                  status: "inProgress"
+                },
+                completed: {
+                  type: "dynamicToolCall",
+                  id: "tool_completed_" + turnId + "_" + index,
+                  tool: index % 2 === 0 ? "Read" : "Bash",
+                  status: "completed"
+                }
+              }))
+            : []),
           ...(BEHAVIOR === "with-reasoning"
             ? [
                 {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -175,6 +175,28 @@ test("task runs when the active provider does not require OpenAI login", () => {
   assert.match(result.stdout, /Handled the requested task/);
 });
 
+test("task keeps high-frequency dynamic tool progress out of foreground stderr and in the job log", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "noisy-tool-progress");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "exercise progress reporting"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stderr, /Running tool:|Tool (Read|Bash) completed/);
+  const state = JSON.parse(fs.readFileSync(path.join(resolveStateDir(repo), "state.json"), "utf8"));
+  const log = fs.readFileSync(state.jobs[0].logFile, "utf8");
+  assert.equal((log.match(/Running tool:/g) ?? []).length, 100);
+  assert.equal((log.match(/Tool (Read|Bash) completed/g) ?? []).length, 100);
+});
+
 test("task runs without auth preflight so Codex can refresh an expired session", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
## Summary

Suppress high-frequency `dynamicToolCall` progress updates from foreground stderr while retaining them in each job's log file.

## Why

The Claude Code host can retain stderr progress as transcript tool output. A task with many dynamic `Read`/`Bash` calls can therefore create a very large, repetitive JSONL assistant record and make session resume slow or unusable.

## Change

- add `hideFromStderr` to normalized progress events;
- mark only dynamic tool start/completion progress as hidden from stderr;
- retain every event in the job log and preserve all other foreground progress.

## Validation

- `npm test`
- new regression fixture emits 100 dynamic tool start/completion pairs;
- regression asserts zero such lines on stderr and 100 start + 100 completion entries in the job log.
