### PR TITLE
Stop brokers started by the test suite

### DIFF
--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -4,8 +4,61 @@ import path from "node:path";
 import process from "node:process";
 import { spawnSync } from "node:child_process";
 
+import { loadBrokerSession } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+
+/**
+ * Workspaces handed out by makeTempDir, so cleanup can find the brokers that
+ * were started for them.
+ */
+const tempDirs = new Set();
+
 export function makeTempDir(prefix = "codex-plugin-test-") {
-  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.add(dir);
+  return dir;
+}
+
+/**
+ * Stop the broker registered for a workspace, if one is still running.
+ *
+ * The broker is deliberately long-lived so it can be reused across companion
+ * invocations, which means nothing in a test run ever shuts it down. Each test
+ * that runs the companion therefore leaves a broker and its app-server child
+ * behind for the lifetime of the machine.
+ */
+export function stopBrokerFor(cwd) {
+  let session = null;
+  try {
+    session = loadBrokerSession(cwd);
+  } catch {
+    return;
+  }
+
+  if (session && Number.isFinite(session.pid)) {
+    terminateProcessTree(session.pid);
+  }
+}
+
+/**
+ * Tear down every workspace created by makeTempDir: stop its broker, then
+ * remove the directory. Extra workspaces (for example the repository root,
+ * which some tests use as the companion cwd) can be passed in.
+ */
+export function cleanupTempWorkspaces(extraWorkspaces = []) {
+  for (const cwd of [...tempDirs, ...extraWorkspaces]) {
+    stopBrokerFor(cwd);
+  }
+
+  for (const dir of tempDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // Best effort: a leftover temp dir is not worth failing the suite over.
+    }
+  }
+
+  tempDirs.clear();
 }
 
 export function writeExecutable(filePath, source) {

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -4,7 +4,11 @@ import path from "node:path";
 import process from "node:process";
 import { spawnSync } from "node:child_process";
 
-import { loadBrokerSession } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import {
+  clearBrokerSession,
+  loadBrokerSession,
+  teardownBrokerSession
+} from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
 import { terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
 
 /**
@@ -20,12 +24,17 @@ export function makeTempDir(prefix = "codex-plugin-test-") {
 }
 
 /**
- * Stop the broker registered for a workspace, if one is still running.
+ * Stop the broker registered for a workspace, if one is still running, and
+ * clear its session so nothing later reads a dead PID.
  *
  * The broker is deliberately long-lived so it can be reused across companion
  * invocations, which means nothing in a test run ever shuts it down. Each test
  * that runs the companion therefore leaves a broker and its app-server child
  * behind for the lifetime of the machine.
+ *
+ * The session file has to go too. It records a bare PID, so leaving it behind
+ * for a stable workspace such as the repository root means a later run can read
+ * it and signal whatever process has since inherited that PID.
  */
 export function stopBrokerFor(cwd) {
   let session = null;
@@ -35,8 +44,27 @@ export function stopBrokerFor(cwd) {
     return;
   }
 
-  if (session && Number.isFinite(session.pid)) {
-    terminateProcessTree(session.pid);
+  if (!session) {
+    return;
+  }
+
+  try {
+    teardownBrokerSession({
+      endpoint: session.endpoint ?? null,
+      pidFile: session.pidFile ?? null,
+      logFile: session.logFile ?? null,
+      sessionDir: session.sessionDir ?? null,
+      pid: Number.isFinite(session.pid) ? session.pid : null,
+      killProcess: (pid) => terminateProcessTree(pid)
+    });
+  } catch {
+    // Best effort: teardown must never fail the suite.
+  }
+
+  try {
+    clearBrokerSession(cwd);
+  } catch {
+    // Best effort.
   }
 }
 

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -19,8 +19,26 @@ const SESSION_HOOK = path.join(PLUGIN_ROOT, "scripts", "session-lifecycle-hook.m
 // Companion invocations start a broker that is deliberately long-lived so it
 // can be reused. Nothing else shuts it down, so without this the suite leaves a
 // broker plus its app-server child behind for every workspace it touches.
+//
+// ROOT is a stable workspace a developer may already have a live companion
+// session on, so it is only torn down when this run is the thing that started
+// it: the session is sampled before any test and stopped only if it changed.
+const rootBrokerPidBeforeRun = readRootBrokerPid();
+
+function readRootBrokerPid() {
+  try {
+    return loadBrokerSession(ROOT)?.pid ?? null;
+  } catch {
+    return null;
+  }
+}
+
 after(() => {
-  cleanupTempWorkspaces([ROOT]);
+  const rootBrokerPidAfterRun = readRootBrokerPid();
+  const startedRootBroker =
+    rootBrokerPidAfterRun !== null && rootBrokerPidAfterRun !== rootBrokerPidBeforeRun;
+
+  cleanupTempWorkspaces(startedRootBroker ? [ROOT] : []);
 });
 
 async function waitFor(predicate, { timeoutMs = 5000, intervalMs = 50 } = {}) {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1,12 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { buildEnv, installFakeCodex } from "./fake-codex-fixture.mjs";
-import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
+import { cleanupTempWorkspaces, initGitRepo, makeTempDir, run } from "./helpers.mjs";
 import { loadBrokerSession, saveBrokerSession } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
 import { resolveStateDir } from "../plugins/codex/scripts/lib/state.mjs";
 
@@ -15,6 +15,13 @@ const PLUGIN_ROOT = path.join(ROOT, "plugins", "codex");
 const SCRIPT = path.join(PLUGIN_ROOT, "scripts", "codex-companion.mjs");
 const STOP_HOOK = path.join(PLUGIN_ROOT, "scripts", "stop-review-gate-hook.mjs");
 const SESSION_HOOK = path.join(PLUGIN_ROOT, "scripts", "session-lifecycle-hook.mjs");
+
+// Companion invocations start a broker that is deliberately long-lived so it
+// can be reused. Nothing else shuts it down, so without this the suite leaves a
+// broker plus its app-server child behind for every workspace it touches.
+after(() => {
+  cleanupTempWorkspaces([ROOT]);
+});
 
 async function waitFor(predicate, { timeoutMs = 5000, intervalMs = 50 } = {}) {
   const start = Date.now();


### PR DESCRIPTION
Fixes the process leak reported in #640 (see [this comment](https://github.com/openai/codex-plugin-cc/issues/640#issuecomment-5279778266)).

## Problem

The broker is deliberately long-lived so it can be reused across companion invocations. Nothing in the test suite shuts it down, so every workspace a test touches leaves a broker plus its app-server child running for the lifetime of the machine — and the count grows with every run:

```
$ node --test tests/runtime.test.mjs
$ pgrep -f "codex-plugin-test" | wc -l
58
```

After a handful of full-suite runs I had 114 orphaned node processes.

## Change

`tests/helpers.mjs` now tracks the workspaces `makeTempDir` hands out, and exposes `cleanupTempWorkspaces()`, which stops each workspace's broker through the existing `terminateProcessTree` and then removes the directory. `tests/runtime.test.mjs` registers it in an `after` hook, passing the repository root explicitly because some tests use it as the companion cwd.

No production code is touched — this is test teardown only.

## Verification

Counting processes matching `codex-plugin-test` three seconds after `node --test tests/runtime.test.mjs`:

| | before | after |
|---|---|---|
| leftover processes | **58** | **0** |
| tests / passing / failing | 61 / 58 / 3 | 61 / 58 / 3 |

Test results are unchanged. The same 3 failures (`status shows phases, hints, and the latest finished job`, `status preserves adversarial review kind labels`, `result returns the stored output for the latest finished job by default`) reproduce identically on an unmodified checkout, so they are pre-existing and unrelated.

## Note

While looking into this I noticed the suite does not isolate `CLAUDE_PLUGIN_DATA`: `buildEnv` only prepends to `PATH`, so broker state is written into the developer's real plugin data directory rather than a temp one. That is a separate concern and out of scope here, but it may be worth isolating so a test run cannot disturb a live session.
