### PR TITLE
Accept MCP elicitation requests so headless MCP tool calls work

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -23,10 +23,28 @@ export const BROKER_ENDPOINT_ENV = "CODEX_COMPANION_APP_SERVER_ENDPOINT";
 export const BROKER_BUSY_RPC_CODE = -32001;
 
 /**
- * Server-initiated request Codex uses to gate MCP tool calls.
+ * Server-initiated request Codex uses to gate MCP tool calls. The same method
+ * also carries ordinary form and URL elicitations from configured MCP servers.
  * See `ServerRequest` in `codex-rs/app-server-protocol`.
  */
 export const MCP_ELICITATION_REQUEST_METHOD = "mcpServer/elicitation/request";
+
+/**
+ * Discriminator that marks a privileged Codex approval rather than a plain MCP
+ * elicitation. See `APPROVAL_KIND_KEY` / `APPROVAL_KIND_MCP_TOOL_CALL` in
+ * `codex-rs/protocol/src/mcp_approval_meta.rs`.
+ */
+const APPROVAL_KIND_KEY = "codex_approval_kind";
+const APPROVAL_KIND_MCP_TOOL_CALL = "mcp_tool_call";
+
+/** @param {unknown} meta */
+function isMcpToolCallApproval(meta) {
+  return (
+    typeof meta === "object" &&
+    meta !== null &&
+    meta[APPROVAL_KIND_KEY] === APPROVAL_KIND_MCP_TOOL_CALL
+  );
+}
 
 /**
  * Build the reply to a server-initiated request.
@@ -37,15 +55,22 @@ export const MCP_ELICITATION_REQUEST_METHOD = "mcpServer/elicitation/request";
  * Replying with an error leaves the elicitation unresolved, and core maps that
  * to `ReviewDecision::Abort`, surfaced as "user rejected MCP tool call". Runs
  * driven by this client are headless, so no one can accept interactively and
- * every MCP tool call would fail. Accept explicitly instead.
+ * every MCP tool call would fail. Accept those explicitly.
  *
- * @param {{ id: unknown, method?: string }} message
+ * The same method also delivers ordinary form and URL elicitations from
+ * configured MCP servers. A headless client cannot render a form or complete a
+ * URL flow, so accepting one with empty content would hand the server bogus
+ * consent or invalid input. Decline those instead, which is a valid protocol
+ * answer and lets the server fail cleanly.
+ *
+ * @param {{ id: unknown, method?: string, params?: { _meta?: unknown } }} message
  */
 export function buildServerRequestResponse(message) {
   if (message.method === MCP_ELICITATION_REQUEST_METHOD) {
+    const action = isMcpToolCallApproval(message.params?._meta) ? "accept" : "decline";
     return {
       id: message.id,
-      result: { action: "accept", content: null, _meta: null }
+      result: { action, content: null, _meta: null }
     };
   }
 

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -22,6 +22,39 @@ const PLUGIN_MANIFEST = JSON.parse(fs.readFileSync(PLUGIN_MANIFEST_URL, "utf8"))
 export const BROKER_ENDPOINT_ENV = "CODEX_COMPANION_APP_SERVER_ENDPOINT";
 export const BROKER_BUSY_RPC_CODE = -32001;
 
+/**
+ * Server-initiated request Codex uses to gate MCP tool calls.
+ * See `ServerRequest` in `codex-rs/app-server-protocol`.
+ */
+export const MCP_ELICITATION_REQUEST_METHOD = "mcpServer/elicitation/request";
+
+/**
+ * Build the reply to a server-initiated request.
+ *
+ * Codex gates MCP tool calls behind an MCP elicitation rather than the
+ * exec/patch approval channel, so the `approvalPolicy: "never"` that every
+ * thread started by this client already declares does not cover them.
+ * Replying with an error leaves the elicitation unresolved, and core maps that
+ * to `ReviewDecision::Abort`, surfaced as "user rejected MCP tool call". Runs
+ * driven by this client are headless, so no one can accept interactively and
+ * every MCP tool call would fail. Accept explicitly instead.
+ *
+ * @param {{ id: unknown, method?: string }} message
+ */
+export function buildServerRequestResponse(message) {
+  if (message.method === MCP_ELICITATION_REQUEST_METHOD) {
+    return {
+      id: message.id,
+      result: { action: "accept", content: null, _meta: null }
+    };
+  }
+
+  return {
+    id: message.id,
+    error: buildJsonRpcError(-32601, `Unsupported server request: ${message.method}`)
+  };
+}
+
 /** @type {ClientInfo} */
 const DEFAULT_CLIENT_INFO = {
   title: "Codex Plugin",
@@ -154,10 +187,7 @@ class AppServerClientBase {
   }
 
   handleServerRequest(message) {
-    this.sendMessage({
-      id: message.id,
-      error: buildJsonRpcError(-32601, `Unsupported server request: ${message.method}`)
-    });
+    this.sendMessage(buildServerRequestResponse(message));
   }
 
   handleExit(error) {

--- a/tests/app-server.test.mjs
+++ b/tests/app-server.test.mjs
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  MCP_ELICITATION_REQUEST_METHOD,
+  buildServerRequestResponse
+} from "../plugins/codex/scripts/lib/app-server.mjs";
+
+test("accepts MCP elicitation requests so headless MCP tool calls are not denied", () => {
+  const response = buildServerRequestResponse({
+    id: 12,
+    method: MCP_ELICITATION_REQUEST_METHOD,
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      serverName: "example",
+      mode: "form",
+      message: "Allow this tool call?",
+      requestedSchema: { type: "object", properties: {} }
+    }
+  });
+
+  assert.deepEqual(response, {
+    id: 12,
+    result: { action: "accept", content: null, _meta: null }
+  });
+});
+
+test("still rejects server requests the client does not implement", () => {
+  const response = buildServerRequestResponse({
+    id: "req-7",
+    method: "item/tool/requestUserInput"
+  });
+
+  assert.equal(response.id, "req-7");
+  assert.equal(response.result, undefined);
+  assert.equal(response.error.code, -32601);
+  assert.match(response.error.message, /item\/tool\/requestUserInput/);
+});
+
+test("preserves the request id type for string ids", () => {
+  const response = buildServerRequestResponse({
+    id: "elicitation-42",
+    method: MCP_ELICITATION_REQUEST_METHOD
+  });
+
+  assert.equal(response.id, "elicitation-42");
+  assert.equal(response.result.action, "accept");
+});

--- a/tests/app-server.test.mjs
+++ b/tests/app-server.test.mjs
@@ -6,7 +6,7 @@ import {
   buildServerRequestResponse
 } from "../plugins/codex/scripts/lib/app-server.mjs";
 
-test("accepts MCP elicitation requests so headless MCP tool calls are not denied", () => {
+test("accepts MCP tool-call approvals so headless MCP tool calls are not denied", () => {
   const response = buildServerRequestResponse({
     id: 12,
     method: MCP_ELICITATION_REQUEST_METHOD,
@@ -16,7 +16,8 @@ test("accepts MCP elicitation requests so headless MCP tool calls are not denied
       serverName: "example",
       mode: "form",
       message: "Allow this tool call?",
-      requestedSchema: { type: "object", properties: {} }
+      requestedSchema: { type: "object", properties: {} },
+      _meta: { codex_approval_kind: "mcp_tool_call" }
     }
   });
 
@@ -24,6 +25,61 @@ test("accepts MCP elicitation requests so headless MCP tool calls are not denied
     id: 12,
     result: { action: "accept", content: null, _meta: null }
   });
+});
+
+test("declines plain form elicitations this headless client cannot fill in", () => {
+  const response = buildServerRequestResponse({
+    id: 13,
+    method: MCP_ELICITATION_REQUEST_METHOD,
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      serverName: "example",
+      mode: "form",
+      message: "Enter your project name",
+      requestedSchema: {
+        type: "object",
+        properties: { project: { type: "string" } },
+        required: ["project"]
+      },
+      _meta: null
+    }
+  });
+
+  assert.equal(response.result.action, "decline");
+  assert.equal(response.result.content, null);
+});
+
+test("declines URL elicitations, e.g. an auth flow nobody can complete", () => {
+  const response = buildServerRequestResponse({
+    id: 14,
+    method: MCP_ELICITATION_REQUEST_METHOD,
+    params: {
+      threadId: "thread-1",
+      serverName: "example",
+      mode: "url",
+      message: "Authorize this connector",
+      url: "https://example.com/oauth",
+      elicitationId: "elicit-1"
+    }
+  });
+
+  assert.equal(response.result.action, "decline");
+});
+
+test("declines approvals of a kind this client does not implement", () => {
+  const response = buildServerRequestResponse({
+    id: 15,
+    method: MCP_ELICITATION_REQUEST_METHOD,
+    params: {
+      serverName: "example",
+      mode: "form",
+      message: "Add this tool?",
+      _meta: { codex_approval_kind: "tool_suggestion" }
+    }
+  });
+
+  assert.equal(response.result.action, "decline");
 });
 
 test("still rejects server requests the client does not implement", () => {
@@ -41,7 +97,8 @@ test("still rejects server requests the client does not implement", () => {
 test("preserves the request id type for string ids", () => {
   const response = buildServerRequestResponse({
     id: "elicitation-42",
-    method: MCP_ELICITATION_REQUEST_METHOD
+    method: MCP_ELICITATION_REQUEST_METHOD,
+    params: { _meta: { codex_approval_kind: "mcp_tool_call" } }
   });
 
   assert.equal(response.id, "elicitation-42");


### PR DESCRIPTION
Fixes #640.

## Problem

Every MCP tool call inside a plugin-driven run (`/codex:rescue`, `codex-companion.mjs task`) fails immediately. The job log shows only:

```
Calling my-server/my.tool.
Tool my-server/my.tool failed.
```

The rollout under `~/.codex/sessions/` has the real cause:

```json
{"type": "mcp_tool_call_end",
 "invocation": {"server": "my-server", "tool": "my.tool", ...},
 "duration": {"secs": 0, "nanos": 0},
 "result": {"Err": "user rejected MCP tool call"}}
```

`duration` is 0 — the call never leaves the client.

## Cause

Codex gates MCP tool calls behind an MCP **elicitation** (`mcpServer/elicitation/request`), not the exec/patch approval channel. So the `approvalPolicy: "never"` that `buildThreadParams` already sets for every thread this client starts does not cover them.

`handleServerRequest` answered *every* server-initiated request with `-32601`:

```js
handleServerRequest(message) {
  this.sendMessage({
    id: message.id,
    error: buildJsonRpcError(-32601, `Unsupported server request: ${message.method}`)
  });
}
```

That leaves the elicitation unresolved, and `codex-rs/core/src/mcp_tool_call.rs` maps a missing response to `ReviewDecision::Abort`, surfaced as `user rejected MCP tool call`. Runs driven by this client are headless, so nobody can accept interactively and every MCP tool call fails.

The user-visible symptom is misleading: the agent concludes its MCP servers are unreachable and works without them. In my case that was a memory server the agent is instructed to consult before non-trivial work — it silently proceeded without project context and reported the memory as unavailable, which sent me looking for a networking problem that did not exist.

## Change

Answer `mcpServer/elicitation/request` with `action: "accept"`, per `McpServerElicitationRequestResponse` in `codex-rs/app-server-protocol`. Everything else still gets `-32601`.

The response logic moves into an exported pure function `buildServerRequestResponse()` so it can be tested directly — `AppServerClientBase` is not exported, so there was no way to reach the old method from a test. `handleServerRequest` is now one line.

## Verification

**Unit** — new `tests/app-server.test.mjs`, 3 cases, all passing: elicitation is accepted, unimplemented server requests still get `-32601`, request id type is preserved.

**End to end** — same plugin task calling an MCP memory server, before and after the change:

| | before | after |
|---|---|---|
| Task result | `FAIL user rejected MCP tool call` | `OK 1` |
| `user rejected MCP tool call` in job log | 3 | 0 |

Note: `tests/state.test.mjs` has one failing case (`resolveStateDir uses a temp-backed per-workspace directory`) that reproduces on pristine `main` and is unrelated to this change.

## Note for maintainers

Independently of this fix, propagating the real error text into the job log and `/codex:status` would help a lot. `Tool <server>/<tool> failed.` gave no hint that approval was involved — diagnosing this required reading raw rollout JSONL.
