### PR TITLE
fix: skip Stop review when thumbs owns the fixer

### DIFF
--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -140,6 +140,12 @@ function runStopReview(cwd, input = {}) {
 }
 
 function main() {
+  // thumbs owns its review/fix loop and marks the Claude fixer process so
+  // this interactive gate does not start a nested, untracked Codex review.
+  if (process.env.THUMBS_ACTIVE === "1") {
+    return;
+  }
+
   const input = readHookInput();
   const cwd = input.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd();
   const workspaceRoot = resolveWorkspaceRoot(cwd);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1979,6 +1979,40 @@ test("stop hook runs a stop-time review task and blocks on findings when the rev
   assert.match(status.stdout, /Codex Stop Gate Review/);
 });
 
+test("stop hook skips review when thumbs owns the fixer session", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const fakeStatePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  const setup = run("node", [SCRIPT, "setup", "--enable-review-gate", "--json"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+  assert.equal(setup.status, 0, setup.stderr);
+  assert.equal(JSON.parse(setup.stdout).reviewGateEnabled, true);
+  const stateBeforeStop = fs.readFileSync(fakeStatePath, "utf8");
+
+  const skipped = run("node", [STOP_HOOK], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      THUMBS_ACTIVE: "1",
+      THUMBS_STAGE: "fixer"
+    },
+    input: JSON.stringify({
+      cwd: repo,
+      last_assistant_message: "I completed the requested fix."
+    })
+  });
+
+  assert.equal(skipped.status, 0, skipped.stderr);
+  assert.equal(skipped.stdout, "");
+  assert.equal(skipped.stderr, "");
+  assert.equal(fs.readFileSync(fakeStatePath, "utf8"), stateBeforeStop);
+});
+
 test("stop hook logs running tasks to stderr without blocking when the review gate is disabled", () => {
   const repo = makeTempDir();
   initGitRepo(repo);


### PR DESCRIPTION
## Summary

- skip the optional Stop-time review when `THUMBS_ACTIVE=1`
- prevent the interactive gate from nesting an untracked Codex review inside a thumbs fixer session
- cover the ownership handshake with a runtime regression test

## Context

[thumbs](https://github.com/dotbrains/thumbs) is a bounded Codex-review → Claude-fix automation harness. Its noninteractive Claude fixer inherits enabled plugin hooks. When this plugin's optional review gate is enabled, the Stop hook can therefore start a second review loop inside the one thumbs already owns.

thumbs now exports `THUMBS_ACTIVE=1` and `THUMBS_STAGE=fixer` only for that fixer process. Treating `THUMBS_ACTIVE` as the orchestration ownership signal lets both tools remain installed without disabling unrelated Claude hooks.

## Verification

- `node --test --test-name-pattern='stop hook skips review when thumbs owns' tests/runtime.test.mjs`
- `npm test` (92 passing)
