### PR TITLE
Log the start of model reasoning in background job logs

### DIFF
--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -263,6 +263,8 @@ function describeStartedItem(state, item) {
     }
     case "webSearch":
       return { message: `Searching: ${shorten(item.query, 96)}`, phase: "investigating" };
+    case "reasoning":
+      return { message: "Thinking.", phase: null };
     default:
       return null;
   }


### PR DESCRIPTION
Resubmits #480, which was auto-closed on 2026-08-11 when a history rewrite on my fork force-pushed its head branch. GitHub does not allow reopening a pull request whose branch was force-pushed while closed, so this is the same branch, unchanged, under a new number.

## Summary

Background job logs (`state/<slug>-<hash>/jobs/<id>.log`) go silent during reasoning stretches. Every other item type already logs a start line via `describeStartedItem` in `plugins/codex/scripts/lib/codex.mjs`: `commandExecution` ("Running command: ..."), `fileChange` ("Applying N file change(s)."), `mcpToolCall`, `dynamicToolCall`, `collabAgentToolCall`, and `webSearch`. `reasoning` is the only started item type that falls through to `default: return null`, so nothing is written and anyone tailing a job log cannot tell whether the model is thinking or the job is stuck.

## Change

Add a `reasoning` case to `describeStartedItem` that emits `Thinking.` with `phase: null`. The message follows the existing period-terminated declarative style ("Turn completed.", "File changes completed."). `phase` stays null deliberately: none of the existing phase values (starting/running/editing/investigating/verifying/reviewing/finalizing) describes reasoning, and inventing a new phase would widen the change beyond logging.

## Verification

- Live-verified against plugin v1.0.6 (WSL2, Codex CLI 0.145.0-alpha.2): with this case patched into the installed plugin, job logs gain a real-time `[<iso-ts>] Thinking.` line at the start of each reasoning block. This confirms the app-server delivers `item/started` for reasoning items; the stock plugin currently drops them.
- `npm test`: 91/91 passing. The fake-codex fixture only emits completed reasoning items, so no existing test output changes.
- `npm run build`: clean.

## Noise consideration

Reasoning blocks complete every few seconds during long thinking stretches, so this adds one short line per block rather than one line per turn. Consumers that want a quieter view can collapse consecutive markers; the downstream log watcher [@cubicj/codex-watch](https://github.com/cubicj/codex-watch) 0.3.0 already renders them as a single collapsed "Thinking..." indicator.

## Related

- #359 adds a structured `.events.jsonl` stream via `/codex:observe`; this change instead improves the existing `.log` files that current tooling tails, and the two are complementary.

