### PR TITLE
Harden the Codex companion invocation layer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,17 +1,17 @@
 {
-  "name": "openai-codex",
+  "name": "codex-fork",
   "owner": {
-    "name": "OpenAI"
+    "name": "Giordano Pistagni"
   },
   "metadata": {
-    "description": "Codex plugins to use in Claude Code for delegation and code review.",
-    "version": "1.0.6"
+    "description": "Personal fork of the OpenAI Codex plugin for Claude Code: GPT-5.6 guidance, image generation, and the codex-advisor second-opinion hook.",
+    "version": "1.0.6-fork.1"
   },
   "plugins": [
     {
       "name": "codex",
       "description": "Use Codex from Claude Code to review code or delegate tasks.",
-      "version": "1.0.6",
+      "version": "1.0.6-fork.1",
       "author": {
         "name": "OpenAI"
       },

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Examples:
 /codex:rescue investigate why the tests started failing
 /codex:rescue fix the failing test with the smallest safe patch
 /codex:rescue --resume apply the top fix from the last run
-/codex:rescue --model gpt-5.4-mini --effort medium investigate the flaky integration test
+/codex:rescue --model gpt-5.6-luna --effort medium investigate the flaky integration test
 /codex:rescue --model spark fix the issue quickly
 /codex:rescue --background investigate the regression
 ```
@@ -270,10 +270,10 @@ The Codex plugin wraps the [Codex app server](https://developers.openai.com/code
 
 ### Common Configurations
 
-If you want to change the default reasoning effort or the default model that gets used by the plugin, you can define that inside your user-level or project-level `config.toml`. For example to always use `gpt-5.4-mini` on `high` for a specific project you can add the following to a `.codex/config.toml` file at the root of the directory you started Claude in:
+If you want to change the default reasoning effort or the default model that gets used by the plugin, you can define that inside your user-level or project-level `config.toml`. For example to always use `gpt-5.6-luna` on `high` for a specific project you can add the following to a `.codex/config.toml` file at the root of the directory you started Claude in:
 
 ```toml
-model = "gpt-5.4-mini"
+model = "gpt-5.6-luna"
 model_reasoning_effort = "high"
 ```
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Ask Codex to redesign the database connection to be more resilient.
 **Notes:**
 
 - if you do not pass `--model` or `--effort`, Codex chooses its own defaults.
-- if you say `spark`, the plugin maps that to `gpt-5.3-codex-spark`
+- if you say `spark`, the plugin maps that to `gpt-5.6-luna` (the fast tier; the old `gpt-5.3-codex-spark` is rejected on ChatGPT-account auth)
 - follow-up rescue requests can continue the latest Codex task in the repo
 
 ### `/codex:transfer`

--- a/plugins/codex/.claude-plugin/plugin.json
+++ b/plugins/codex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "1.0.6-fork.1",
+  "version": "1.0.6-fork.2",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "OpenAI"

--- a/plugins/codex/.claude-plugin/plugin.json
+++ b/plugins/codex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "1.0.6",
+  "version": "1.0.6-fork.1",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "OpenAI"

--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -28,7 +28,7 @@ Forwarding rules:
 - Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`. This subagent only forwards to `task`.
 - Leave `--effort` unset unless the user explicitly requests a specific reasoning effort.
 - Leave model unset by default. Only add `--model` when the user explicitly asks for a specific model.
-- If the user asks for `spark`, map that to `--model gpt-5.3-codex-spark`.
+- If the user asks for `spark`, map that to `--model gpt-5.6-luna` (fast tier; `gpt-5.3-codex-spark` is rejected on ChatGPT-account auth).
 - If the user asks for a concrete model name such as `gpt-5.6-luna`, pass it through with `--model`.
 - Treat `--effort <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
 - Default to a write-capable Codex run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.

--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -5,7 +5,7 @@ model: sonnet
 tools: Bash
 skills:
   - codex-cli-runtime
-  - gpt-5-4-prompting
+  - gpt-5-6-prompting
 ---
 
 You are a thin forwarding wrapper around the Codex companion task runtime.
@@ -22,14 +22,14 @@ Forwarding rules:
 - Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task ...`.
 - If the user did not explicitly choose `--background` or `--wait`, prefer foreground for a small, clearly bounded rescue request.
 - If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution.
-- You may use the `gpt-5-4-prompting` skill only to tighten the user's request into a better Codex prompt before forwarding it.
+- You may use the `gpt-5-6-prompting` skill only to tighten the user's request into a better Codex prompt before forwarding it.
 - Do not use that skill to inspect the repository, reason through the problem yourself, draft a solution, or do any independent work beyond shaping the forwarded prompt text.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
 - Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`. This subagent only forwards to `task`.
 - Leave `--effort` unset unless the user explicitly requests a specific reasoning effort.
 - Leave model unset by default. Only add `--model` when the user explicitly asks for a specific model.
 - If the user asks for `spark`, map that to `--model gpt-5.3-codex-spark`.
-- If the user asks for a concrete model name such as `gpt-5.4-mini`, pass it through with `--model`.
+- If the user asks for a concrete model name such as `gpt-5.6-luna`, pass it through with `--model`.
 - Treat `--effort <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
 - Default to a write-capable Codex run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
 - Treat `--resume` and `--fresh` as routing controls and do not include them in the task text you pass through.

--- a/plugins/codex/commands/adversarial-review.md
+++ b/plugins/codex/commands/adversarial-review.md
@@ -38,7 +38,8 @@ Argument handling:
 - Preserve the user's arguments exactly.
 - Do not strip `--wait` or `--background` yourself.
 - Do not weaken the adversarial framing or rewrite the user's focus text.
-- The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
+- The companion script owns detachment: `--background` spawns its own worker, returns a job id immediately, and keeps running even if this shell exits.
+- The companion also owns queueing and the execution deadline. Pass `--timeout-ms <ms>` to change the deadline; keep any outer Bash timeout at least 60s longer than it.
 - `/codex:adversarial-review` uses the same review target selection as `/codex:review`.
 - It supports working-tree review, branch review, and `--base <ref>`.
 - It does not support `--scope staged` or `--scope unstaged`.
@@ -54,7 +55,7 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" adversarial-review "$AR
 - Do not fix any issues mentioned in the review output.
 
 Background flow:
-- Launch the review with `Bash` in the background:
+- Launch the review with `Bash`. The companion detaches its own worker, so this call returns a job id straight away:
 ```typescript
 Bash({
   command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" adversarial-review "$ARGUMENTS"`,
@@ -62,5 +63,7 @@ Bash({
   run_in_background: true
 })
 ```
+- `run_in_background: true` is a convenience only; the review's lifetime no longer depends on it.
 - Do not call `BashOutput` or wait for completion in this turn.
 - After launching the command, tell the user: "Codex adversarial review started in the background. Check `/codex:status` for progress."
+- Once it finishes, `/codex:result <id>` returns the bounded verdict envelope and `/codex:result <id> --full` returns the complete review.

--- a/plugins/codex/commands/collab.md
+++ b/plugins/codex/commands/collab.md
@@ -1,0 +1,22 @@
+---
+description: Drive the Claude/Codex peer-collaboration loop — assign issues to parallel worktrees, run Codex, cross-review, and merge
+argument-hint: "[assign|run|handoff|review|merge|status|conflicts] [issue-slug] [free text]"
+allowed-tools: Bash(node:*), Bash(git:*), Read, Grep, Glob, AskUserQuestion, PushNotification
+---
+
+Drive the collaboration runtime at `${CLAUDE_PLUGIN_ROOT}/scripts/collab.mjs` (run every subcommand as `node "${CLAUDE_PLUGIN_ROOT}/scripts/collab.mjs" <command> ...`).
+
+Raw user request:
+`$ARGUMENTS`
+
+Subcommands: `init` · `assign --agent <codex|claude> --issue <slug> [--title <t>]` · `post` · `inbox --for <agent> [--peek]` · `claim` · `conflicts` · `run --issue <slug> --prompt <text> [--effort <level>]` · `handoff --issue <slug> [--summary <t>]` · `merge --issue <slug>` · `status`.
+
+Operating rules:
+
+- You are the orchestrator and the claude-side worker. Codex work goes through `run`, which executes in the issue's worktree with the shared workspace writable and the collaboration protocol prepended to the prompt. `run` is synchronous — use a background Bash call for long tasks.
+- Claude-side issues: do your own work inside the issue's worktree (never the main checkout), claim paths before touching shared surface, and post grounded `status` messages at milestones.
+- Check the inbox (`inbox --for claude`) at every loop boundary: after each `run` completes, after finishing your own work step, and before `handoff` or `merge`. Act on questions before continuing.
+- Cross-review is mandatory and capped at 2 review/fix cycles per issue: Codex-authored issues are reviewed by you (read the diff in the worktree: `git diff <base>...HEAD`); Claude-authored issues are reviewed by Codex via `run` with a report-only review prompt. Post the verdict as a `review` message — body must start with `approve` to unlock `merge`, otherwise list the findings.
+- Disagreements: exactly one `rebuttal` round. Still contested → post a `decision`-type message with both positions and a recommended default (this lands in decisions.md), then surface it to Giordano: `AskUserQuestion` when interactive, `PushNotification` when running unattended. Trivial disagreements resolve toward the reviewer.
+- `merge` enforces the approval gate and cleans up the worktree and branch. After merging, check `conflicts` — a claim overlap with a still-active issue means the other agent must rebase before its handoff.
+- Every handoff and `run` prints a pick-up line (`cd <worktree> && codex resume <session-id>`) — always show it to Giordano so he can take over any thread himself.

--- a/plugins/codex/commands/inbox.md
+++ b/plugins/codex/commands/inbox.md
@@ -1,0 +1,20 @@
+---
+description: Read and act on new messages from Codex in the shared collaboration workspace
+argument-hint: "[--peek]"
+allowed-tools: Bash(node:*), Bash(git:*), Read, AskUserQuestion
+---
+
+Run:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/collab.mjs" inbox --for claude $ARGUMENTS
+```
+
+Present each message compactly (time · type · issue · body), then act:
+
+- `question` — answer it with a `post --from claude --type question` reply, or do the small thing it asks and post a grounded `status`.
+- `handoff` — start the cross-review of that issue's diff.
+- `claim` with a CONFLICT — coordinate: agree who owns the overlapping paths and post the outcome.
+- `status` / `assign` — context only; no action unless something looks wrong.
+
+If there are no new messages, say so and stop.

--- a/plugins/codex/commands/rescue.md
+++ b/plugins/codex/commands/rescue.md
@@ -43,7 +43,7 @@ Operating rules:
 - Do not paraphrase, summarize, rewrite, or add commentary before or after it.
 - Do not ask the subagent to inspect files, monitor progress, poll `/codex:status`, fetch `/codex:result`, call `/codex:cancel`, summarize output, or do follow-up work of its own.
 - Leave `--effort` unset unless the user explicitly asks for a specific reasoning effort.
-- Leave the model unset unless the user explicitly asks for one. If they ask for `spark`, map it to `gpt-5.3-codex-spark`.
+- Leave the model unset unless the user explicitly asks for one. If they ask for `spark`, map it to `gpt-5.6-luna` (fast tier — `gpt-5.3-codex-spark` is rejected on ChatGPT-account auth).
 - Leave `--resume` and `--fresh` in the forwarded request. The subagent handles that routing when it builds the `task` command.
 - If the helper reports that Codex is missing or unauthenticated, stop and tell the user to run `/codex:setup`.
 - If the user did not supply a request, ask what Codex should investigate or fix.

--- a/plugins/codex/commands/result.md
+++ b/plugins/codex/commands/result.md
@@ -1,15 +1,25 @@
 ---
-description: Show the stored final output for a finished Codex job in this repository
-argument-hint: '[job-id]'
+description: Show the stored result for a finished Codex job in this repository
+argument-hint: '[job-id] [--full]'
 disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 
 !`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" result "$ARGUMENTS"`
 
+Reviews and consults answer with the bounded result envelope: status, verdict, severity tally, summary, findings preview, and the paths where the complete log and final answer are stored. Tasks answer with their stored output as before.
+
 Present the full command output to the user. Do not summarize or condense it. Preserve all details including:
 - Job ID and status
-- The complete result payload, including verdict, summary, findings, details, artifacts, and next steps
+- The complete result payload, including verdict, severity tally, summary, findings, details, artifacts, and next steps
 - File paths and line numbers exactly as reported
 - Any error messages or parse errors
 - Follow-up commands such as `/codex:status <id>` and `/codex:review`
+
+If the user needs the complete text rather than the envelope, rerun with `--full`:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" result <job-id> --full
+```
+
+`--json` returns the same envelope as JSON. A `verdict` of `inconclusive` means the run timed out, failed to launch, or returned output that could not be parsed. Never report it as an approval.

--- a/plugins/codex/commands/review.md
+++ b/plugins/codex/commands/review.md
@@ -35,7 +35,8 @@ Argument handling:
 - Preserve the user's arguments exactly.
 - Do not strip `--wait` or `--background` yourself.
 - Do not add extra review instructions or rewrite the user's intent.
-- The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
+- The companion script owns detachment: `--background` spawns its own worker, returns a job id immediately, and keeps running even if this shell exits.
+- The companion also owns queueing and the execution deadline. Pass `--timeout-ms <ms>` to change the deadline; keep any outer Bash timeout at least 60s longer than it.
 - `/codex:review` is native-review only. It does not support staged-only review, unstaged-only review, or extra focus text.
 - If the user needs custom review instructions or more adversarial framing, they should use `/codex:adversarial-review`.
 
@@ -49,7 +50,7 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" review "$ARGUMENTS"
 - Do not fix any issues mentioned in the review output.
 
 Background flow:
-- Launch the review with `Bash` in the background:
+- Launch the review with `Bash`. The companion detaches its own worker, so this call returns a job id straight away:
 ```typescript
 Bash({
   command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" review "$ARGUMENTS"`,
@@ -57,5 +58,7 @@ Bash({
   run_in_background: true
 })
 ```
+- `run_in_background: true` is a convenience only; the review's lifetime no longer depends on it.
 - Do not call `BashOutput` or wait for completion in this turn.
 - After launching the command, tell the user: "Codex review started in the background. Check `/codex:status` for progress."
+- Once it finishes, `/codex:result <id>` returns the bounded verdict envelope and `/codex:result <id> --full` returns the complete review.

--- a/plugins/codex/commands/second-opinion.md
+++ b/plugins/codex/commands/second-opinion.md
@@ -6,7 +6,8 @@ allowed-tools: Bash(node:*)
 
 Run the codex-advisor script exactly once and surface its opinion:
 
-- Default: `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-advisor.mjs"` (Bash timeout ~300000ms). It reviews the most recent built-in advisor verdict in this session's transcript.
+- Default: `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-advisor.mjs"` (Bash timeout ~420000ms). It reviews the most recent built-in advisor verdict in this session's transcript.
+- The script enforces its own limits: up to 60s waiting for the global Codex queue slot, then a 300000ms execution deadline. Keep the outer Bash timeout above that sum so the script's own normalized message is what you see.
 - If this session has no built-in advisor verdict but does have a plan (approved or drafted), write that plan text verbatim to a temp file and add `--plan-file <path>` so the script reviews the plan instead.
 - If the user passed `--force`, prefix the command with `CODEX_ADVISOR_FORCE=1 ` to bypass the one-opinion-per-subject dedup.
 - If the user added a focus note, mention it when weighing the opinion — the script itself takes no free-text input.

--- a/plugins/codex/commands/second-opinion.md
+++ b/plugins/codex/commands/second-opinion.md
@@ -1,0 +1,16 @@
+---
+description: Run the Codex (GPT) second-opinion advisor on demand — reviews the latest approved plan or built-in advisor verdict
+argument-hint: "[--force] [optional focus note]"
+allowed-tools: Bash(node:*)
+---
+
+Run the codex-advisor script exactly once and surface its opinion:
+
+- Default: `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-advisor.mjs"` (Bash timeout ~300000ms). It reviews the most recent built-in advisor verdict in this session's transcript.
+- If this session has no built-in advisor verdict but does have a plan (approved or drafted), write that plan text verbatim to a temp file and add `--plan-file <path>` so the script reviews the plan instead.
+- If the user passed `--force`, prefix the command with `CODEX_ADVISOR_FORCE=1 ` to bypass the one-opinion-per-subject dedup.
+- If the user added a focus note, mention it when weighing the opinion — the script itself takes no free-text input.
+- If it prints `[codex-advisor] …skipping` or `…unavailable`, report that line verbatim and stop.
+- The final user-visible response must include Codex's opinion verbatim, followed by your own brief assessment of where you agree or disagree.
+
+Note: approved plans normally get this opinion automatically via the ExitPlanMode hook — this command is for re-runs (`--force`), drafted-but-unapproved plans, and advisor verdicts.

--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -23,6 +23,18 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/exit-plan-second-opinion-hook.mjs\"",
+            "timeout": 480
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -32,6 +32,15 @@
             "timeout": 900
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/codex-advisor-backstop.mjs\"",
+            "timeout": 15
+          }
+        ]
       }
     ]
   }

--- a/plugins/codex/prompts/collab-protocol.md
+++ b/plugins/codex/prompts/collab-protocol.md
@@ -1,0 +1,9 @@
+Collaboration protocol — issue {{ISSUE}} ("{{TITLE}}") in repo {{REPO}}. You are the codex agent; your peer is claude.
+
+Shared workspace: {{COLLAB_DIR}}. Interact with it only through `node {{COLLAB_CLI}} <command>`.
+
+- First action: check messages with `node {{COLLAB_CLI}} inbox --for codex` and factor them in.
+- Before editing code that other work might touch, claim it: `node {{COLLAB_CLI}} claim --agent codex --issue {{ISSUE}} --paths <comma-separated repo-relative paths>`. If it prints a CONFLICT, do not edit the conflicted paths; post a question (`post --from codex --type question --issue {{ISSUE}} --body "..."`) and finish the rest of the task.
+- At milestones, post a one-line status: `node {{COLLAB_CLI}} post --from codex --type status --issue {{ISSUE}} --body "..."`. Every status or completion claim must be grounded in a command or tool result you observed in this session — never report unverified progress.
+- Authorization: edits inside your worktree that serve issue {{ISSUE}} are authorized. Anything beyond that scope — other issues, files outside the worktree, destructive operations — post a question instead of acting.
+- Commit your work on the current branch as you go. End with a final message summarizing what changed and what you verified; the handoff itself is posted by the orchestrator.

--- a/plugins/codex/scripts/codex-advisor-backstop.mjs
+++ b/plugins/codex/scripts/codex-advisor-backstop.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Stop-hook backstop for the Codex second-opinion advisor (fork addition).
+// Guarantees: if the built-in `advisor` ran in this session and no `codex-advisor`
+// run followed it, block the stop and force the agent to run it. Loop-safe: once the
+// codex-advisor command appears in the transcript (success OR skip), it allows the stop.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+// codex-advisor.mjs lives next to this script wherever the plugin is materialized.
+const ADVISOR_PATH = join(dirname(fileURLToPath(import.meta.url)), 'codex-advisor.mjs');
+
+const allow = () => process.exit(0);
+const block = (reason) => {
+  process.stdout.write(JSON.stringify({ decision: 'block', reason }));
+  process.exit(0);
+};
+
+let input;
+try { input = JSON.parse(readFileSync(0, 'utf8') || '{}'); } catch { allow(); }
+const tpath = input.transcript_path;
+if (!tpath) allow();
+
+let lines;
+try { lines = readFileSync(tpath, 'utf8').split('\n').filter(Boolean); } catch { allow(); }
+
+const parsed = lines.map((l) => { try { return JSON.parse(l); } catch { return null; } });
+
+// index of the most recent built-in advisor result
+let lastAdvisorIdx = -1;
+for (let i = 0; i < parsed.length; i++) {
+  const c = parsed[i]?.message?.content;
+  if (parsed[i]?.type === 'assistant' && Array.isArray(c) && c.some((b) => b.type === 'advisor_tool_result')) {
+    lastAdvisorIdx = i;
+  }
+}
+if (lastAdvisorIdx === -1) allow(); // no advisor used this session
+
+// did the agent invoke codex-advisor after the latest advisor result?
+for (let i = lastAdvisorIdx + 1; i < parsed.length; i++) {
+  const c = parsed[i]?.message?.content;
+  if (!Array.isArray(c)) continue;
+  for (const b of c) {
+    if (b.type === 'tool_use' && b.name === 'Bash' &&
+        typeof b.input?.command === 'string' && b.input.command.includes('codex-advisor')) {
+      allow();
+    }
+  }
+}
+
+// already forced once and still not run -> give up rather than trap the session
+if (input.stop_hook_active) allow();
+
+block(`A built-in advisor() opinion was given but the required Codex second opinion has not run yet. Run \`node ${ADVISOR_PATH}\` once now (use a Bash timeout of ~300000ms), then weigh its GPT second opinion before finishing.`);

--- a/plugins/codex/scripts/codex-advisor-backstop.mjs
+++ b/plugins/codex/scripts/codex-advisor-backstop.mjs
@@ -37,14 +37,21 @@ for (let i = 0; i < parsed.length; i++) {
 }
 if (lastAdvisorIdx === -1) allow(); // no advisor used this session
 
-// did the agent invoke codex-advisor after the latest advisor result?
+// Did a codex-advisor run actually PRODUCE output after the latest advisor result?
+// Evidence = a tool_result carrying the second-opinion banner, or the "[codex-advisor]"
+// skip/error prefix (skips count as compliance per the operating rule). A Bash command
+// merely MENTIONING codex-advisor is NOT evidence — that hole let failed or wrong-path
+// attempts satisfy this gate.
+const textOf = (c) => typeof c === 'string' ? c
+  : Array.isArray(c) ? c.map((x) => (x && x.text) || '').join('\n')
+  : c ? JSON.stringify(c) : '';
 for (let i = lastAdvisorIdx + 1; i < parsed.length; i++) {
   const c = parsed[i]?.message?.content;
   if (!Array.isArray(c)) continue;
   for (const b of c) {
-    if (b.type === 'tool_use' && b.name === 'Bash' &&
-        typeof b.input?.command === 'string' && b.input.command.includes('codex-advisor')) {
-      allow();
+    if (b.type === 'tool_result') {
+      const t = textOf(b.content);
+      if (t.includes('SECOND OPINION (codex-advisor') || t.includes('[codex-advisor]')) allow();
     }
   }
 }

--- a/plugins/codex/scripts/codex-advisor.mjs
+++ b/plugins/codex/scripts/codex-advisor.mjs
@@ -16,6 +16,8 @@ import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+import { describeExecOutcome, runHardenedCodexExec } from './lib/exec-launcher.mjs';
+
 const HOME = homedir();
 const PROJECTS = join(HOME, '.claude', 'projects');
 // Live run logs — the canonical persistent location (one <runId> subdir per run). Never /tmp.
@@ -192,17 +194,34 @@ const writeMeta = (status) => {
 try { writeFileSync(join(LOG_DIR, 'prompt.txt'), prompt); } catch {}
 
 const outFile = join(LOG_DIR, 'output.txt');
-const r = spawnSync('codex', [
-  'exec', '--skip-git-repo-check', '-m', MODEL, '-s', 'read-only',
-  '-c', `model_reasoning_effort=${EFFORT}`,
-  '-o', outFile, '-',
-], { input: prompt, cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+const promptFile = join(LOG_DIR, 'prompt.txt');
+// One blessed launcher: prompt from a file, stdin never inherited, a global queue
+// slot, an execution deadline, and the skip-git-repo-check decision made for us.
+// Deadline + queue wait stay under the exit-plan hook's 450s outer guard.
+let r;
+try {
+  r = await runHardenedCodexExec({
+    cwd: REPO_ROOT,
+    promptFile,
+    outputFile: outFile,
+    logFile: join(LOG_DIR, 'run.log'),
+    model: MODEL,
+    effort: EFFORT,
+    sandbox: 'read-only',
+    kind: 'advisor',
+    timeoutMs: 300000,
+    queueWaitMs: 60000,
+  });
+} catch (error) {
+  writeMeta('codex-error');
+  done(`[codex-advisor] codex unavailable: ${error.message}\n[codex-advisor] log: ${LOG_DIR}`);
+}
 
-if (r.error) { writeMeta('codex-error'); done(`[codex-advisor] codex unavailable: ${r.error.message}\n[codex-advisor] log: ${LOG_DIR}`); }
-let answer = '';
-try { answer = readFileSync(outFile, 'utf8').trim(); } catch {}
-if (!answer) answer = (r.stdout || '').trim();
-if (!answer) { writeMeta('no-output'); done(`[codex-advisor] codex produced no output (exit ${r.status}). ${(r.stderr || '').slice(-400)}\n[codex-advisor] log: ${LOG_DIR}`); }
+const answer = r.finalOutput;
+if (!answer) {
+  writeMeta(r.timedOut ? 'timed-out' : 'no-output');
+  done(`[codex-advisor] ${describeExecOutcome(r)} No opinion was produced.\n[codex-advisor] log: ${LOG_DIR}`);
+}
 
 console.log(`===== GPT SECOND OPINION (codex-advisor · ${MODEL} · ${plan ? 'plan' : 'advisor-verdict'} · effort=${EFFORT}) =====\n`);
 console.log(answer);

--- a/plugins/codex/scripts/codex-advisor.mjs
+++ b/plugins/codex/scripts/codex-advisor.mjs
@@ -1,14 +1,18 @@
 #!/usr/bin/env node
-// codex-advisor — second opinion after Claude Code's built-in `advisor` tool.
-// Reconstructs the FULL session transcript (true parity with what the advisor saw)
-// plus the advisor's verdict, sends it to GPT via `codex exec`, and prints
-// Codex's independent second opinion to stdout. Non-fatal on any failure (exit 0).
+// codex-advisor — independent GPT second opinion for Claude Code. Two subjects, auto-selected:
+//   1) the latest built-in `advisor` verdict in the transcript (original behavior), or
+//   2) with --plan-file <path>: an approved ExitPlanMode plan (decoupled trigger — the
+//      built-in advisor never fires on Fable 5 mains, so the exit-plan hook feeds plans here).
+// Reconstructs the FULL session transcript for context, runs `codex exec` READ-ONLY from the
+// repo root with instructions to verify claims against the actual code, and prints the
+// opinion to stdout. Non-fatal on any failure (exit 0).
 //
 // Env overrides: CODEX_ADVISOR_MODEL (default gpt-5.6-sol), CODEX_ADVISOR_EFFORT (default high).
-// Arg override:  --transcript <path>  to point at a specific session jsonl.
+// Arg overrides: --transcript <path> (specific session jsonl); --plan-file <path> (plan mode).
 
 import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, mkdirSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -97,24 +101,58 @@ function reconstruct(path) {
 const path = findTranscript();
 if (!path) done('[codex-advisor] no transcript found; skipping.');
 const { transcript, verdict, verdictId } = reconstruct(path);
-if (!verdict) done('[codex-advisor] no advisor verdict in transcript; skipping.');
 
-// Dedup: exactly one Codex opinion per advisor verdict. A second invocation for the same
-// verdict — e.g. a council sub-agent, which SHARES this session's CLAUDE_CODE_SESSION_ID —
-// skips. The main agent runs first (right after advisor()), so it wins the marker and
+// Subject: an explicit --plan-file beats the advisor-verdict path.
+const planFile = argVal('--plan-file');
+let plan = null;
+if (planFile) { try { plan = readFileSync(planFile, 'utf8').trim() || null; } catch {} }
+if (!plan && !verdict) done('[codex-advisor] no plan or advisor verdict to review; skipping.');
+const subjectId = plan
+  ? `plan_${createHash('sha1').update(plan).digest('hex').slice(0, 16)}`
+  : verdictId;
+
+// Dedup: exactly one Codex opinion per subject (advisor verdict or plan). A second
+// invocation for the same subject — e.g. a council sub-agent, which SHARES this session's
+// CLAUDE_CODE_SESSION_ID — skips. The main agent runs first, so it wins the marker and
 // sub-agents skip. CODEX_ADVISOR_FORCE=1 bypasses (for testing).
 const MARKER_DIR = join(HOME, '.claude', 'cache', 'codex-advisor');
-const markerPath = join(MARKER_DIR, `${(verdictId || 'unknown').replace(/[^A-Za-z0-9_-]/g, '_')}.json`);
-if (!process.env.CODEX_ADVISOR_FORCE && verdictId && existsSync(markerPath)) {
-  done('[codex-advisor] a second opinion already ran for this advisor verdict; skipping.');
+const markerPath = join(MARKER_DIR, `${(subjectId || 'unknown').replace(/[^A-Za-z0-9_-]/g, '_')}.json`);
+if (!process.env.CODEX_ADVISOR_FORCE && subjectId && existsSync(markerPath)) {
+  done('[codex-advisor] a second opinion already ran for this subject; skipping.');
 }
 try {
   mkdirSync(MARKER_DIR, { recursive: true });
-  writeFileSync(markerPath, JSON.stringify({ sid: process.env.CLAUDE_CODE_SESSION_ID || null, verdictId, transcript: path, ts: new Date().toISOString() }));
+  writeFileSync(markerPath, JSON.stringify({ sid: process.env.CLAUDE_CODE_SESSION_ID || null, subjectId, transcript: path, ts: new Date().toISOString() }));
 } catch {}
 
-const prompt = [
-  'You are GPT-5.5 acting as a SECOND ADVISOR. Below is the FULL session a first (Claude) advisor reviewed — every user/assistant message, the assistant\'s REASONING TRACE, and every tool call and result. The session is CONTEXT. The Claude advisor verdict you must give a second opinion on is the SINGLE block appended at the very end (the MOST RECENT verdict); any earlier "CLAUDE ADVISOR VERDICT" blocks appearing inline within the session are context only — do not review those. Give an INDEPENDENT second opinion on that most-recent verdict.',
+// Ground the opinion in the actual repository, not just the transcript: run codex from the
+// repo root so its read-only sandbox can verify claims against real code.
+const rootProbe = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' });
+const REPO_ROOT = rootProbe.status === 0 ? rootProbe.stdout.trim() : process.cwd();
+const GROUNDING = `You have READ-ONLY access to the repository at ${REPO_ROOT} (your working directory). Before agreeing or disagreeing with anything, VERIFY the load-bearing claims against the actual code with read-only commands (ls, cat, grep, git log/diff). Cite the files you checked. An opinion that cites no repository evidence is incomplete.`;
+
+const prompt = (plan ? [
+  'You are GPT acting as an independent SECOND ADVISOR. Claude (the assistant) has just had an implementation PLAN approved; it is the SINGLE block appended at the very end. Below it is the FULL session that led to the plan — every user/assistant message, the assistant\'s REASONING TRACE, and every tool call and result. The session is CONTEXT; your review is of the PLAN.',
+  '',
+  GROUNDING,
+  '',
+  'Specifically:',
+  '1) Flaws, risks, and missing steps in the plan — and any simpler approach that would do. Be concrete.',
+  '2) REASONING-TRACE AUDIT: scrutinize the assistant\'s reasoning blocks and explicitly flag any logical flaws, invalid inferences, unjustified leaps, or factual errors that shaped the plan. Quote the specific step.',
+  '3) What should change BEFORE execution starts, in priority order. If nothing, say so plainly.',
+  'Be direct and concise. Do not restate the session back to me.',
+  '',
+  '================ FULL SESSION ================',
+  transcript,
+  '================ END SESSION ================',
+  '',
+  '================ THE APPROVED PLAN TO REVIEW (your second opinion is about THIS) ================',
+  plan,
+  '================ END PLAN ================',
+] : [
+  'You are GPT acting as a SECOND ADVISOR. Below is the FULL session a first (Claude) advisor reviewed — every user/assistant message, the assistant\'s REASONING TRACE, and every tool call and result. The session is CONTEXT. The Claude advisor verdict you must give a second opinion on is the SINGLE block appended at the very end (the MOST RECENT verdict); any earlier "CLAUDE ADVISOR VERDICT" blocks appearing inline within the session are context only — do not review those. Give an INDEPENDENT second opinion on that most-recent verdict.',
+  '',
+  GROUNDING,
   '',
   'Specifically:',
   '1) Where you AGREE or DISAGREE with the Claude advisor, and why. Be concrete.',
@@ -129,7 +167,7 @@ const prompt = [
   '================ THE ADVISOR VERDICT TO REVIEW (most recent — your second opinion is about THIS) ================',
   verdict,
   '================ END VERDICT ================',
-].join('\n');
+]).join('\n');
 
 // Persistent run log: ~/.claude/logs/codex-advisor/<runId>/ (runId = UTC ts + short session id).
 const ts = new Date().toISOString();
@@ -141,7 +179,9 @@ const writeMeta = (status) => {
     writeFileSync(join(LOG_DIR, 'meta.json'), JSON.stringify({
       session_id: process.env.CLAUDE_CODE_SESSION_ID || null,
       resolved_transcript_path: path,
-      verdict_id: verdictId,
+      subject_id: subjectId,
+      subject: plan ? 'plan' : 'advisor-verdict',
+      repo_root: REPO_ROOT,
       model: MODEL,
       effort: EFFORT,
       ts,
@@ -156,7 +196,7 @@ const r = spawnSync('codex', [
   'exec', '--skip-git-repo-check', '-m', MODEL, '-s', 'read-only',
   '-c', `model_reasoning_effort=${EFFORT}`,
   '-o', outFile, '-',
-], { input: prompt, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+], { input: prompt, cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
 
 if (r.error) { writeMeta('codex-error'); done(`[codex-advisor] codex unavailable: ${r.error.message}\n[codex-advisor] log: ${LOG_DIR}`); }
 let answer = '';
@@ -164,7 +204,7 @@ try { answer = readFileSync(outFile, 'utf8').trim(); } catch {}
 if (!answer) answer = (r.stdout || '').trim();
 if (!answer) { writeMeta('no-output'); done(`[codex-advisor] codex produced no output (exit ${r.status}). ${(r.stderr || '').slice(-400)}\n[codex-advisor] log: ${LOG_DIR}`); }
 
-console.log(`===== GPT-5.5 SECOND OPINION (codex-advisor · effort=${EFFORT}) =====\n`);
+console.log(`===== GPT SECOND OPINION (codex-advisor · ${MODEL} · ${plan ? 'plan' : 'advisor-verdict'} · effort=${EFFORT}) =====\n`);
 console.log(answer);
 writeMeta('ok');
 console.log(`\n[codex-advisor] log: ${LOG_DIR}`);

--- a/plugins/codex/scripts/codex-advisor.mjs
+++ b/plugins/codex/scripts/codex-advisor.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// codex-advisor — second opinion after Claude Code's built-in `advisor` tool.
+// Reconstructs the FULL session transcript (true parity with what the advisor saw)
+// plus the advisor's verdict, sends it to GPT via `codex exec`, and prints
+// Codex's independent second opinion to stdout. Non-fatal on any failure (exit 0).
+//
+// Env overrides: CODEX_ADVISOR_MODEL (default gpt-5.6-sol), CODEX_ADVISOR_EFFORT (default high).
+// Arg override:  --transcript <path>  to point at a specific session jsonl.
+
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, mkdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const HOME = homedir();
+const PROJECTS = join(HOME, '.claude', 'projects');
+// Live run logs — the canonical persistent location (one <runId> subdir per run). Never /tmp.
+const LOGS_ROOT = join(HOME, '.claude', 'logs', 'codex-advisor');
+const MODEL = process.env.CODEX_ADVISOR_MODEL || 'gpt-5.6-sol';
+const EFFORT = process.env.CODEX_ADVISOR_EFFORT || 'high';
+
+const argVal = (flag) => {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 ? process.argv[i + 1] : null;
+};
+const done = (msg) => { console.log(msg); process.exit(0); };
+
+// --- locate the current session transcript (newest jsonl; cwd-encoded dir first) ---
+function findTranscript() {
+  const override = argVal('--transcript');
+  if (override) return override;
+  // Deterministic: the CURRENT session id is in the environment. Its transcript is
+  // <projects>/<enc-cwd>/<sid>.jsonl. Session ids are globally unique, so scan project
+  // dirs for that exact file (sidesteps cwd-encoding mismatch). This avoids the
+  // cross-session bleed that picking the globally-newest mtime caused when multiple
+  // Claude sessions were open at once.
+  const sid = process.env.CLAUDE_CODE_SESSION_ID;
+  if (sid) {
+    try {
+      for (const d of readdirSync(PROJECTS)) {
+        const p = join(PROJECTS, d, `${sid}.jsonl`);
+        if (existsSync(p)) return p;
+      }
+    } catch {}
+  }
+  // Fallback (no session id): newest jsonl in THIS cwd's project dir ONLY — never across
+  // all projects.
+  const enc = process.cwd().replace(/\//g, '-');
+  let found = [];
+  try {
+    found = readdirSync(join(PROJECTS, enc))
+      .filter((f) => f.endsWith('.jsonl'))
+      .map((f) => { const p = join(PROJECTS, enc, f); return [p, statSync(p).mtimeMs]; });
+  } catch {}
+  if (!found.length) return null;
+  found.sort((a, b) => b[1] - a[1]);
+  return found[0][0];
+}
+
+// --- reconstruct conversation (full parity) + capture latest advisor verdict ---
+function reconstruct(path) {
+  const out = [];
+  let verdict = null;
+  let verdictId = null;
+  for (const line of readFileSync(path, 'utf8').split('\n')) {
+    if (!line) continue;
+    let o; try { o = JSON.parse(line); } catch { continue; }
+    if ((o.type !== 'user' && o.type !== 'assistant') || !o.message) continue;
+    const content = o.message.content;
+    if (typeof content === 'string') { out.push(`### ${o.type.toUpperCase()}\n${content}`); continue; }
+    if (!Array.isArray(content)) continue;
+    for (const b of content) {
+      switch (b.type) {
+        case 'text': out.push(`### ${o.type.toUpperCase()}\n${b.text}`); break;
+        case 'thinking': out.push(`### ASSISTANT (reasoning trace)\n${b.thinking || b.text || ''}`); break;
+        case 'tool_use': out.push(`### TOOL CALL: ${b.name}\n${JSON.stringify(b.input)}`); break;
+        case 'server_tool_use': out.push(`### SERVER TOOL CALL: ${b.name}`); break;
+        case 'tool_result': {
+          const c = b.content;
+          const txt = typeof c === 'string' ? c
+            : Array.isArray(c) ? c.map((x) => x.text || '').join('\n')
+            : JSON.stringify(c);
+          out.push(`### TOOL RESULT\n${txt}`);
+          break;
+        }
+        case 'advisor_tool_result':
+          verdict = (b.content && b.content.text) || null;
+          verdictId = b.tool_use_id || verdictId;
+          out.push(`### CLAUDE ADVISOR VERDICT (inline — context only; the verdict to review is appended at the end)\n${verdict || ''}`);
+          break;
+      }
+    }
+  }
+  return { transcript: out.join('\n\n'), verdict, verdictId };
+}
+
+const path = findTranscript();
+if (!path) done('[codex-advisor] no transcript found; skipping.');
+const { transcript, verdict, verdictId } = reconstruct(path);
+if (!verdict) done('[codex-advisor] no advisor verdict in transcript; skipping.');
+
+// Dedup: exactly one Codex opinion per advisor verdict. A second invocation for the same
+// verdict — e.g. a council sub-agent, which SHARES this session's CLAUDE_CODE_SESSION_ID —
+// skips. The main agent runs first (right after advisor()), so it wins the marker and
+// sub-agents skip. CODEX_ADVISOR_FORCE=1 bypasses (for testing).
+const MARKER_DIR = join(HOME, '.claude', 'cache', 'codex-advisor');
+const markerPath = join(MARKER_DIR, `${(verdictId || 'unknown').replace(/[^A-Za-z0-9_-]/g, '_')}.json`);
+if (!process.env.CODEX_ADVISOR_FORCE && verdictId && existsSync(markerPath)) {
+  done('[codex-advisor] a second opinion already ran for this advisor verdict; skipping.');
+}
+try {
+  mkdirSync(MARKER_DIR, { recursive: true });
+  writeFileSync(markerPath, JSON.stringify({ sid: process.env.CLAUDE_CODE_SESSION_ID || null, verdictId, transcript: path, ts: new Date().toISOString() }));
+} catch {}
+
+const prompt = [
+  'You are GPT-5.5 acting as a SECOND ADVISOR. Below is the FULL session a first (Claude) advisor reviewed — every user/assistant message, the assistant\'s REASONING TRACE, and every tool call and result. The session is CONTEXT. The Claude advisor verdict you must give a second opinion on is the SINGLE block appended at the very end (the MOST RECENT verdict); any earlier "CLAUDE ADVISOR VERDICT" blocks appearing inline within the session are context only — do not review those. Give an INDEPENDENT second opinion on that most-recent verdict.',
+  '',
+  'Specifically:',
+  '1) Where you AGREE or DISAGREE with the Claude advisor, and why. Be concrete.',
+  '2) REASONING-TRACE AUDIT: scrutinize the assistant\'s reasoning blocks and explicitly flag any logical flaws, invalid inferences, unjustified leaps, or factual errors. Quote the specific step.',
+  '3) Anything important BOTH the assistant and the Claude advisor missed.',
+  'Be direct and concise. Do not restate the session back to me.',
+  '',
+  '================ FULL SESSION ================',
+  transcript,
+  '================ END SESSION ================',
+  '',
+  '================ THE ADVISOR VERDICT TO REVIEW (most recent — your second opinion is about THIS) ================',
+  verdict,
+  '================ END VERDICT ================',
+].join('\n');
+
+// Persistent run log: ~/.claude/logs/codex-advisor/<runId>/ (runId = UTC ts + short session id).
+const ts = new Date().toISOString();
+const runId = `${ts.replace(/:/g, '-').replace(/\.\d+Z$/, 'Z')}__${(process.env.CLAUDE_CODE_SESSION_ID || 'nosid').slice(0, 8)}`;
+const LOG_DIR = join(LOGS_ROOT, runId);
+mkdirSync(LOG_DIR, { recursive: true });
+const writeMeta = (status) => {
+  try {
+    writeFileSync(join(LOG_DIR, 'meta.json'), JSON.stringify({
+      session_id: process.env.CLAUDE_CODE_SESSION_ID || null,
+      resolved_transcript_path: path,
+      verdict_id: verdictId,
+      model: MODEL,
+      effort: EFFORT,
+      ts,
+      status,
+    }, null, 2));
+  } catch {}
+};
+try { writeFileSync(join(LOG_DIR, 'prompt.txt'), prompt); } catch {}
+
+const outFile = join(LOG_DIR, 'output.txt');
+const r = spawnSync('codex', [
+  'exec', '--skip-git-repo-check', '-m', MODEL, '-s', 'read-only',
+  '-c', `model_reasoning_effort=${EFFORT}`,
+  '-o', outFile, '-',
+], { input: prompt, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+
+if (r.error) { writeMeta('codex-error'); done(`[codex-advisor] codex unavailable: ${r.error.message}\n[codex-advisor] log: ${LOG_DIR}`); }
+let answer = '';
+try { answer = readFileSync(outFile, 'utf8').trim(); } catch {}
+if (!answer) answer = (r.stdout || '').trim();
+if (!answer) { writeMeta('no-output'); done(`[codex-advisor] codex produced no output (exit ${r.status}). ${(r.stderr || '').slice(-400)}\n[codex-advisor] log: ${LOG_DIR}`); }
+
+console.log(`===== GPT-5.5 SECOND OPINION (codex-advisor · effort=${EFFORT}) =====\n`);
+console.log(answer);
+writeMeta('ok');
+console.log(`\n[codex-advisor] log: ${LOG_DIR}`);

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -465,8 +465,10 @@ async function executeReviewRun(request) {
       jobId: request.jobId ?? null,
       kind: "review",
       status: jobStatus,
-      // The built-in reviewer returns prose, so there is no machine-readable verdict.
+      // The built-in reviewer answers in prose: the verdict is absent by design,
+      // which is not the same as a failed or unparseable run.
       parsed: null,
+      unstructuredKind: !result.timedOut,
       parseError: result.timedOut ? "The review deadline expired before Codex finished." : null,
       summaryText: result.reviewText,
       rawOutput: result.reviewText,
@@ -803,7 +805,7 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId, timeoutMs, noWait }) {
   return {
     cwd,
     model,
@@ -811,7 +813,9 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     prompt,
     write,
     resumeLast,
-    jobId
+    jobId,
+    timeoutMs,
+    noWait
   };
 }
 
@@ -866,13 +870,24 @@ function boundedStdout(execution) {
   return renderResultEnvelope(execution.envelope);
 }
 
+function boundedPayload(execution) {
+  const payload = execution.payload;
+  if (!execution.envelope) {
+    return payload;
+  }
+  // JSON mode carries the same budget as text mode: review payloads embed the
+  // whole transcript, so oversized ones collapse to the envelope.
+  const size = Buffer.byteLength(JSON.stringify(payload ?? null), "utf8");
+  return size <= MAX_ENVELOPE_STDOUT_BYTES ? payload : execution.envelope;
+}
+
 async function runForegroundCommand(job, runner, options = {}) {
   const { logFile, progress } = createTrackedProgress(job, {
     logFile: options.logFile,
     stderr: !options.json
   });
   const execution = await runTrackedJob(job, () => runner(progress, logFile), { logFile });
-  outputResult(options.json ? execution.payload : boundedStdout(execution), options.json);
+  outputResult(options.json ? boundedPayload(execution) : boundedStdout(execution), options.json);
   if (execution.exitStatus !== 0) {
     process.exitCode = execution.exitStatus;
   }
@@ -1029,7 +1044,8 @@ async function handleTask(argv) {
       write,
       resumeLast,
       jobId: job.id,
-      timeoutMs
+      timeoutMs,
+      noWait: Boolean(options["no-wait"])
     });
     const { payload } = enqueueBackgroundJob(cwd, job, request);
     outputCommandResult(payload, renderQueuedTaskLaunch(payload), options.json);
@@ -1121,13 +1137,37 @@ async function handleConsult(argv) {
   } catch (error) {
     // A launch, queue, or transport failure still returns a bounded envelope so
     // callers can tell "no second opinion" apart from "silence".
+    const stored = readStoredJob(workspaceRoot, job.id) ?? {};
     const envelope = buildResultEnvelope({
       jobId: job.id,
       kind: "consult",
       status: "failed",
       parsed: null,
       errorMessage: error instanceof Error ? error.message : String(error),
-      logPath: job.logFile ?? null
+      logPath: stored.logFile ?? job.logFile ?? null
+    });
+    // Persist it too, so /codex:result <id> answers with the same envelope.
+    writeJobFile(workspaceRoot, job.id, {
+      ...stored,
+      id: job.id,
+      kind: "consult",
+      jobClass: "consult",
+      title: job.title,
+      workspaceRoot,
+      status: "failed",
+      phase: "failed",
+      pid: null,
+      errorMessage: envelope.error_message,
+      envelope
+    });
+    upsertJob(workspaceRoot, {
+      id: job.id,
+      status: "failed",
+      phase: "failed",
+      pid: null,
+      errorMessage: envelope.error_message,
+      verdict: envelope.verdict,
+      completedAt: nowIso()
     });
     outputResult(options.json ? envelope : renderResultEnvelope(envelope), options.json);
     process.exitCode = 1;

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -24,7 +24,13 @@ import {
     runAppServerReview,
     runAppServerTurn
   } from "./lib/codex.mjs";
-import { buildResultEnvelope, MAX_ENVELOPE_STDOUT_BYTES, renderResultEnvelope } from "./lib/envelope.mjs";
+import {
+  buildResultEnvelope,
+  emittedJsonBytes,
+  MAX_ENVELOPE_STDOUT_BYTES,
+  renderResultEnvelope,
+  validateStructuredResult
+} from "./lib/envelope.mjs";
 import { cancelQueuedWorkload, readSchedulerSnapshot } from "./lib/scheduler.mjs";
 import { resolveClaudeSessionPath } from "./lib/claude-session-transfer.mjs";
 import { readStdinIfPiped } from "./lib/fs.mjs";
@@ -205,6 +211,38 @@ function storeFinalOutput(workspaceRoot, jobId, text) {
   const finalOutputPath = resolveJobFinalOutputFile(workspaceRoot, jobId);
   fs.writeFileSync(finalOutputPath, `${String(text ?? "").trimEnd()}\n`, "utf8");
   return finalOutputPath;
+}
+
+function extractJsonBlock(text) {
+  const trimmed = String(text ?? "").trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (trimmed.startsWith("{")) {
+    return trimmed;
+  }
+  const fenced = trimmed.match(/```(?:json)?\s*(\{[\s\S]*?\})\s*```/i);
+  return fenced ? fenced[1].trim() : null;
+}
+
+/**
+ * The app-server types give the built-in reviewer's output as a plain string
+ * (ThreadItem `exitedReviewMode.review`), and `review/start` takes no output
+ * schema, so there is no structured verdict to read. When the reviewer does put
+ * a JSON result in that string, parse it for real; otherwise report an absent
+ * verdict rather than guessing one from prose.
+ */
+function parseNativeReviewOutput(reviewText) {
+  const block = extractJsonBlock(reviewText);
+  if (!block) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(block);
+    return validateStructuredResult(parsed) === null ? parsed : null;
+  } catch {
+    return null;
+  }
 }
 
 function jobStatusForExecution({ timedOut, exitStatus }) {
@@ -461,14 +499,16 @@ async function executeReviewRun(request) {
     );
     const jobStatus = jobStatusForExecution({ timedOut: result.timedOut, exitStatus: result.status });
     const finalOutputPath = storeFinalOutput(workspaceRoot, request.jobId, fullText);
+    // Parse the reviewer's output when it carries a structured result; when it
+    // answers in prose the verdict is absent by design, which is not the same
+    // as a failed or unparseable run.
+    const parsedNative = result.timedOut ? null : parseNativeReviewOutput(result.reviewText);
     const envelope = buildResultEnvelope({
       jobId: request.jobId ?? null,
       kind: "review",
       status: jobStatus,
-      // The built-in reviewer answers in prose: the verdict is absent by design,
-      // which is not the same as a failed or unparseable run.
-      parsed: null,
-      unstructuredKind: !result.timedOut,
+      parsed: parsedNative,
+      unstructuredKind: !parsedNative && !result.timedOut,
       parseError: result.timedOut ? "The review deadline expired before Codex finished." : null,
       summaryText: result.reviewText,
       rawOutput: result.reviewText,
@@ -805,7 +845,7 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId, timeoutMs, noWait }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId, timeoutMs, queueWaitMs, noWait }) {
   return {
     cwd,
     model,
@@ -815,6 +855,7 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     resumeLast,
     jobId,
     timeoutMs,
+    queueWaitMs,
     noWait
   };
 }
@@ -876,9 +917,9 @@ function boundedPayload(execution) {
     return payload;
   }
   // JSON mode carries the same budget as text mode: review payloads embed the
-  // whole transcript, so oversized ones collapse to the envelope.
-  const size = Buffer.byteLength(JSON.stringify(payload ?? null), "utf8");
-  return size <= MAX_ENVELOPE_STDOUT_BYTES ? payload : execution.envelope;
+  // whole transcript, so oversized ones collapse to the envelope. Measured on
+  // the pretty-printed form, because that is what gets written to stdout.
+  return emittedJsonBytes(payload ?? null) <= MAX_ENVELOPE_STDOUT_BYTES ? payload : execution.envelope;
 }
 
 async function runForegroundCommand(job, runner, options = {}) {
@@ -1026,6 +1067,7 @@ async function handleTask(argv) {
   }
   const write = Boolean(options.write);
   const timeoutMs = normalizeTimeoutMs(options["timeout-ms"], DEFAULT_TASK_TIMEOUT_MS);
+  const queueWaitMs = options["queue-wait-ms"] ? Number(options["queue-wait-ms"]) : null;
   const taskMetadata = buildTaskRunMetadata({
     prompt,
     resumeLast
@@ -1045,6 +1087,7 @@ async function handleTask(argv) {
       resumeLast,
       jobId: job.id,
       timeoutMs,
+      queueWaitMs,
       noWait: Boolean(options["no-wait"])
     });
     const { payload } = enqueueBackgroundJob(cwd, job, request);
@@ -1065,6 +1108,7 @@ async function handleTask(argv) {
         resumeLast,
         jobId: job.id,
         timeoutMs,
+        queueWaitMs,
         noWait: Boolean(options["no-wait"]),
         onProgress: progress
       }),

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -9,7 +9,10 @@ import { fileURLToPath } from "node:url";
 import { parseArgs, splitRawArgumentString } from "./lib/args.mjs";
 import {
     buildPersistentTaskThreadName,
+    DEFAULT_CONSULT_TIMEOUT_MS,
     DEFAULT_CONTINUE_PROMPT,
+    DEFAULT_REVIEW_TIMEOUT_MS,
+    DEFAULT_TASK_TIMEOUT_MS,
     findLatestTaskThread,
     getCodexAuthStatus,
     getCodexAvailability,
@@ -21,6 +24,8 @@ import {
     runAppServerReview,
     runAppServerTurn
   } from "./lib/codex.mjs";
+import { buildResultEnvelope, MAX_ENVELOPE_STDOUT_BYTES, renderResultEnvelope } from "./lib/envelope.mjs";
+import { cancelQueuedWorkload, readSchedulerSnapshot } from "./lib/scheduler.mjs";
 import { resolveClaudeSessionPath } from "./lib/claude-session-transfer.mjs";
 import { readStdinIfPiped } from "./lib/fs.mjs";
 import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./lib/git.mjs";
@@ -30,6 +35,7 @@ import {
   generateJobId,
   getConfig,
   listJobs,
+  resolveJobFinalOutputFile,
   setConfig,
   upsertJob,
   writeJobFile
@@ -77,12 +83,13 @@ function printUsage() {
     [
       "Usage:",
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
-      "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
-      "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--timeout-ms <ms>]",
+      "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--timeout-ms <ms>] [focus text]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [--timeout-ms <ms>] [prompt]",
+      "  node scripts/codex-companion.mjs consult --prompt-file <path> [--cwd <path>] [--model <model>] [--effort <level>] [--timeout-ms <ms>] [--no-wait] [--json]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
-      "  node scripts/codex-companion.mjs result [job-id] [--json]",
+      "  node scripts/codex-companion.mjs result [job-id] [--full] [--json]",
       "  node scripts/codex-companion.mjs cancel [job-id] [--json]"
     ].join("\n")
   );
@@ -158,6 +165,44 @@ function resolveCommandWorkspace(options = {}) {
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeTimeoutMs(value, fallback) {
+  if (value == null || String(value).trim() === "") {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`--timeout-ms must be a positive number of milliseconds, got "${value}".`);
+  }
+  return Math.round(parsed);
+}
+
+function buildWorkloadLease({ jobId, kind, workspaceRoot, timeoutMs, noWait = false, queueWaitMs = null }) {
+  return {
+    jobId,
+    kind,
+    workspace: workspaceRoot,
+    timeoutMs,
+    noWait: Boolean(noWait),
+    ...(queueWaitMs == null ? {} : { waitTimeoutMs: queueWaitMs })
+  };
+}
+
+function storeFinalOutput(workspaceRoot, jobId, text) {
+  if (!workspaceRoot || !jobId) {
+    return null;
+  }
+  const finalOutputPath = resolveJobFinalOutputFile(workspaceRoot, jobId);
+  fs.writeFileSync(finalOutputPath, `${String(text ?? "").trimEnd()}\n`, "utf8");
+  return finalOutputPath;
+}
+
+function jobStatusForExecution({ timedOut, exitStatus }) {
+  if (timedOut) {
+    return "timed-out";
+  }
+  return exitStatus === 0 ? "completed" : "failed";
 }
 
 function shorten(text, limit = 96) {
@@ -365,11 +410,24 @@ async function executeReviewRun(request) {
   });
   const focusText = request.focusText?.trim() ?? "";
   const reviewName = request.reviewName ?? "Review";
+  const workspaceRoot = request.workspaceRoot ?? resolveWorkspaceRoot(request.cwd);
+  const timeoutMs = request.timeoutMs ?? DEFAULT_REVIEW_TIMEOUT_MS;
+  const lease = buildWorkloadLease({
+    jobId: request.jobId ?? generateJobId("review"),
+    kind: request.reviewName === "Adversarial Review" ? "adversarial-review" : "review",
+    workspaceRoot,
+    timeoutMs,
+    noWait: request.noWait,
+    queueWaitMs: request.queueWaitMs
+  });
+
   if (reviewName === "Review") {
     const reviewTarget = validateNativeReviewRequest(target, focusText);
     const result = await runAppServerReview(request.cwd, {
       target: reviewTarget,
       model: request.model,
+      timeoutMs,
+      lease,
       onProgress: request.onProgress
     });
     const payload = {
@@ -384,7 +442,7 @@ async function executeReviewRun(request) {
         reasoning: result.reasoningSummary
       }
     };
-    const rendered = renderNativeReviewResult(
+    const fullText = renderNativeReviewResult(
       {
         status: result.status,
         stdout: result.reviewText,
@@ -392,13 +450,36 @@ async function executeReviewRun(request) {
       },
       { reviewLabel: reviewName, targetLabel: target.label, reasoningSummary: result.reasoningSummary }
     );
+    const jobStatus = jobStatusForExecution({ timedOut: result.timedOut, exitStatus: result.status });
+    const finalOutputPath = storeFinalOutput(workspaceRoot, request.jobId, fullText);
+    const envelope = buildResultEnvelope({
+      jobId: request.jobId ?? null,
+      kind: "review",
+      status: jobStatus,
+      // The built-in reviewer returns prose, so there is no machine-readable verdict.
+      parsed: null,
+      parseError: result.timedOut ? "The review deadline expired before Codex finished." : null,
+      summaryText: result.reviewText,
+      rawOutput: result.reviewText,
+      durationMs: request.durationMs,
+      queueWaitMs: result.queueWaitMs,
+      threadId: result.threadId,
+      finalOutputPath,
+      logPath: request.logFile ?? null,
+      exitCode: result.status
+    });
 
     return {
       exitStatus: result.status,
+      jobStatus,
+      timedOut: Boolean(result.timedOut),
+      queueWaitMs: result.queueWaitMs ?? null,
+      envelope,
+      finalOutputPath,
       threadId: result.threadId,
       turnId: result.turnId,
-      payload,
-      rendered,
+      payload: { ...payload, envelope, finalOutputPath },
+      rendered: fullText,
       summary: firstMeaningfulLine(result.reviewText, `${reviewName} completed.`),
       jobTitle: `Codex ${reviewName}`,
       jobClass: "review",
@@ -413,6 +494,8 @@ async function executeReviewRun(request) {
     model: request.model,
     sandbox: "read-only",
     outputSchema: readOutputSchema(REVIEW_SCHEMA),
+    timeoutMs,
+    lease,
     onProgress: request.onProgress
   });
   const parsed = parseStructuredOutput(result.finalMessage, {
@@ -440,16 +523,39 @@ async function executeReviewRun(request) {
     reasoningSummary: result.reasoningSummary
   };
 
+  const rendered = renderReviewResult(parsed, {
+    reviewLabel: reviewName,
+    targetLabel: context.target.label,
+    reasoningSummary: result.reasoningSummary
+  });
+  const jobStatus = jobStatusForExecution({ timedOut: result.timedOut, exitStatus: result.status });
+  const finalOutputPath = storeFinalOutput(workspaceRoot, request.jobId, rendered);
+  const envelope = buildResultEnvelope({
+    jobId: request.jobId ?? null,
+    kind: "adversarial-review",
+    status: jobStatus,
+    parsed: parsed.parsed,
+    parseError: parsed.parseError,
+    rawOutput: parsed.rawOutput,
+    durationMs: request.durationMs,
+    queueWaitMs: result.queueWaitMs,
+    threadId: result.threadId,
+    finalOutputPath,
+    logPath: request.logFile ?? null,
+    exitCode: result.status
+  });
+
   return {
     exitStatus: result.status,
+    jobStatus,
+    timedOut: Boolean(result.timedOut),
+    queueWaitMs: result.queueWaitMs ?? null,
+    envelope,
+    finalOutputPath,
     threadId: result.threadId,
     turnId: result.turnId,
-    payload,
-    rendered: renderReviewResult(parsed, {
-      reviewLabel: reviewName,
-      targetLabel: context.target.label,
-      reasoningSummary: result.reasoningSummary
-    }),
+    payload: { ...payload, envelope, finalOutputPath },
+    rendered,
     summary: parsed.parsed?.summary ?? parsed.parseError ?? firstMeaningfulLine(result.finalMessage, `${reviewName} finished.`),
     jobTitle: `Codex ${reviewName}`,
     jobClass: "review",
@@ -482,6 +588,7 @@ async function executeTaskRun(request) {
     throw new Error("Provide a prompt, a prompt file, piped stdin, or use --resume-last.");
   }
 
+  const timeoutMs = request.timeoutMs ?? DEFAULT_TASK_TIMEOUT_MS;
   const result = await runAppServerTurn(workspaceRoot, {
     resumeThreadId,
     prompt: request.prompt,
@@ -489,6 +596,15 @@ async function executeTaskRun(request) {
     model: request.model,
     effort: request.effort,
     sandbox: request.write ? "workspace-write" : "read-only",
+    timeoutMs,
+    lease: buildWorkloadLease({
+      jobId: request.jobId ?? generateJobId("task"),
+      kind: "task",
+      workspaceRoot,
+      timeoutMs,
+      noWait: request.noWait,
+      queueWaitMs: request.queueWaitMs
+    }),
     onProgress: request.onProgress,
     persistThread: true,
     threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
@@ -508,16 +624,24 @@ async function executeTaskRun(request) {
       write: Boolean(request.write)
     }
   );
+  const jobStatus = jobStatusForExecution({ timedOut: result.timedOut, exitStatus: result.status });
+  const finalOutputPath = storeFinalOutput(workspaceRoot, request.jobId, rendered);
   const payload = {
     status: result.status,
+    timedOut: Boolean(result.timedOut),
     threadId: result.threadId,
     rawOutput,
     touchedFiles: result.touchedFiles,
-    reasoningSummary: result.reasoningSummary
+    reasoningSummary: result.reasoningSummary,
+    finalOutputPath
   };
 
   return {
     exitStatus: result.status,
+    jobStatus,
+    timedOut: Boolean(result.timedOut),
+    queueWaitMs: result.queueWaitMs ?? null,
+    finalOutputPath,
     threadId: result.threadId,
     turnId: result.turnId,
     payload,
@@ -526,6 +650,75 @@ async function executeTaskRun(request) {
     jobTitle: taskMetadata.title,
     jobClass: "task",
     write: Boolean(request.write)
+  };
+}
+
+async function executeConsultRun(request) {
+  ensureCodexAvailable(request.cwd);
+
+  const workspaceRoot = request.workspaceRoot ?? resolveWorkspaceRoot(request.cwd);
+  const timeoutMs = request.timeoutMs ?? DEFAULT_CONSULT_TIMEOUT_MS;
+  const startedAt = Date.now();
+  const result = await runAppServerTurn(request.cwd, {
+    prompt: request.prompt,
+    model: request.model,
+    effort: request.effort,
+    // Consult is stateless: fresh ephemeral thread, read-only, never resumable.
+    sandbox: "read-only",
+    persistThread: false,
+    // Same structured contract as adversarial review so every consult returns a verdict.
+    outputSchema: readOutputSchema(REVIEW_SCHEMA),
+    timeoutMs,
+    lease: buildWorkloadLease({
+      jobId: request.jobId,
+      kind: "consult",
+      workspaceRoot,
+      timeoutMs,
+      noWait: request.noWait,
+      queueWaitMs: request.queueWaitMs
+    }),
+    onProgress: request.onProgress
+  });
+
+  const parsed = parseStructuredOutput(result.finalMessage, {
+    status: result.status,
+    failureMessage: result.error?.message ?? result.stderr
+  });
+  const jobStatus = jobStatusForExecution({ timedOut: result.timedOut, exitStatus: result.status });
+  const finalOutputPath = storeFinalOutput(
+    workspaceRoot,
+    request.jobId,
+    parsed.parsed ? JSON.stringify(parsed.parsed, null, 2) : parsed.rawOutput
+  );
+  const envelope = buildResultEnvelope({
+    jobId: request.jobId,
+    kind: "consult",
+    status: jobStatus,
+    parsed: parsed.parsed,
+    parseError: result.timedOut ? "The consult deadline expired before Codex finished." : parsed.parseError,
+    rawOutput: parsed.rawOutput,
+    durationMs: Date.now() - startedAt,
+    queueWaitMs: result.queueWaitMs,
+    threadId: result.threadId,
+    finalOutputPath,
+    logPath: request.logFile ?? null,
+    exitCode: result.status
+  });
+
+  return {
+    exitStatus: result.status,
+    jobStatus,
+    timedOut: Boolean(result.timedOut),
+    queueWaitMs: result.queueWaitMs ?? null,
+    envelope,
+    finalOutputPath,
+    threadId: result.threadId,
+    turnId: result.turnId,
+    payload: envelope,
+    rendered: renderResultEnvelope(envelope),
+    summary: envelope.summary || "Consult finished.",
+    jobTitle: "Codex Consult",
+    jobClass: "consult"
   };
 }
 
@@ -655,22 +848,31 @@ function requireTaskRequest(prompt, resumeLast) {
   }
 }
 
+function boundedStdout(execution) {
+  const rendered = execution.rendered ?? "";
+  if (!execution.envelope || Buffer.byteLength(rendered, "utf8") <= MAX_ENVELOPE_STDOUT_BYTES) {
+    return rendered;
+  }
+  // Never dump an unbounded transcript: the complete text stays on disk.
+  return renderResultEnvelope(execution.envelope);
+}
+
 async function runForegroundCommand(job, runner, options = {}) {
   const { logFile, progress } = createTrackedProgress(job, {
     logFile: options.logFile,
     stderr: !options.json
   });
-  const execution = await runTrackedJob(job, () => runner(progress), { logFile });
-  outputResult(options.json ? execution.payload : execution.rendered, options.json);
+  const execution = await runTrackedJob(job, () => runner(progress, logFile), { logFile });
+  outputResult(options.json ? execution.payload : boundedStdout(execution), options.json);
   if (execution.exitStatus !== 0) {
     process.exitCode = execution.exitStatus;
   }
   return execution;
 }
 
-function spawnDetachedTaskWorker(cwd, jobId) {
+function spawnDetachedWorker(cwd, jobId, workerCommand = "task-worker") {
   const scriptPath = path.join(ROOT_DIR, "scripts", "codex-companion.mjs");
-  const child = spawn(process.execPath, [scriptPath, "task-worker", "--cwd", cwd, "--job-id", jobId], {
+  const child = spawn(process.execPath, [scriptPath, workerCommand, "--cwd", cwd, "--job-id", jobId], {
     cwd,
     env: process.env,
     detached: true,
@@ -681,11 +883,11 @@ function spawnDetachedTaskWorker(cwd, jobId) {
   return child;
 }
 
-function enqueueBackgroundTask(cwd, job, request) {
+function enqueueBackgroundJob(cwd, job, request, workerCommand = "task-worker") {
   const { logFile } = createTrackedProgress(job);
   appendLogLine(logFile, "Queued for background execution.");
 
-  const child = spawnDetachedTaskWorker(cwd, job.id);
+  const child = spawnDetachedWorker(cwd, job.id, workerCommand);
   const queuedRecord = {
     ...job,
     status: "queued",
@@ -711,8 +913,8 @@ function enqueueBackgroundTask(cwd, job, request) {
 
 async function handleReviewCommand(argv, config) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["base", "scope", "model", "cwd"],
-    booleanOptions: ["json", "background", "wait"],
+    valueOptions: ["base", "scope", "model", "cwd", "timeout-ms", "queue-wait-ms"],
+    booleanOptions: ["json", "background", "wait", "no-wait"],
     aliasMap: {
       m: "model"
     }
@@ -736,16 +938,35 @@ async function handleReviewCommand(argv, config) {
     jobClass: "review",
     summary: metadata.summary
   });
+  const request = {
+    cwd,
+    workspaceRoot,
+    base: options.base,
+    scope: options.scope,
+    model: options.model,
+    focusText,
+    reviewName: config.reviewName,
+    jobId: job.id,
+    timeoutMs: normalizeTimeoutMs(options["timeout-ms"], DEFAULT_REVIEW_TIMEOUT_MS),
+    queueWaitMs: options["queue-wait-ms"] ? Number(options["queue-wait-ms"]) : null,
+    noWait: Boolean(options["no-wait"])
+  };
+
+  if (options.background) {
+    ensureCodexAvailable(cwd);
+    // The companion detaches its own review worker; callers must not depend on
+    // the host shell keeping the run alive.
+    const { payload } = enqueueBackgroundJob(cwd, job, request, "review-worker");
+    outputCommandResult(payload, renderQueuedTaskLaunch(payload), options.json);
+    return;
+  }
+
   await runForegroundCommand(
     job,
-    (progress) =>
+    (progress, logFile) =>
       executeReviewRun({
-        cwd,
-        base: options.base,
-        scope: options.scope,
-        model: options.model,
-        focusText,
-        reviewName: config.reviewName,
+        ...request,
+        logFile,
         onProgress: progress
       }),
     { json: options.json }
@@ -761,8 +982,8 @@ async function handleReview(argv) {
 
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["model", "effort", "cwd", "prompt-file"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
+    valueOptions: ["model", "effort", "cwd", "prompt-file", "timeout-ms", "queue-wait-ms"],
+    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background", "no-wait"],
     aliasMap: {
       m: "model"
     }
@@ -780,6 +1001,7 @@ async function handleTask(argv) {
     throw new Error("Choose either --resume/--resume-last or --fresh.");
   }
   const write = Boolean(options.write);
+  const timeoutMs = normalizeTimeoutMs(options["timeout-ms"], DEFAULT_TASK_TIMEOUT_MS);
   const taskMetadata = buildTaskRunMetadata({
     prompt,
     resumeLast
@@ -797,9 +1019,10 @@ async function handleTask(argv) {
       prompt,
       write,
       resumeLast,
-      jobId: job.id
+      jobId: job.id,
+      timeoutMs
     });
-    const { payload } = enqueueBackgroundTask(cwd, job, request);
+    const { payload } = enqueueBackgroundJob(cwd, job, request);
     outputCommandResult(payload, renderQueuedTaskLaunch(payload), options.json);
     return;
   }
@@ -816,10 +1039,90 @@ async function handleTask(argv) {
         write,
         resumeLast,
         jobId: job.id,
+        timeoutMs,
+        noWait: Boolean(options["no-wait"]),
         onProgress: progress
       }),
     { json: options.json }
   );
+}
+
+async function handleConsult(argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["cwd", "model", "effort", "prompt-file", "timeout-ms", "queue-wait-ms"],
+    booleanOptions: ["json", "write", "no-wait"],
+    aliasMap: {
+      m: "model"
+    }
+  });
+
+  // Rejected before anything is queued: consult is a read-only entry point.
+  if (options.write) {
+    throw new Error("`consult` is read-only and does not accept --write. Use `task --write` for changes.");
+  }
+  if (!options["prompt-file"]) {
+    throw new Error("`consult` requires --prompt-file <absolute-path>. Positional prompts and stdin are not accepted.");
+  }
+  if (positionals.length > 0) {
+    throw new Error("`consult` takes its prompt only from --prompt-file. Remove the positional prompt text.");
+  }
+
+  const cwd = resolveCommandCwd(options);
+  // Consult must work outside a Git repository; the workspace falls back to cwd.
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const promptPath = path.resolve(cwd, options["prompt-file"]);
+  if (!fs.existsSync(promptPath)) {
+    throw new Error(`No prompt file found at ${promptPath}.`);
+  }
+  const prompt = fs.readFileSync(promptPath, "utf8");
+  if (!prompt.trim()) {
+    throw new Error(`The prompt file ${promptPath} is empty.`);
+  }
+
+  const job = createCompanionJob({
+    prefix: "consult",
+    kind: "consult",
+    title: "Codex Consult",
+    workspaceRoot,
+    jobClass: "consult",
+    summary: shorten(prompt)
+  });
+  const timeoutMs = normalizeTimeoutMs(options["timeout-ms"], DEFAULT_CONSULT_TIMEOUT_MS);
+
+  try {
+    await runForegroundCommand(
+      job,
+      (progress, logFile) =>
+        executeConsultRun({
+          cwd,
+          workspaceRoot,
+          prompt,
+          promptPath,
+          model: normalizeRequestedModel(options.model),
+          effort: normalizeReasoningEffort(options.effort),
+          jobId: job.id,
+          timeoutMs,
+          queueWaitMs: options["queue-wait-ms"] ? Number(options["queue-wait-ms"]) : null,
+          noWait: Boolean(options["no-wait"]),
+          logFile,
+          onProgress: progress
+        }),
+      { json: options.json }
+    );
+  } catch (error) {
+    // A launch, queue, or transport failure still returns a bounded envelope so
+    // callers can tell "no second opinion" apart from "silence".
+    const envelope = buildResultEnvelope({
+      jobId: job.id,
+      kind: "consult",
+      status: "failed",
+      parsed: null,
+      errorMessage: error instanceof Error ? error.message : String(error),
+      logPath: job.logFile ?? null
+    });
+    outputResult(options.json ? envelope : renderResultEnvelope(envelope), options.json);
+    process.exitCode = 1;
+  }
 }
 
 async function handleTransfer(argv) {
@@ -835,13 +1138,15 @@ async function handleTransfer(argv) {
   outputCommandResult(payload, rendered, options.json);
 }
 
-async function handleTaskWorker(argv) {
+async function handleTaskWorker(argv, config = {}) {
+  const workerName = config.workerName ?? "task-worker";
+  const runner = config.runner ?? executeTaskRun;
   const { options } = parseCommandInput(argv, {
     valueOptions: ["cwd", "job-id"]
   });
 
   if (!options["job-id"]) {
-    throw new Error("Missing required --job-id for task-worker.");
+    throw new Error(`Missing required --job-id for ${workerName}.`);
   }
 
   const cwd = resolveCommandCwd(options);
@@ -853,7 +1158,7 @@ async function handleTaskWorker(argv) {
 
   const request = storedJob.request;
   if (!request || typeof request !== "object") {
-    throw new Error(`Stored job ${options["job-id"]} is missing its task request payload.`);
+    throw new Error(`Stored job ${options["job-id"]} is missing its ${workerName} request payload.`);
   }
 
   const { logFile, progress } = createTrackedProgress(
@@ -872,8 +1177,9 @@ async function handleTaskWorker(argv) {
       logFile
     },
     () =>
-      executeTaskRun({
+      runner({
         ...request,
+        logFile,
         onProgress: progress
       }),
     { logFile }
@@ -910,19 +1216,33 @@ async function handleStatus(argv) {
 function handleResult(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["cwd"],
-    booleanOptions: ["json"]
+    booleanOptions: ["json", "full"]
   });
 
   const cwd = resolveCommandCwd(options);
   const reference = positionals[0] ?? "";
   const { workspaceRoot, job } = resolveResultJob(cwd, reference);
   const storedJob = readStoredJob(workspaceRoot, job.id);
-  const payload = {
-    job,
-    storedJob
-  };
+  const envelope = storedJob?.envelope ?? null;
 
-  outputCommandResult(payload, renderStoredJobResult(job, storedJob), options.json);
+  if (options.full) {
+    const finalOutputPath = storedJob?.finalOutputPath ?? null;
+    const fullText =
+      finalOutputPath && fs.existsSync(finalOutputPath)
+        ? fs.readFileSync(finalOutputPath, "utf8")
+        : renderStoredJobResult(job, storedJob);
+    outputCommandResult({ job, storedJob, envelope, fullOutput: fullText }, fullText, options.json);
+    return;
+  }
+
+  // Jobs that carry an envelope answer with the bounded envelope by default;
+  // the complete text stays one `--full` away.
+  if (envelope) {
+    outputCommandResult(envelope, renderResultEnvelope(envelope), options.json);
+    return;
+  }
+
+  outputCommandResult({ job, storedJob }, renderStoredJobResult(job, storedJob), options.json);
 }
 
 function handleTaskResumeCandidate(argv) {
@@ -972,6 +1292,13 @@ async function handleCancel(argv) {
   const existing = readStoredJob(workspaceRoot, job.id) ?? {};
   const threadId = existing.threadId ?? job.threadId ?? null;
   const turnId = existing.turnId ?? job.turnId ?? null;
+
+  // Cancelling a queued job only removes its queue record; the active workload
+  // is interrupted first and only then has its worker terminated.
+  const dequeued = cancelQueuedWorkload(job.id);
+  if (dequeued.removed) {
+    appendLogLine(job.logFile, "Removed from the global Codex queue before it started.");
+  }
 
   const interrupt = await interruptAppServerTurn(cwd, { threadId, turnId });
   if (interrupt.attempted) {
@@ -1046,8 +1373,14 @@ async function main() {
     case "transfer":
       await handleTransfer(argv);
       break;
+    case "consult":
+      await handleConsult(argv);
+      break;
     case "task-worker":
       await handleTaskWorker(argv);
+      break;
+    case "review-worker":
+      await handleTaskWorker(argv, { workerName: "review-worker", runner: executeReviewRun });
       break;
     case "status":
       await handleStatus(argv);

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -78,21 +78,30 @@ const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "hi
 const MODEL_ALIASES = new Map([["spark", "gpt-5.3-codex-spark"]]);
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
 
+const USAGE_LINES = [
+  "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
+  "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--timeout-ms <ms>]",
+  "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--timeout-ms <ms>] [focus text]",
+  "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [--timeout-ms <ms>] [prompt]",
+  "  node scripts/codex-companion.mjs consult --prompt-file <path> [--cwd <path>] [--model <model>] [--effort <level>] [--timeout-ms <ms>] [--no-wait] [--json]",
+  "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
+  "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
+  "  node scripts/codex-companion.mjs result [job-id] [--full] [--json]",
+  "  node scripts/codex-companion.mjs cancel [job-id] [--json]"
+];
+
 function printUsage() {
-  console.log(
-    [
-      "Usage:",
-      "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
-      "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--timeout-ms <ms>]",
-      "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--timeout-ms <ms>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [--timeout-ms <ms>] [prompt]",
-      "  node scripts/codex-companion.mjs consult --prompt-file <path> [--cwd <path>] [--model <model>] [--effort <level>] [--timeout-ms <ms>] [--no-wait] [--json]",
-      "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
-      "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
-      "  node scripts/codex-companion.mjs result [job-id] [--full] [--json]",
-      "  node scripts/codex-companion.mjs cancel [job-id] [--json]"
-    ].join("\n")
-  );
+  console.log(["Usage:", ...USAGE_LINES].join("\n"));
+}
+
+function printCommandUsage(subcommand) {
+  const marker = `codex-companion.mjs ${subcommand} `;
+  const lines = USAGE_LINES.filter((line) => line.includes(marker));
+  console.log(["Usage:", ...(lines.length > 0 ? lines : USAGE_LINES)].join("\n"));
+}
+
+function requestsHelp(argv) {
+  return argv.some((token) => token === "--help" || token === "-h");
 }
 
 function outputResult(value, asJson) {
@@ -1349,9 +1358,17 @@ async function handleCancel(argv) {
 }
 
 async function main() {
-  const [subcommand, ...argv] = process.argv.slice(2);
-  if (!subcommand || subcommand === "help" || subcommand === "--help") {
+  const [subcommand, ...rawArgv] = process.argv.slice(2);
+  if (!subcommand || subcommand === "help" || subcommand === "--help" || subcommand === "-h") {
     printUsage();
+    return;
+  }
+
+  // Help is answered at dispatch: asking a thread-launching command for its
+  // usage must never start a Codex run.
+  const argv = normalizeArgv(rawArgv);
+  if (requestsHelp(argv)) {
+    printCommandUsage(subcommand);
     return;
   }
 

--- a/plugins/codex/scripts/collab.mjs
+++ b/plugins/codex/scripts/collab.mjs
@@ -420,8 +420,8 @@ async function cmdRun(mainRoot, flags) {
     assignment.sessions.push(sessionMatch[1]);
     writeJson(paths.assignments, assignments);
   }
-  if (result.status !== 0) {
-    fail(`codex exec failed (exit ${result.status}); see ${logFile}`);
+  if (result.exitCode !== 0) {
+    fail(`codex exec failed (exit ${result.exitCode}); see ${logFile}`);
   }
   const finalMessage = fs.existsSync(finalFile) ? fs.readFileSync(finalFile, "utf8").trim() : "(no final message)";
   console.log(finalMessage);

--- a/plugins/codex/scripts/collab.mjs
+++ b/plugins/codex/scripts/collab.mjs
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const PROTOCOL_TEMPLATE = path.join(path.dirname(SCRIPT_PATH), "..", "prompts", "collab-protocol.md");
 const COLLAB_DIR_NAME = ".codex-claude";
+const COLLAB_EXEC_TIMEOUT_MS = 1800000;
 const AGENTS = new Set(["codex", "claude"]);
 const MESSAGE_TYPES = new Set([
   "assign",
@@ -396,8 +397,16 @@ function cmdRun(mainRoot, flags) {
   }
   args.push(fullPrompt);
   const logFd = fs.openSync(logFile, "w");
-  const result = spawnSync("codex", args, { stdio: ["ignore", logFd, logFd] });
+  // Stdin is never inherited and the run carries its own deadline, so a wedged
+  // Codex cannot hold a collab lane open forever.
+  const result = spawnSync("codex", args, {
+    stdio: ["ignore", logFd, logFd],
+    timeout: COLLAB_EXEC_TIMEOUT_MS
+  });
   fs.closeSync(logFd);
+  if (result.error?.code === "ETIMEDOUT") {
+    fail(`codex exec exceeded its ${COLLAB_EXEC_TIMEOUT_MS}ms deadline; see ${logFile}`);
+  }
   const log = fs.readFileSync(logFile, "utf8");
   const sessionMatch = log.match(/session id: ([0-9a-f-]+)/);
   if (sessionMatch && assignment.sessions[assignment.sessions.length - 1] !== sessionMatch[1]) {

--- a/plugins/codex/scripts/collab.mjs
+++ b/plugins/codex/scripts/collab.mjs
@@ -9,10 +9,13 @@ import process from "node:process";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import { runQueuedCodexExec } from "./lib/exec-launcher.mjs";
+
 const SCRIPT_PATH = fileURLToPath(import.meta.url);
 const PROTOCOL_TEMPLATE = path.join(path.dirname(SCRIPT_PATH), "..", "prompts", "collab-protocol.md");
 const COLLAB_DIR_NAME = ".codex-claude";
 const COLLAB_EXEC_TIMEOUT_MS = 1800000;
+const COLLAB_QUEUE_WAIT_MS = 3600000;
 const AGENTS = new Set(["codex", "claude"]);
 const MESSAGE_TYPES = new Set([
   "assign",
@@ -331,7 +334,7 @@ function cmdHandoff(mainRoot, flags) {
   }
 }
 
-function cmdRun(mainRoot, flags) {
+async function cmdRun(mainRoot, flags) {
   const paths = ensureInit(mainRoot);
   const assignments = readJson(paths.assignments, {});
   const assignment = requireIssue(assignments, flags.issue);
@@ -396,15 +399,19 @@ function cmdRun(mainRoot, flags) {
     args.push("-m", flags.model);
   }
   args.push(fullPrompt);
-  const logFd = fs.openSync(logFile, "w");
-  // Stdin is never inherited and the run carries its own deadline, so a wedged
-  // Codex cannot hold a collab lane open forever.
-  const result = spawnSync("codex", args, {
-    stdio: ["ignore", logFd, logFd],
-    timeout: COLLAB_EXEC_TIMEOUT_MS
+  // One launcher for every plugin-owned `codex exec`: the run takes the global
+  // Codex slot, never inherits stdin, and is killed at its deadline.
+  const result = await runQueuedCodexExec({
+    args,
+    cwd: assignment.worktree,
+    logFile,
+    appendLog: false,
+    kind: "collab",
+    jobId: `collab-${assignment.issue}-${stamp}`,
+    timeoutMs: COLLAB_EXEC_TIMEOUT_MS,
+    queueWaitMs: COLLAB_QUEUE_WAIT_MS
   });
-  fs.closeSync(logFd);
-  if (result.error?.code === "ETIMEDOUT") {
+  if (result.timedOut) {
     fail(`codex exec exceeded its ${COLLAB_EXEC_TIMEOUT_MS}ms deadline; see ${logFile}`);
   }
   const log = fs.readFileSync(logFile, "utf8");
@@ -485,7 +492,7 @@ function printUsage() {
   );
 }
 
-function main() {
+async function main() {
   const [command, ...rest] = process.argv.slice(2);
   const { flags } = parseFlags(rest);
   if (!command || command === "help" || flags.help === true) {
@@ -513,7 +520,7 @@ function main() {
       cmdConflicts(mainRoot);
       break;
     case "run":
-      cmdRun(mainRoot, flags);
+      await cmdRun(mainRoot, flags);
       break;
     case "handoff":
       cmdHandoff(mainRoot, flags);

--- a/plugins/codex/scripts/collab.mjs
+++ b/plugins/codex/scripts/collab.mjs
@@ -1,0 +1,524 @@
+#!/usr/bin/env node
+// collab — Claude/Codex peer-collaboration runtime (fork addition).
+// Shared workspace lives at <main-checkout>/.codex-claude (gitignored via .git/info/exclude).
+// Self-contained on purpose: no imports from upstream lib/ so upstream merges stay clean.
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const PROTOCOL_TEMPLATE = path.join(path.dirname(SCRIPT_PATH), "..", "prompts", "collab-protocol.md");
+const COLLAB_DIR_NAME = ".codex-claude";
+const AGENTS = new Set(["codex", "claude"]);
+const MESSAGE_TYPES = new Set([
+  "assign",
+  "status",
+  "question",
+  "claim",
+  "handoff",
+  "review",
+  "rebuttal",
+  "decision"
+]);
+
+function fail(message) {
+  process.stderr.write(`collab: ${message}\n`);
+  process.exit(1);
+}
+
+function git(cwd, args, options = {}) {
+  const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8", ...options });
+  if (result.status !== 0 && !options.allowFailure) {
+    fail(`git ${args.join(" ")} failed: ${(result.stderr || result.stdout || "").trim()}`);
+  }
+  return result;
+}
+
+function resolveMainRoot(cwd) {
+  const result = spawnSync(
+    "git",
+    ["-C", cwd, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+    { encoding: "utf8" }
+  );
+  if (result.status !== 0) {
+    fail("not inside a git repository");
+  }
+  return path.dirname(result.stdout.trim());
+}
+
+function collabPaths(mainRoot) {
+  const dir = path.join(mainRoot, COLLAB_DIR_NAME);
+  return {
+    dir,
+    mailbox: path.join(dir, "mailbox.jsonl"),
+    claims: path.join(dir, "claims.json"),
+    assignments: path.join(dir, "assignments.json"),
+    decisions: path.join(dir, "decisions.md"),
+    cursors: path.join(dir, "cursors"),
+    logs: path.join(dir, "logs")
+  };
+}
+
+function readJson(filePath, fallback) {
+  if (!fs.existsSync(filePath)) {
+    return fallback;
+  }
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function ensureInit(mainRoot) {
+  const paths = collabPaths(mainRoot);
+  fs.mkdirSync(paths.cursors, { recursive: true });
+  fs.mkdirSync(paths.logs, { recursive: true });
+  if (!fs.existsSync(paths.mailbox)) {
+    fs.writeFileSync(paths.mailbox, "", "utf8");
+  }
+  if (!fs.existsSync(paths.claims)) {
+    writeJson(paths.claims, []);
+  }
+  if (!fs.existsSync(paths.assignments)) {
+    writeJson(paths.assignments, {});
+  }
+  if (!fs.existsSync(paths.decisions)) {
+    fs.writeFileSync(paths.decisions, "# Decisions\n", "utf8");
+  }
+  const excludeFile = path.join(mainRoot, ".git", "info", "exclude");
+  const marker = `${COLLAB_DIR_NAME}/`;
+  const existing = fs.existsSync(excludeFile) ? fs.readFileSync(excludeFile, "utf8") : "";
+  if (!existing.split("\n").includes(marker)) {
+    fs.mkdirSync(path.dirname(excludeFile), { recursive: true });
+    fs.appendFileSync(excludeFile, `${existing.endsWith("\n") || existing === "" ? "" : "\n"}${marker}\n`, "utf8");
+  }
+  return paths;
+}
+
+function parseFlags(argv) {
+  const flags = {};
+  const positional = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token.startsWith("--")) {
+      const key = token.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        flags[key] = true;
+      } else {
+        flags[key] = next;
+        i += 1;
+      }
+    } else {
+      positional.push(token);
+    }
+  }
+  return { flags, positional };
+}
+
+function readMessages(paths) {
+  const raw = fs.readFileSync(paths.mailbox, "utf8");
+  return raw
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line));
+}
+
+function appendMessage(paths, message) {
+  const record = {
+    ts: new Date().toISOString(),
+    from: message.from,
+    type: message.type,
+    issue: message.issue ?? null,
+    body: message.body,
+    refs: message.refs ?? []
+  };
+  fs.appendFileSync(paths.mailbox, `${JSON.stringify(record)}\n`, "utf8");
+  if (record.type === "decision") {
+    fs.appendFileSync(
+      paths.decisions,
+      `\n## ${record.ts} · ${record.issue ?? "general"} · ${record.from}\n\n${record.body}\n`,
+      "utf8"
+    );
+  }
+  return record;
+}
+
+function requireAgent(value, label = "--from/--agent") {
+  if (!value || !AGENTS.has(value)) {
+    fail(`${label} must be one of: codex, claude`);
+  }
+  return value;
+}
+
+function requireIssue(assignments, slug) {
+  if (!slug || !assignments[slug]) {
+    fail(`unknown issue "${slug ?? ""}". Known: ${Object.keys(assignments).join(", ") || "(none)"}`);
+  }
+  return assignments[slug];
+}
+
+function pathsOverlap(a, b) {
+  const na = a.replace(/\/+$/, "");
+  const nb = b.replace(/\/+$/, "");
+  return na === nb || na.startsWith(`${nb}/`) || nb.startsWith(`${na}/`);
+}
+
+function findConflicts(claims) {
+  const conflicts = [];
+  for (const mine of claims) {
+    for (const theirs of claims) {
+      if (mine.agent >= theirs.agent) {
+        continue;
+      }
+      for (const p1 of mine.paths) {
+        for (const p2 of theirs.paths) {
+          if (pathsOverlap(p1, p2)) {
+            conflicts.push({ path: p1, otherPath: p2, agents: [mine.agent, theirs.agent], issues: [mine.issue, theirs.issue] });
+          }
+        }
+      }
+    }
+  }
+  return conflicts;
+}
+
+function printConflicts(conflicts) {
+  if (conflicts.length === 0) {
+    console.log("No claim conflicts.");
+    return;
+  }
+  for (const conflict of conflicts) {
+    console.log(
+      `CONFLICT: ${conflict.agents[0]} (${conflict.issues[0]}) and ${conflict.agents[1]} (${conflict.issues[1]}) both touch ${conflict.path}${conflict.path === conflict.otherPath ? "" : ` / ${conflict.otherPath}`}`
+    );
+  }
+}
+
+function cmdInit(mainRoot) {
+  ensureInit(mainRoot);
+  console.log(`Initialized ${path.join(mainRoot, COLLAB_DIR_NAME)}`);
+}
+
+function cmdAssign(mainRoot, flags) {
+  const paths = ensureInit(mainRoot);
+  const agent = requireAgent(flags.agent, "--agent");
+  const slug = typeof flags.issue === "string" ? flags.issue : "";
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) {
+    fail("--issue must be a lowercase slug (a-z, 0-9, hyphens)");
+  }
+  const assignments = readJson(paths.assignments, {});
+  if (assignments[slug]) {
+    fail(`issue "${slug}" is already assigned to ${assignments[slug].agent}`);
+  }
+  const branch = `${agent}/${slug}`;
+  const repoBase = path.basename(mainRoot);
+  const worktree = path.join(path.dirname(mainRoot), `${repoBase}--${agent}-${slug}`);
+  const base = git(mainRoot, ["symbolic-ref", "--short", "HEAD"]).stdout.trim();
+  git(mainRoot, ["worktree", "add", "-b", branch, worktree]);
+  assignments[slug] = {
+    issue: slug,
+    agent,
+    title: typeof flags.title === "string" ? flags.title : slug,
+    branch,
+    base,
+    worktree,
+    sessions: [],
+    status: "active",
+    created: new Date().toISOString()
+  };
+  writeJson(paths.assignments, assignments);
+  appendMessage(paths, {
+    from: agent === "codex" ? "claude" : "codex",
+    type: "assign",
+    issue: slug,
+    body: `Issue "${assignments[slug].title}" assigned to ${agent} on branch ${branch} (worktree ${worktree}).`
+  });
+  console.log(`Assigned ${slug} to ${agent}.`);
+  console.log(`  branch:   ${branch} (base ${base})`);
+  console.log(`  worktree: ${worktree}`);
+}
+
+function cmdPost(mainRoot, flags) {
+  const paths = ensureInit(mainRoot);
+  const from = requireAgent(flags.from, "--from");
+  const type = typeof flags.type === "string" ? flags.type : "";
+  if (!MESSAGE_TYPES.has(type)) {
+    fail(`--type must be one of: ${[...MESSAGE_TYPES].join(", ")}`);
+  }
+  if (typeof flags.body !== "string" || flags.body.trim() === "") {
+    fail("--body is required");
+  }
+  const record = appendMessage(paths, {
+    from,
+    type,
+    issue: typeof flags.issue === "string" ? flags.issue : null,
+    body: flags.body,
+    refs: typeof flags.refs === "string" ? flags.refs.split(",").map((ref) => ref.trim()).filter(Boolean) : []
+  });
+  console.log(`Posted ${record.type} from ${record.from}.`);
+}
+
+function cmdInbox(mainRoot, flags) {
+  const paths = ensureInit(mainRoot);
+  const agent = requireAgent(flags.for, "--for");
+  const cursorFile = path.join(paths.cursors, agent);
+  const cursor = fs.existsSync(cursorFile) ? Number(fs.readFileSync(cursorFile, "utf8").trim()) || 0 : 0;
+  const all = readMessages(paths);
+  const fresh = all.slice(cursor).filter((message) => message.from !== agent);
+  if (fresh.length === 0) {
+    console.log("No new messages.");
+  } else {
+    for (const message of fresh) {
+      console.log(JSON.stringify(message));
+    }
+  }
+  if (!flags.peek) {
+    fs.writeFileSync(cursorFile, String(all.length), "utf8");
+  }
+}
+
+function cmdClaim(mainRoot, flags) {
+  const paths = ensureInit(mainRoot);
+  const agent = requireAgent(flags.agent, "--agent");
+  const issue = typeof flags.issue === "string" ? flags.issue : null;
+  const claimedPaths = typeof flags.paths === "string" ? flags.paths.split(",").map((p) => p.trim()).filter(Boolean) : [];
+  if (claimedPaths.length === 0) {
+    fail("--paths is required (comma-separated repo-relative paths)");
+  }
+  const claims = readJson(paths.claims, []);
+  const existing = claims.find((claim) => claim.agent === agent && claim.issue === issue);
+  if (existing) {
+    existing.paths = [...new Set([...existing.paths, ...claimedPaths])];
+    existing.ts = new Date().toISOString();
+  } else {
+    claims.push({ agent, issue, paths: claimedPaths, ts: new Date().toISOString() });
+  }
+  writeJson(paths.claims, claims);
+  appendMessage(paths, { from: agent, type: "claim", issue, body: `Claimed: ${claimedPaths.join(", ")}` });
+  printConflicts(findConflicts(claims).filter((conflict) => conflict.agents.includes(agent)));
+}
+
+function cmdConflicts(mainRoot) {
+  const paths = ensureInit(mainRoot);
+  printConflicts(findConflicts(readJson(paths.claims, [])));
+}
+
+function cmdHandoff(mainRoot, flags) {
+  const paths = ensureInit(mainRoot);
+  const assignments = readJson(paths.assignments, {});
+  const assignment = requireIssue(assignments, flags.issue);
+  const diffStat = git(assignment.worktree, ["diff", "--stat", `${assignment.base}...HEAD`]).stdout.trim();
+  const summary = typeof flags.summary === "string" ? flags.summary : "Ready for cross-review.";
+  appendMessage(paths, {
+    from: assignment.agent,
+    type: "handoff",
+    issue: assignment.issue,
+    body: `${summary}\n\n${diffStat || "(no committed changes yet)"}`,
+    refs: [assignment.branch, assignment.worktree]
+  });
+  assignment.status = "handoff";
+  writeJson(paths.assignments, assignments);
+  console.log(`Handoff posted for ${assignment.issue} (${assignment.branch}).`);
+  const lastSession = assignment.sessions[assignment.sessions.length - 1];
+  if (lastSession) {
+    console.log(`Pick up yourself: cd ${assignment.worktree} && codex resume ${lastSession}`);
+  }
+}
+
+function cmdRun(mainRoot, flags) {
+  const paths = ensureInit(mainRoot);
+  const assignments = readJson(paths.assignments, {});
+  const assignment = requireIssue(assignments, flags.issue);
+  if (assignment.agent !== "codex") {
+    fail(`issue "${assignment.issue}" is assigned to claude; collab run only drives codex`);
+  }
+  if (typeof flags.prompt !== "string" || flags.prompt.trim() === "") {
+    fail("--prompt is required");
+  }
+  const resumeSession =
+    flags.resume === true
+      ? assignment.sessions[assignment.sessions.length - 1]
+      : typeof flags.resume === "string"
+        ? flags.resume
+        : null;
+  if (flags.resume === true && !resumeSession) {
+    fail(`issue "${assignment.issue}" has no recorded session to resume`);
+  }
+  let fullPrompt;
+  if (resumeSession) {
+    fullPrompt = flags.prompt;
+  } else {
+    const template = fs.readFileSync(PROTOCOL_TEMPLATE, "utf8");
+    const protocol = template
+      .replaceAll("{{ISSUE}}", assignment.issue)
+      .replaceAll("{{TITLE}}", assignment.title)
+      .replaceAll("{{REPO}}", path.basename(mainRoot))
+      .replaceAll("{{COLLAB_CLI}}", SCRIPT_PATH)
+      .replaceAll("{{COLLAB_DIR}}", paths.dir);
+    const titleLine = `[${path.basename(mainRoot)} · ${assignment.issue} · codex] ${assignment.title}`;
+    fullPrompt = `${titleLine}\n\n${protocol}\n\n${flags.prompt}`;
+  }
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const logFile = path.join(paths.logs, `${assignment.issue}-${stamp}.log`);
+  const finalFile = path.join(paths.logs, `${assignment.issue}-${stamp}-final.md`);
+  // A linked worktree's git metadata (index, refs, objects) lives under the main
+  // checkout's .git — commits from the worktree need it writable. `exec resume`
+  // has no -s/-C/--add-dir flags, so the same sandbox is expressed via -c
+  // overrides there; a resumed session keeps its original workdir.
+  const extraRoots = [paths.dir, path.join(mainRoot, ".git")];
+  const args = ["exec"];
+  if (resumeSession) {
+    args.push(
+      "resume",
+      resumeSession,
+      "-c",
+      'sandbox_mode="workspace-write"',
+      "-c",
+      `sandbox_workspace_write.writable_roots=${JSON.stringify(extraRoots)}`
+    );
+  } else {
+    args.push("-s", "workspace-write", "-C", assignment.worktree);
+    for (const root of extraRoots) {
+      args.push("--add-dir", root);
+    }
+  }
+  args.push("-o", finalFile);
+  if (typeof flags.effort === "string") {
+    args.push("-c", `model_reasoning_effort="${flags.effort}"`);
+  }
+  if (typeof flags.model === "string") {
+    args.push("-m", flags.model);
+  }
+  args.push(fullPrompt);
+  const logFd = fs.openSync(logFile, "w");
+  const result = spawnSync("codex", args, { stdio: ["ignore", logFd, logFd] });
+  fs.closeSync(logFd);
+  const log = fs.readFileSync(logFile, "utf8");
+  const sessionMatch = log.match(/session id: ([0-9a-f-]+)/);
+  if (sessionMatch && assignment.sessions[assignment.sessions.length - 1] !== sessionMatch[1]) {
+    assignment.sessions.push(sessionMatch[1]);
+    writeJson(paths.assignments, assignments);
+  }
+  if (result.status !== 0) {
+    fail(`codex exec failed (exit ${result.status}); see ${logFile}`);
+  }
+  const finalMessage = fs.existsSync(finalFile) ? fs.readFileSync(finalFile, "utf8").trim() : "(no final message)";
+  console.log(finalMessage);
+  console.log("");
+  console.log(`session: ${sessionMatch ? sessionMatch[1] : "unknown"} · log: ${logFile}`);
+  if (sessionMatch) {
+    console.log(`Pick up yourself: cd ${assignment.worktree} && codex resume ${sessionMatch[1]}`);
+  }
+}
+
+function cmdMerge(mainRoot, flags) {
+  const paths = ensureInit(mainRoot);
+  const assignments = readJson(paths.assignments, {});
+  const assignment = requireIssue(assignments, flags.issue);
+  const reviewer = assignment.agent === "codex" ? "claude" : "codex";
+  const reviews = readMessages(paths).filter(
+    (message) => message.type === "review" && message.issue === assignment.issue && message.from === reviewer
+  );
+  const latest = reviews[reviews.length - 1];
+  if (!latest || !/^approve/i.test(latest.body.trim())) {
+    fail(
+      `cannot merge "${assignment.issue}": latest review from ${reviewer} must start with "approve" (found: ${latest ? JSON.stringify(latest.body.slice(0, 60)) : "no review"})`
+    );
+  }
+  git(mainRoot, ["merge", "--no-ff", assignment.branch, "-m", `Merge ${assignment.branch}: ${assignment.title}`]);
+  git(mainRoot, ["worktree", "remove", "--force", assignment.worktree]);
+  git(mainRoot, ["branch", "-D", assignment.branch]);
+  assignment.status = "merged";
+  writeJson(paths.assignments, assignments);
+  console.log(`Merged ${assignment.branch} into ${assignment.base} and cleaned up the worktree.`);
+}
+
+function cmdStatus(mainRoot) {
+  const paths = ensureInit(mainRoot);
+  const assignments = readJson(paths.assignments, {});
+  const claims = readJson(paths.claims, []);
+  const messages = readMessages(paths);
+  console.log(`Issues (${Object.keys(assignments).length}):`);
+  for (const assignment of Object.values(assignments)) {
+    console.log(`  ${assignment.issue} · ${assignment.agent} · ${assignment.status} · ${assignment.branch}`);
+  }
+  console.log(`Claims (${claims.length}):`);
+  for (const claim of claims) {
+    console.log(`  ${claim.agent} (${claim.issue ?? "-"}): ${claim.paths.join(", ")}`);
+  }
+  printConflicts(findConflicts(claims));
+  console.log(`Messages: ${messages.length} total; last 5:`);
+  for (const message of messages.slice(-5)) {
+    console.log(`  ${message.ts} ${message.from} ${message.type} ${message.issue ?? "-"}: ${message.body.split("\n")[0].slice(0, 80)}`);
+  }
+}
+
+function printUsage() {
+  console.log(
+    [
+      "Usage: node collab.mjs <command> [flags]",
+      "  init",
+      "  assign  --agent <codex|claude> --issue <slug> [--title <text>]",
+      "  post    --from <agent> --type <assign|status|question|claim|handoff|review|rebuttal|decision> --body <text> [--issue <slug>] [--refs <csv>]",
+      "  inbox   --for <agent> [--peek]",
+      "  claim   --agent <agent> --issue <slug> --paths <csv>",
+      "  conflicts",
+      "  run     --issue <slug> --prompt <text> [--resume [session-id]] [--effort <level>] [--model <model>]",
+      "  handoff --issue <slug> [--summary <text>]",
+      "  merge   --issue <slug>",
+      "  status"
+    ].join("\n")
+  );
+}
+
+function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  const { flags } = parseFlags(rest);
+  if (!command || command === "help" || flags.help === true) {
+    printUsage();
+    return;
+  }
+  const mainRoot = resolveMainRoot(process.cwd());
+  switch (command) {
+    case "init":
+      cmdInit(mainRoot);
+      break;
+    case "assign":
+      cmdAssign(mainRoot, flags);
+      break;
+    case "post":
+      cmdPost(mainRoot, flags);
+      break;
+    case "inbox":
+      cmdInbox(mainRoot, flags);
+      break;
+    case "claim":
+      cmdClaim(mainRoot, flags);
+      break;
+    case "conflicts":
+      cmdConflicts(mainRoot);
+      break;
+    case "run":
+      cmdRun(mainRoot, flags);
+      break;
+    case "handoff":
+      cmdHandoff(mainRoot, flags);
+      break;
+    case "merge":
+      cmdMerge(mainRoot, flags);
+      break;
+    case "status":
+      cmdStatus(mainRoot);
+      break;
+    default:
+      printUsage();
+      fail(`unknown command "${command}"`);
+  }
+}
+
+main();

--- a/plugins/codex/scripts/exit-plan-second-opinion-hook.mjs
+++ b/plugins/codex/scripts/exit-plan-second-opinion-hook.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// PostToolUse(ExitPlanMode) hook — decoupled second-opinion trigger (fork addition).
+// The built-in advisor never fires on Fable 5 mains (Fable-as-advisor is server-gated),
+// so plan approval is the moment that gets an independent GPT review: feed the approved
+// plan to codex-advisor.mjs and return its opinion as additionalContext. Non-fatal
+// everywhere — a broken or slow codex must never block the plan flow (always exit 0).
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ADVISOR = join(dirname(fileURLToPath(import.meta.url)), 'codex-advisor.mjs');
+const quit = () => process.exit(0);
+
+let input;
+try { input = JSON.parse(readFileSync(0, 'utf8') || '{}'); } catch { quit(); }
+const plan = input?.tool_input?.plan;
+if (!plan || typeof plan !== 'string' || !plan.trim()) quit();
+// A rejected plan means Claude keeps planning — don't spend a codex run on it.
+if (/reject|not approved|denied/i.test(JSON.stringify(input.tool_response ?? ''))) quit();
+
+const PLAN_DIR = join(homedir(), '.claude', 'cache', 'codex-advisor', 'plans');
+const planPath = join(PLAN_DIR, `${createHash('sha1').update(plan).digest('hex').slice(0, 16)}.md`);
+try { mkdirSync(PLAN_DIR, { recursive: true }); writeFileSync(planPath, plan); } catch { quit(); }
+
+const args = [ADVISOR, '--plan-file', planPath];
+if (input.transcript_path) args.push('--transcript', input.transcript_path);
+const r = spawnSync('node', args, {
+  cwd: input.cwd || process.cwd(),
+  encoding: 'utf8',
+  timeout: 450_000,
+  env: { ...process.env, CLAUDE_CODE_SESSION_ID: input.session_id || process.env.CLAUDE_CODE_SESSION_ID || '' },
+  maxBuffer: 16 * 1024 * 1024,
+});
+const out = (r.stdout || '').trim();
+// Dedup/skip paths ("[codex-advisor] … skipping.") add nothing — stay silent.
+if (!out || out.includes('skipping.')) quit();
+process.stdout.write(JSON.stringify({
+  hookSpecificOutput: {
+    hookEventName: 'PostToolUse',
+    additionalContext: `Codex (GPT) second opinion on the approved plan — weigh it before executing:\n\n${out}`,
+  },
+}));
+quit();

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -243,6 +243,17 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
 
     if (this.proc && !this.proc.killed) {
       this.proc.stdin.end();
+      // A SIGTERM-resistant app server must not keep this process alive.
+      const forceKillTimer = setTimeout(() => {
+        if (this.proc && this.proc.exitCode === null) {
+          try {
+            this.proc.kill("SIGKILL");
+          } catch {
+            // Already gone.
+          }
+        }
+      }, 5000);
+      forceKillTimer.unref?.();
       setTimeout(() => {
         if (this.proc && !this.proc.killed && this.proc.exitCode === null) {
           // On Windows with shell: true, the direct child is cmd.exe.
@@ -348,6 +359,9 @@ export class CodexAppServerClient {
     const client = brokerEndpoint
       ? new BrokerCodexAppServerClient(cwd, { ...options, brokerEndpoint })
       : new SpawnedCodexAppServerClient(cwd, options);
+    // Hand the client over before initializing: a caller enforcing a deadline
+    // must be able to close it even if initialization never returns.
+    options.onClient?.(client);
     await client.initialize();
     return client;
   }

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -43,6 +43,7 @@ import { readJsonFile } from "./fs.mjs";
 import { BROKER_BUSY_RPC_CODE, BROKER_ENDPOINT_ENV, CodexAppServerClient } from "./app-server.mjs";
 import { loadBrokerSession } from "./broker-lifecycle.mjs";
 import { binaryAvailable } from "./process.mjs";
+import { acquireWorkloadLease } from "./scheduler.mjs";
 
 const SERVICE_NAME = "claude_code_codex_plugin";
 const TASK_THREAD_PREFIX = "Codex Companion Task";
@@ -50,6 +51,12 @@ const DEFAULT_CONTINUE_PROMPT =
   "Continue from the current thread state. Pick the next highest-value step and follow through until the task is resolved.";
 const EXTERNAL_AGENT_IMPORT_COMPLETED = "externalAgentConfig/import/completed";
 const EXTERNAL_AGENT_IMPORT_TIMEOUT_MS = 2 * 60 * 1000;
+const DEFAULT_INTERRUPT_GRACE_MS = 10000;
+
+export const DEFAULT_CONSULT_TIMEOUT_MS = 420000;
+export const DEFAULT_REVIEW_TIMEOUT_MS = 900000;
+export const DEFAULT_TASK_TIMEOUT_MS = 1800000;
+export const TIMED_OUT_EXIT_CODE = 124;
 
 function cleanCodexStderr(stderr) {
   return stderr
@@ -610,7 +617,26 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
   }
 }
 
-async function withAppServer(cwd, fn) {
+const BROKER_BUSY_RETRY_DELAY_MS = 2000;
+const BROKER_BUSY_MAX_RETRIES = 5;
+
+/**
+ * A busy broker means another Codex workload owns it. Starting a second direct
+ * app-server would defeat the global one-workload-at-a-time policy, so busy is
+ * retried against the same broker; only a stale or unreachable broker falls back.
+ */
+export function shouldRetryWithDirectAppServer(error, { transport = null, brokerRequested = false } = {}) {
+  if (transport === "broker" && error?.rpcCode === BROKER_BUSY_RPC_CODE) {
+    return false;
+  }
+  return Boolean(brokerRequested) && (error?.code === "ENOENT" || error?.code === "ECONNREFUSED");
+}
+
+function isBrokerBusyError(error, transport) {
+  return transport === "broker" && error?.rpcCode === BROKER_BUSY_RPC_CODE;
+}
+
+async function withAppServer(cwd, fn, attempt = 0) {
   let client = null;
   try {
     client = await CodexAppServerClient.connect(cwd);
@@ -618,17 +644,23 @@ async function withAppServer(cwd, fn) {
     await client.close();
     return result;
   } catch (error) {
-    const brokerRequested = client?.transport === "broker" || Boolean(process.env[BROKER_ENDPOINT_ENV]);
-    const shouldRetryDirect =
-      (client?.transport === "broker" && error?.rpcCode === BROKER_BUSY_RPC_CODE) ||
-      (brokerRequested && (error?.code === "ENOENT" || error?.code === "ECONNREFUSED"));
+    const transport = client?.transport ?? null;
+    const brokerRequested = transport === "broker" || Boolean(process.env[BROKER_ENDPOINT_ENV]);
 
     if (client) {
       await client.close().catch(() => {});
       client = null;
     }
 
-    if (!shouldRetryDirect) {
+    if (isBrokerBusyError(error, transport)) {
+      if (attempt >= BROKER_BUSY_MAX_RETRIES) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, BROKER_BUSY_RETRY_DELAY_MS));
+      return withAppServer(cwd, fn, attempt + 1);
+    }
+
+    if (!shouldRetryWithDirectAppServer(error, { transport, brokerRequested })) {
       throw error;
     }
 
@@ -639,6 +671,71 @@ async function withAppServer(cwd, fn) {
       await directClient.close();
     }
   }
+}
+
+async function withWorkloadLease(lease, fn) {
+  if (!lease) {
+    return fn({ queueWaitMs: 0 });
+  }
+
+  const acquired = await acquireWorkloadLease(lease);
+  try {
+    return await fn({ queueWaitMs: acquired.queueWaitMs });
+  } finally {
+    acquired.release();
+  }
+}
+
+/**
+ * Run a turn under an execution deadline. On expiry the turn is interrupted
+ * (never silently dropped), partial output is preserved, and the caller learns
+ * the run timed out.
+ */
+async function captureTurnWithDeadline(client, threadId, startRequest, options = {}) {
+  const timeoutMs = Number(options.timeoutMs) > 0 ? Number(options.timeoutMs) : 0;
+  let observedTurnId = null;
+  const captureOptions = {
+    ...options,
+    onResponse(response, state) {
+      observedTurnId = response?.turn?.id ?? observedTurnId;
+      options.onResponse?.(response, state);
+    }
+  };
+
+  const turnPromise = captureTurn(client, threadId, startRequest, captureOptions);
+  if (!timeoutMs) {
+    return { turnState: await turnPromise, timedOut: false };
+  }
+
+  let timer = null;
+  const expiry = new Promise((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), timeoutMs);
+  });
+
+  try {
+    const settled = await Promise.race([turnPromise.then((turnState) => ({ turnState })), expiry]);
+    if (settled !== "timeout") {
+      return { turnState: settled.turnState, timedOut: false };
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+
+  emitProgress(options.onProgress, `Execution deadline of ${timeoutMs}ms expired; interrupting the Codex turn.`, "timed-out");
+  if (observedTurnId) {
+    await client.request("turn/interrupt", { threadId, turnId: observedTurnId }).catch(() => {});
+  }
+
+  const graceMs = Number(options.interruptGraceMs) > 0 ? Number(options.interruptGraceMs) : DEFAULT_INTERRUPT_GRACE_MS;
+  const partial = await Promise.race([
+    turnPromise.catch(() => null),
+    new Promise((resolve) => {
+      const graceTimer = setTimeout(() => resolve(null), graceMs);
+      graceTimer.unref?.();
+    })
+  ]);
+
+  return { turnState: partial, timedOut: true, turnId: observedTurnId };
 }
 
 async function withDirectAppServer(cwd, fn) {
@@ -1005,7 +1102,7 @@ export async function runAppServerReview(cwd, options = {}) {
     throw new Error("Codex CLI is not installed or is missing required runtime support. Install it with `npm install -g @openai/codex`, then rerun `/codex:setup`.");
   }
 
-  return withAppServer(cwd, async (client) => {
+  return withWorkloadLease(options.lease, ({ queueWaitMs }) => withAppServer(cwd, async (client) => {
     emitProgress(options.onProgress, "Starting Codex review thread.", "starting");
     const thread = await startThread(client, cwd, {
       model: options.model,
@@ -1019,7 +1116,7 @@ export async function runAppServerReview(cwd, options = {}) {
     });
     const delivery = options.delivery ?? "inline";
 
-    const turnState = await captureTurn(
+    const { turnState, timedOut, turnId } = await captureTurnWithDeadline(
       client,
       sourceThreadId,
       () =>
@@ -1029,6 +1126,8 @@ export async function runAppServerReview(cwd, options = {}) {
           target: options.target
         }),
       {
+        timeoutMs: options.timeoutMs,
+        interruptGraceMs: options.interruptGraceMs,
         onProgress: options.onProgress,
         onResponse(response, state) {
           if (response.reviewThreadId) {
@@ -1042,17 +1141,19 @@ export async function runAppServerReview(cwd, options = {}) {
     );
 
     return {
-      status: buildResultStatus(turnState),
-      threadId: turnState.threadId,
+      status: timedOut ? TIMED_OUT_EXIT_CODE : buildResultStatus(turnState),
+      timedOut,
+      queueWaitMs,
+      threadId: turnState?.threadId ?? sourceThreadId,
       sourceThreadId,
-      turnId: turnState.turnId,
-      reviewText: turnState.reviewText,
-      reasoningSummary: turnState.reasoningSummary,
-      turn: turnState.finalTurn,
-      error: turnState.error,
+      turnId: turnState?.turnId ?? turnId ?? null,
+      reviewText: turnState?.reviewText ?? "",
+      reasoningSummary: turnState?.reasoningSummary ?? [],
+      turn: turnState?.finalTurn ?? null,
+      error: turnState?.error ?? null,
       stderr: cleanCodexStderr(client.stderr)
     };
-  });
+  }));
 }
 
 export async function importExternalAgentSession(cwd, options = {}) {
@@ -1098,7 +1199,7 @@ export async function runAppServerTurn(cwd, options = {}) {
     throw new Error("Codex CLI is not installed or is missing required runtime support. Install it with `npm install -g @openai/codex`, then rerun `/codex:setup`.");
   }
 
-  return withAppServer(cwd, async (client) => {
+  return withWorkloadLease(options.lease, ({ queueWaitMs }) => withAppServer(cwd, async (client) => {
     let threadId;
 
     if (options.resumeThreadId) {
@@ -1129,7 +1230,7 @@ export async function runAppServerTurn(cwd, options = {}) {
       throw new Error("A prompt is required for this Codex run.");
     }
 
-    const turnState = await captureTurn(
+    const { turnState, timedOut, turnId } = await captureTurnWithDeadline(
       client,
       threadId,
       () =>
@@ -1140,23 +1241,29 @@ export async function runAppServerTurn(cwd, options = {}) {
           effort: options.effort ?? null,
           outputSchema: options.outputSchema ?? null
         }),
-      { onProgress: options.onProgress }
+      {
+        timeoutMs: options.timeoutMs,
+        interruptGraceMs: options.interruptGraceMs,
+        onProgress: options.onProgress
+      }
     );
 
     return {
-      status: buildResultStatus(turnState),
+      status: timedOut ? TIMED_OUT_EXIT_CODE : buildResultStatus(turnState),
+      timedOut,
+      queueWaitMs,
       threadId,
-      turnId: turnState.turnId,
-      finalMessage: turnState.lastAgentMessage,
-      reasoningSummary: turnState.reasoningSummary,
-      turn: turnState.finalTurn,
-      error: turnState.error,
+      turnId: turnState?.turnId ?? turnId ?? null,
+      finalMessage: turnState?.lastAgentMessage ?? "",
+      reasoningSummary: turnState?.reasoningSummary ?? [],
+      turn: turnState?.finalTurn ?? null,
+      error: turnState?.error ?? null,
       stderr: cleanCodexStderr(client.stderr),
-      fileChanges: turnState.fileChanges,
-      touchedFiles: collectTouchedFiles(turnState.fileChanges),
-      commandExecutions: turnState.commandExecutions
+      fileChanges: turnState?.fileChanges ?? [],
+      touchedFiles: collectTouchedFiles(turnState?.fileChanges ?? []),
+      commandExecutions: turnState?.commandExecutions ?? []
     };
-  });
+  }));
 }
 
 export async function findLatestTaskThread(cwd) {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -636,10 +636,22 @@ function isBrokerBusyError(error, transport) {
   return transport === "broker" && error?.rpcCode === BROKER_BUSY_RPC_CODE;
 }
 
-async function withAppServer(cwd, fn, attempt = 0) {
+async function withAppServer(cwd, fn, attempt = 0, holder = null) {
   let client = null;
   try {
-    client = await CodexAppServerClient.connect(cwd);
+    // The holder is populated the moment the client exists, before connect
+    // finishes: a hang in broker startup or initialize must still be closable
+    // by whoever owns the deadline.
+    client = await CodexAppServerClient.connect(cwd, {
+      onClient: (pending) => {
+        if (holder) {
+          holder.client = pending;
+        }
+      }
+    });
+    if (holder) {
+      holder.client = client;
+    }
     const result = await fn(client);
     await client.close();
     return result;
@@ -657,14 +669,24 @@ async function withAppServer(cwd, fn, attempt = 0) {
         throw error;
       }
       await new Promise((resolve) => setTimeout(resolve, BROKER_BUSY_RETRY_DELAY_MS));
-      return withAppServer(cwd, fn, attempt + 1);
+      return withAppServer(cwd, fn, attempt + 1, holder);
     }
 
     if (!shouldRetryWithDirectAppServer(error, { transport, brokerRequested })) {
       throw error;
     }
 
-    const directClient = await CodexAppServerClient.connect(cwd, { disableBroker: true });
+    const directClient = await CodexAppServerClient.connect(cwd, {
+      disableBroker: true,
+      onClient: (pending) => {
+        if (holder) {
+          holder.client = pending;
+        }
+      }
+    });
+    if (holder) {
+      holder.client = directClient;
+    }
     try {
       return await fn(directClient);
     } finally {
@@ -1185,7 +1207,6 @@ export async function runAppServerReview(cwd, options = {}) {
 
 function runAppServerReviewWorkload(cwd, options, queueWaitMs, deadlineAt, holder = {}) {
   return withAppServer(cwd, async (client) => {
-    holder.client = client;
     emitProgress(options.onProgress, "Starting Codex review thread.", "starting");
     const thread = await startThread(client, cwd, {
       model: options.model,
@@ -1237,7 +1258,7 @@ function runAppServerReviewWorkload(cwd, options, queueWaitMs, deadlineAt, holde
       error: turnState?.error ?? null,
       stderr: cleanCodexStderr(client.stderr)
     };
-  });
+  }, 0, holder);
 }
 
 export async function importExternalAgentSession(cwd, options = {}) {
@@ -1314,7 +1335,6 @@ export async function runAppServerTurn(cwd, options = {}) {
 
 function runAppServerTurnWorkload(cwd, options, queueWaitMs, deadlineAt, holder = {}) {
   return withAppServer(cwd, async (client) => {
-    holder.client = client;
     let threadId;
 
     if (options.resumeThreadId) {
@@ -1379,7 +1399,7 @@ function runAppServerTurnWorkload(cwd, options, queueWaitMs, deadlineAt, holder 
       touchedFiles: collectTouchedFiles(turnState?.fileChanges ?? []),
       commandExecutions: turnState?.commandExecutions ?? []
     };
-  });
+  }, 0, holder);
 }
 
 export async function findLatestTaskThread(cwd) {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -687,6 +687,60 @@ async function withWorkloadLease(lease, fn) {
 }
 
 /**
+ * A workload abandoned at its deadline must not leave its app server running:
+ * the client owns a child process whose open pipes would keep this process alive.
+ */
+function abandonAppServer(holder) {
+  const client = holder?.client;
+  if (!client) {
+    return;
+  }
+  holder.client = null;
+  Promise.resolve()
+    .then(() => client.close())
+    .catch(() => {});
+}
+
+function remainingMs(deadlineAt) {
+  if (!deadlineAt) {
+    return 0;
+  }
+  return Math.max(1, deadlineAt - Date.now());
+}
+
+/**
+ * The deadline covers the whole workload, not just the turn: connecting to the
+ * broker, initializing, and creating the thread can all hang while this process
+ * holds the single global lease.
+ */
+async function raceWorkloadDeadline(workloadPromise, deadlineAt, buildTimeoutResult, timeoutMs = 0) {
+  if (!deadlineAt) {
+    return workloadPromise;
+  }
+
+  let timer = null;
+  // The turn-level interrupt normally settles first; this backstop only fires
+  // when the setup phase itself hangs. Scale its tail to the deadline.
+  const graceMs = Math.min(DEFAULT_INTERRUPT_GRACE_MS, Math.max(1000, Math.round((timeoutMs || 0) / 2)));
+  const hardDeadline = deadlineAt + graceMs + 1000;
+  const expiry = new Promise((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), Math.max(1, hardDeadline - Date.now()));
+    timer.unref?.();
+  });
+
+  try {
+    const settled = await Promise.race([workloadPromise.then((value) => ({ value })), expiry]);
+    if (settled === "timeout") {
+      workloadPromise.catch(() => {});
+      return buildTimeoutResult();
+    }
+    return settled.value;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Run a turn under an execution deadline. On expiry the turn is interrupted
  * (never silently dropped), partial output is preserved, and the caller learns
  * the run timed out.
@@ -1102,7 +1156,36 @@ export async function runAppServerReview(cwd, options = {}) {
     throw new Error("Codex CLI is not installed or is missing required runtime support. Install it with `npm install -g @openai/codex`, then rerun `/codex:setup`.");
   }
 
-  return withWorkloadLease(options.lease, ({ queueWaitMs }) => withAppServer(cwd, async (client) => {
+  return withWorkloadLease(options.lease, ({ queueWaitMs }) => {
+    const deadlineAt = Number(options.timeoutMs) > 0 ? Date.now() + Number(options.timeoutMs) : 0;
+    const holder = {};
+    return raceWorkloadDeadline(
+      runAppServerReviewWorkload(cwd, options, queueWaitMs, deadlineAt, holder),
+      deadlineAt,
+      () => {
+        abandonAppServer(holder);
+        return {
+          status: TIMED_OUT_EXIT_CODE,
+          timedOut: true,
+          queueWaitMs,
+          threadId: null,
+          sourceThreadId: null,
+          turnId: null,
+          reviewText: "",
+          reasoningSummary: [],
+          turn: null,
+          error: null,
+          stderr: ""
+        };
+      },
+      Number(options.timeoutMs) || 0
+    );
+  });
+}
+
+function runAppServerReviewWorkload(cwd, options, queueWaitMs, deadlineAt, holder = {}) {
+  return withAppServer(cwd, async (client) => {
+    holder.client = client;
     emitProgress(options.onProgress, "Starting Codex review thread.", "starting");
     const thread = await startThread(client, cwd, {
       model: options.model,
@@ -1126,7 +1209,8 @@ export async function runAppServerReview(cwd, options = {}) {
           target: options.target
         }),
       {
-        timeoutMs: options.timeoutMs,
+        // Whatever the setup phase consumed is gone from the deadline.
+        timeoutMs: remainingMs(deadlineAt),
         interruptGraceMs: options.interruptGraceMs,
         onProgress: options.onProgress,
         onResponse(response, state) {
@@ -1153,7 +1237,7 @@ export async function runAppServerReview(cwd, options = {}) {
       error: turnState?.error ?? null,
       stderr: cleanCodexStderr(client.stderr)
     };
-  }));
+  });
 }
 
 export async function importExternalAgentSession(cwd, options = {}) {
@@ -1199,7 +1283,38 @@ export async function runAppServerTurn(cwd, options = {}) {
     throw new Error("Codex CLI is not installed or is missing required runtime support. Install it with `npm install -g @openai/codex`, then rerun `/codex:setup`.");
   }
 
-  return withWorkloadLease(options.lease, ({ queueWaitMs }) => withAppServer(cwd, async (client) => {
+  return withWorkloadLease(options.lease, ({ queueWaitMs }) => {
+    const deadlineAt = Number(options.timeoutMs) > 0 ? Date.now() + Number(options.timeoutMs) : 0;
+    const holder = {};
+    return raceWorkloadDeadline(
+      runAppServerTurnWorkload(cwd, options, queueWaitMs, deadlineAt, holder),
+      deadlineAt,
+      () => {
+        abandonAppServer(holder);
+        return {
+          status: TIMED_OUT_EXIT_CODE,
+          timedOut: true,
+          queueWaitMs,
+          threadId: null,
+          turnId: null,
+          finalMessage: "",
+          reasoningSummary: [],
+          turn: null,
+          error: null,
+          stderr: "",
+          fileChanges: [],
+          touchedFiles: [],
+          commandExecutions: []
+        };
+      },
+      Number(options.timeoutMs) || 0
+    );
+  });
+}
+
+function runAppServerTurnWorkload(cwd, options, queueWaitMs, deadlineAt, holder = {}) {
+  return withAppServer(cwd, async (client) => {
+    holder.client = client;
     let threadId;
 
     if (options.resumeThreadId) {
@@ -1242,7 +1357,8 @@ export async function runAppServerTurn(cwd, options = {}) {
           outputSchema: options.outputSchema ?? null
         }),
       {
-        timeoutMs: options.timeoutMs,
+        // Whatever the setup phase consumed is gone from the deadline.
+        timeoutMs: remainingMs(deadlineAt),
         interruptGraceMs: options.interruptGraceMs,
         onProgress: options.onProgress
       }
@@ -1263,7 +1379,7 @@ export async function runAppServerTurn(cwd, options = {}) {
       touchedFiles: collectTouchedFiles(turnState?.fileChanges ?? []),
       commandExecutions: turnState?.commandExecutions ?? []
     };
-  }));
+  });
 }
 
 export async function findLatestTaskThread(cwd) {

--- a/plugins/codex/scripts/lib/envelope.mjs
+++ b/plugins/codex/scripts/lib/envelope.mjs
@@ -6,13 +6,83 @@ export const MAX_ENVELOPE_STDOUT_BYTES = 32768;
 const SEVERITIES = ["critical", "high", "medium", "low"];
 const VALID_STATUSES = new Set(["queued", "running", "completed", "failed", "timed-out", "cancelled"]);
 const VALID_VERDICTS = new Set(["approve", "needs-attention", "inconclusive", "not-applicable"]);
+const MAX_TITLE_LENGTH = 200;
+const MAX_FILE_LENGTH = 200;
+// Leave headroom below the stdout budget so the rendered form fits as well.
+const MAX_ENVELOPE_JSON_BYTES = 24576;
 
+/** Bounded by characters and by bytes: a character limit alone is not a size limit. */
 function boundedText(value, limit = MAX_SUMMARY_LENGTH) {
   const text = String(value ?? "").trim();
-  if (text.length <= limit) {
+  if (text.length <= limit && Buffer.byteLength(text, "utf8") <= limit) {
     return { text, truncated: false };
   }
-  return { text: `${text.slice(0, limit - 1)}…`, truncated: true };
+
+  let clipped = [...text].slice(0, limit).join("");
+  while (clipped && Buffer.byteLength(clipped, "utf8") > limit - 1) {
+    clipped = [...clipped].slice(0, Math.max(0, Math.floor([...clipped].length * 0.9) - 1)).join("");
+  }
+  return { text: `${clipped}…`, truncated: true };
+}
+
+/**
+ * Structured output is only structured if it carries the fields the contract
+ * promises. A bare `{"verdict":"approve"}` is malformed, not an approval.
+ */
+export function validateStructuredResult(data) {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return "Expected a top-level JSON object.";
+  }
+  if (typeof data.verdict !== "string" || !data.verdict.trim()) {
+    return "Missing string `verdict`.";
+  }
+  if (typeof data.summary !== "string" || !data.summary.trim()) {
+    return "Missing string `summary`.";
+  }
+  if (!Array.isArray(data.findings)) {
+    return "Missing array `findings`.";
+  }
+  if (!Array.isArray(data.next_steps)) {
+    return "Missing array `next_steps`.";
+  }
+
+  const invalidIndex = data.findings.findIndex(
+    (finding) =>
+      !finding ||
+      typeof finding !== "object" ||
+      Array.isArray(finding) ||
+      typeof finding.severity !== "string" ||
+      !finding.severity.trim() ||
+      typeof finding.title !== "string" ||
+      !finding.title.trim()
+  );
+  if (invalidIndex >= 0) {
+    return `Finding ${invalidIndex + 1} is missing a string \`severity\` or \`title\`.`;
+  }
+
+  return null;
+}
+
+/** Last line of defence: the envelope itself must fit the stdout budget. */
+function enforceEnvelopeBudget(envelope) {
+  const jsonBytes = () => Buffer.byteLength(JSON.stringify(envelope), "utf8");
+
+  while (envelope.findings_preview.length > 0 && jsonBytes() > MAX_ENVELOPE_JSON_BYTES) {
+    envelope.findings_preview.pop();
+    envelope.truncated = true;
+  }
+  if (jsonBytes() > MAX_ENVELOPE_JSON_BYTES) {
+    envelope.summary = boundedText(envelope.summary, 500).text;
+    envelope.truncated = true;
+  }
+  if (jsonBytes() > MAX_ENVELOPE_JSON_BYTES) {
+    envelope.summary = "";
+    envelope.parse_error = envelope.parse_error ? boundedText(envelope.parse_error, 200).text : envelope.parse_error;
+    envelope.error_message = envelope.error_message ? boundedText(envelope.error_message, 200).text : envelope.error_message;
+    envelope.truncated = true;
+  }
+
+  return envelope;
 }
 
 export function buildSeverityTally(findings) {
@@ -28,11 +98,19 @@ export function buildSeverityTally(findings) {
   return tally;
 }
 
+function normalizeSeverity(severity) {
+  const normalized = typeof severity === "string" ? severity.trim().toLowerCase() : "";
+  return SEVERITIES.includes(normalized) ? normalized : "low";
+}
+
 function buildFindingsPreview(findings) {
   return (Array.isArray(findings) ? findings : []).slice(0, MAX_FINDINGS_PREVIEW).map((finding, index) => ({
-    severity: typeof finding?.severity === "string" && finding.severity.trim() ? finding.severity.trim() : "low",
-    title: boundedText(finding?.title || `Finding ${index + 1}`, 200).text,
-    file: typeof finding?.file === "string" && finding.file.trim() ? finding.file.trim() : null,
+    severity: normalizeSeverity(finding?.severity),
+    title: boundedText(finding?.title || `Finding ${index + 1}`, MAX_TITLE_LENGTH).text,
+    file:
+      typeof finding?.file === "string" && finding.file.trim()
+        ? boundedText(finding.file, MAX_FILE_LENGTH).text
+        : null,
     line_start: Number.isInteger(finding?.line_start) ? finding.line_start : null
   }));
 }
@@ -54,11 +132,18 @@ function normalizeVerdict(verdict) {
 export function buildResultEnvelope(input = {}) {
   const status = normalizeStatus(input.status);
   const parsed = input.parsed && typeof input.parsed === "object" && !Array.isArray(input.parsed) ? input.parsed : null;
-  const parseError = input.parseError ?? null;
-  const findings = Array.isArray(parsed?.findings) ? parsed.findings : [];
-  const parsedVerdict = normalizeVerdict(parsed?.verdict);
+  // Shape is part of validity: a parsed object missing required fields is
+  // malformed output, and malformed output can never read as an approval.
+  const shapeError = parsed ? validateStructuredResult(parsed) : null;
+  const parseError = input.parseError ?? shapeError ?? null;
+  const findings = shapeError ? [] : Array.isArray(parsed?.findings) ? parsed.findings : [];
+  const parsedVerdict = shapeError ? null : normalizeVerdict(parsed?.verdict);
   const structured = Boolean(parsed) && !parseError;
   const cleanRun = status === "completed" && structured;
+  // Some workloads (the built-in reviewer) return prose by design: that is a
+  // missing verdict, not a failed one.
+  const unstructuredKind = Boolean(input.unstructuredKind) && !input.parseError;
+  const unstructuredVerdict = status === "completed" ? "not-applicable" : "inconclusive";
 
   const summarySource = parsed?.summary || input.summaryText || input.rawOutput || "";
   const summary = boundedText(summarySource);
@@ -69,7 +154,8 @@ export function buildResultEnvelope(input = {}) {
     kind: input.kind ?? null,
     status,
     // A clean verdict is only valid when the workload completed and parsed.
-    verdict: cleanRun ? parsedVerdict ?? "inconclusive" : "inconclusive",
+    verdict: cleanRun ? parsedVerdict ?? "inconclusive" : unstructuredKind ? unstructuredVerdict : "inconclusive",
+    structured,
     severity_tally: buildSeverityTally(findings),
     summary: summary.text,
     findings_preview: buildFindingsPreview(findings),
@@ -85,7 +171,7 @@ export function buildResultEnvelope(input = {}) {
   if (!cleanRun && parsedVerdict) {
     envelope.partial_verdict = parsedVerdict;
   }
-  if (parseError) {
+  if (parseError && !unstructuredKind) {
     envelope.parse_error = boundedText(parseError, 500).text;
   }
   if (Number.isFinite(input.exitCode)) {
@@ -95,7 +181,7 @@ export function buildResultEnvelope(input = {}) {
     envelope.error_message = boundedText(input.errorMessage, 500).text;
   }
 
-  return envelope;
+  return enforceEnvelopeBudget(envelope);
 }
 
 export function buildInconclusiveEnvelope(input = {}) {
@@ -113,7 +199,11 @@ export function renderResultEnvelope(envelope) {
     "",
     `Job: ${envelope.job_id ?? "unknown"}`,
     `Status: ${envelope.status}`,
-    `Verdict: ${envelope.verdict}`,
+    `Verdict: ${envelope.verdict}${
+      envelope.structured === false && envelope.verdict === "not-applicable"
+        ? " (this reviewer answers in prose; read the summary or the full result)"
+        : ""
+    }`,
     `Findings: ${envelope.finding_count} (critical ${tally.critical ?? 0}, high ${tally.high ?? 0}, medium ${tally.medium ?? 0}, low ${tally.low ?? 0})`
   ];
 

--- a/plugins/codex/scripts/lib/envelope.mjs
+++ b/plugins/codex/scripts/lib/envelope.mjs
@@ -46,26 +46,60 @@ export function validateStructuredResult(data) {
     return "Missing array `next_steps`.";
   }
 
-  const invalidIndex = data.findings.findIndex(
-    (finding) =>
-      !finding ||
-      typeof finding !== "object" ||
-      Array.isArray(finding) ||
-      typeof finding.severity !== "string" ||
-      !finding.severity.trim() ||
-      typeof finding.title !== "string" ||
-      !finding.title.trim()
-  );
-  if (invalidIndex >= 0) {
-    return `Finding ${invalidIndex + 1} is missing a string \`severity\` or \`title\`.`;
+  for (const [index, finding] of data.findings.entries()) {
+    const error = validateFinding(finding);
+    if (error) {
+      return `Finding ${index + 1} ${error}`;
+    }
   }
 
   return null;
 }
 
+/**
+ * The full finding shape from schemas/review-output.schema.json. A finding that
+ * names a severity and nothing else is not a finding this contract can report.
+ */
+function validateFinding(finding) {
+  if (!finding || typeof finding !== "object" || Array.isArray(finding)) {
+    return "is not an object.";
+  }
+  for (const field of ["severity", "title", "body", "file"]) {
+    if (typeof finding[field] !== "string" || !finding[field].trim()) {
+      return `is missing a non-empty string \`${field}\`.`;
+    }
+  }
+  if (!SEVERITIES.includes(finding.severity.trim().toLowerCase())) {
+    return `has severity "${finding.severity}", which is not one of ${SEVERITIES.join(", ")}.`;
+  }
+  for (const field of ["line_start", "line_end"]) {
+    if (!Number.isInteger(finding[field]) || finding[field] < 1) {
+      return `is missing a positive integer \`${field}\`.`;
+    }
+  }
+  if (finding.line_end < finding.line_start) {
+    return "has `line_end` before `line_start`.";
+  }
+  if (typeof finding.confidence !== "number" || !Number.isFinite(finding.confidence) || finding.confidence < 0 || finding.confidence > 1) {
+    return "is missing a `confidence` between 0 and 1.";
+  }
+  if (typeof finding.recommendation !== "string") {
+    return "is missing a string `recommendation`.";
+  }
+  return null;
+}
+
+/**
+ * Size is measured on the JSON that is actually printed — pretty-printed, the
+ * same form `outputResult` emits — never on a compact form nobody sees.
+ */
+export function emittedJsonBytes(value) {
+  return Buffer.byteLength(JSON.stringify(value, null, 2), "utf8");
+}
+
 /** Last line of defence: the envelope itself must fit the stdout budget. */
 function enforceEnvelopeBudget(envelope) {
-  const jsonBytes = () => Buffer.byteLength(JSON.stringify(envelope), "utf8");
+  const jsonBytes = () => emittedJsonBytes(envelope);
 
   while (envelope.findings_preview.length > 0 && jsonBytes() > MAX_ENVELOPE_JSON_BYTES) {
     envelope.findings_preview.pop();

--- a/plugins/codex/scripts/lib/envelope.mjs
+++ b/plugins/codex/scripts/lib/envelope.mjs
@@ -1,0 +1,166 @@
+export const ENVELOPE_SCHEMA_VERSION = 1;
+export const MAX_SUMMARY_LENGTH = 2000;
+export const MAX_FINDINGS_PREVIEW = 10;
+export const MAX_ENVELOPE_STDOUT_BYTES = 32768;
+
+const SEVERITIES = ["critical", "high", "medium", "low"];
+const VALID_STATUSES = new Set(["queued", "running", "completed", "failed", "timed-out", "cancelled"]);
+const VALID_VERDICTS = new Set(["approve", "needs-attention", "inconclusive", "not-applicable"]);
+
+function boundedText(value, limit = MAX_SUMMARY_LENGTH) {
+  const text = String(value ?? "").trim();
+  if (text.length <= limit) {
+    return { text, truncated: false };
+  }
+  return { text: `${text.slice(0, limit - 1)}…`, truncated: true };
+}
+
+export function buildSeverityTally(findings) {
+  const tally = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const finding of Array.isArray(findings) ? findings : []) {
+    const severity = typeof finding?.severity === "string" ? finding.severity.trim().toLowerCase() : "";
+    if (SEVERITIES.includes(severity)) {
+      tally[severity] += 1;
+    } else {
+      tally.low += 1;
+    }
+  }
+  return tally;
+}
+
+function buildFindingsPreview(findings) {
+  return (Array.isArray(findings) ? findings : []).slice(0, MAX_FINDINGS_PREVIEW).map((finding, index) => ({
+    severity: typeof finding?.severity === "string" && finding.severity.trim() ? finding.severity.trim() : "low",
+    title: boundedText(finding?.title || `Finding ${index + 1}`, 200).text,
+    file: typeof finding?.file === "string" && finding.file.trim() ? finding.file.trim() : null,
+    line_start: Number.isInteger(finding?.line_start) ? finding.line_start : null
+  }));
+}
+
+function normalizeStatus(status) {
+  const normalized = String(status ?? "").trim();
+  return VALID_STATUSES.has(normalized) ? normalized : "failed";
+}
+
+function normalizeVerdict(verdict) {
+  const normalized = String(verdict ?? "").trim().toLowerCase();
+  return VALID_VERDICTS.has(normalized) ? normalized : null;
+}
+
+/**
+ * Build the bounded result envelope every review and consult returns on stdout.
+ * The complete log and final answer stay on disk; nothing unbounded goes in here.
+ */
+export function buildResultEnvelope(input = {}) {
+  const status = normalizeStatus(input.status);
+  const parsed = input.parsed && typeof input.parsed === "object" && !Array.isArray(input.parsed) ? input.parsed : null;
+  const parseError = input.parseError ?? null;
+  const findings = Array.isArray(parsed?.findings) ? parsed.findings : [];
+  const parsedVerdict = normalizeVerdict(parsed?.verdict);
+  const structured = Boolean(parsed) && !parseError;
+  const cleanRun = status === "completed" && structured;
+
+  const summarySource = parsed?.summary || input.summaryText || input.rawOutput || "";
+  const summary = boundedText(summarySource);
+
+  const envelope = {
+    schema_version: ENVELOPE_SCHEMA_VERSION,
+    job_id: input.jobId ?? null,
+    kind: input.kind ?? null,
+    status,
+    // A clean verdict is only valid when the workload completed and parsed.
+    verdict: cleanRun ? parsedVerdict ?? "inconclusive" : "inconclusive",
+    severity_tally: buildSeverityTally(findings),
+    summary: summary.text,
+    findings_preview: buildFindingsPreview(findings),
+    finding_count: findings.length,
+    truncated: summary.truncated || findings.length > MAX_FINDINGS_PREVIEW,
+    duration_ms: Number.isFinite(input.durationMs) ? Math.round(input.durationMs) : null,
+    queue_wait_ms: Number.isFinite(input.queueWaitMs) ? Math.round(input.queueWaitMs) : null,
+    thread_id: input.threadId ?? null,
+    final_output_path: input.finalOutputPath ?? null,
+    log_path: input.logPath ?? null
+  };
+
+  if (!cleanRun && parsedVerdict) {
+    envelope.partial_verdict = parsedVerdict;
+  }
+  if (parseError) {
+    envelope.parse_error = boundedText(parseError, 500).text;
+  }
+  if (Number.isFinite(input.exitCode)) {
+    envelope.exit_code = input.exitCode;
+  }
+  if (input.errorMessage) {
+    envelope.error_message = boundedText(input.errorMessage, 500).text;
+  }
+
+  return envelope;
+}
+
+export function buildInconclusiveEnvelope(input = {}) {
+  return buildResultEnvelope({
+    ...input,
+    parsed: null,
+    parseError: input.parseError ?? input.errorMessage ?? "No usable Codex output was produced."
+  });
+}
+
+export function renderResultEnvelope(envelope) {
+  const tally = envelope.severity_tally ?? {};
+  const lines = [
+    `# Codex ${envelope.kind ?? "result"}`,
+    "",
+    `Job: ${envelope.job_id ?? "unknown"}`,
+    `Status: ${envelope.status}`,
+    `Verdict: ${envelope.verdict}`,
+    `Findings: ${envelope.finding_count} (critical ${tally.critical ?? 0}, high ${tally.high ?? 0}, medium ${tally.medium ?? 0}, low ${tally.low ?? 0})`
+  ];
+
+  if (envelope.partial_verdict) {
+    lines.push(`Partial verdict: ${envelope.partial_verdict} (not trusted; the run did not finish cleanly)`);
+  }
+  if (envelope.duration_ms != null) {
+    lines.push(`Duration: ${Math.round(envelope.duration_ms / 1000)}s`);
+  }
+  if (envelope.queue_wait_ms != null) {
+    lines.push(`Queue wait: ${Math.round(envelope.queue_wait_ms / 1000)}s`);
+  }
+
+  lines.push("", envelope.summary || "No summary was produced.");
+
+  if (envelope.findings_preview?.length) {
+    lines.push("", "Findings preview:");
+    for (const finding of envelope.findings_preview) {
+      const location = finding.file ? ` (${finding.file}${finding.line_start ? `:${finding.line_start}` : ""})` : "";
+      lines.push(`- [${finding.severity}] ${finding.title}${location}`);
+    }
+    if (envelope.finding_count > envelope.findings_preview.length) {
+      lines.push(`- ... ${envelope.finding_count - envelope.findings_preview.length} more in the full result.`);
+    }
+  }
+
+  if (envelope.parse_error) {
+    lines.push("", `Parse error: ${envelope.parse_error}`);
+  }
+  if (envelope.error_message) {
+    lines.push("", `Error: ${envelope.error_message}`);
+  }
+
+  lines.push("");
+  if (envelope.thread_id) {
+    lines.push(`Codex session ID: ${envelope.thread_id}`);
+    lines.push(`Resume in Codex: codex resume ${envelope.thread_id}`);
+  }
+  if (envelope.final_output_path) {
+    lines.push(`Full result: ${envelope.final_output_path}`);
+  }
+  if (envelope.log_path) {
+    lines.push(`Log: ${envelope.log_path}`);
+  }
+  if (envelope.job_id) {
+    lines.push(`Full text: /codex:result ${envelope.job_id} --full`);
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}

--- a/plugins/codex/scripts/lib/exec-launcher.mjs
+++ b/plugins/codex/scripts/lib/exec-launcher.mjs
@@ -1,0 +1,156 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+import { runCommand, terminateProcessTree } from "./process.mjs";
+import { acquireWorkloadLease } from "./scheduler.mjs";
+
+export const TIMED_OUT_EXIT_CODE = 124;
+const DEFAULT_EXEC_TIMEOUT_MS = 1800000;
+const DEFAULT_QUEUE_WAIT_MS = 900000;
+
+export function isInsideGitWorktree(cwd) {
+  const result = runCommand("git", ["-C", cwd, "rev-parse", "--is-inside-work-tree"]);
+  return result.status === 0 && result.stdout.trim() === "true";
+}
+
+/**
+ * Build the argument list for one `codex exec` run. `--skip-git-repo-check` is
+ * decided here so no caller has to remember when Codex needs it.
+ */
+export function buildCodexExecArgs(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const skipGitRepoCheck = options.skipGitRepoCheck ?? !isInsideGitWorktree(cwd);
+  const args = ["exec"];
+  if (skipGitRepoCheck) {
+    args.push("--skip-git-repo-check");
+  }
+  if (options.model) {
+    args.push("-m", options.model);
+  }
+  args.push("-s", options.sandbox ?? "read-only");
+  if (options.effort) {
+    args.push("-c", `model_reasoning_effort=${options.effort}`);
+  }
+  for (const extra of options.extraArgs ?? []) {
+    args.push(extra);
+  }
+  if (options.outputFile) {
+    args.push("-o", options.outputFile);
+  }
+  // The prompt arrives on a pipe this process owns and closes, so the child sees
+  // EOF immediately and never waits on an inherited terminal.
+  args.push("-");
+  return { args, skipGitRepoCheck };
+}
+
+/** Signals must never be normalized into a successful exit. */
+export function normalizeExitCode(code, signal) {
+  if (typeof code === "number") {
+    return code;
+  }
+  if (!signal) {
+    return 0;
+  }
+  const signalNumber = os.constants.signals[signal];
+  return Number.isInteger(signalNumber) ? 128 + signalNumber : 128;
+}
+
+export function describeExecOutcome(result) {
+  if (result.timedOut) {
+    return `Codex was interrupted after its ${result.timeoutMs}ms deadline expired.`;
+  }
+  if (result.signal) {
+    return `Codex was terminated by ${result.signal} (exit ${result.exitCode}).`;
+  }
+  if (result.exitCode !== 0) {
+    return `Codex exited with code ${result.exitCode}.`;
+  }
+  return "Codex completed.";
+}
+
+/**
+ * The single blessed way for plugin code to launch `codex exec`:
+ * prompt from a file, stdin never inherited, one global queue slot, an execution
+ * deadline, and separate final-answer and transcript files.
+ */
+export async function runHardenedCodexExec(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const timeoutMs = Number(options.timeoutMs) > 0 ? Number(options.timeoutMs) : DEFAULT_EXEC_TIMEOUT_MS;
+  const promptFile = options.promptFile;
+  if (!promptFile || !fs.existsSync(promptFile)) {
+    throw new Error(`A readable --prompt-file is required; ${promptFile ?? "none"} was not found.`);
+  }
+  const prompt = fs.readFileSync(promptFile, "utf8");
+  const logFile = options.logFile ?? path.join(path.dirname(promptFile), "run.log");
+  const outputFile = options.outputFile ?? path.join(path.dirname(promptFile), "final.md");
+  const { args, skipGitRepoCheck } = buildCodexExecArgs({ ...options, cwd, outputFile });
+
+  const lease = await acquireWorkloadLease({
+    jobId: options.jobId ?? `exec-${process.pid}`,
+    kind: options.kind ?? "codex-exec",
+    workspace: cwd,
+    schedulerDir: options.schedulerDir,
+    env: options.env,
+    timeoutMs,
+    waitTimeoutMs: Number(options.queueWaitMs) > 0 ? Number(options.queueWaitMs) : DEFAULT_QUEUE_WAIT_MS,
+    noWait: Boolean(options.noWait)
+  });
+
+  const startedAt = Date.now();
+  const logFd = fs.openSync(logFile, "a");
+  try {
+    const outcome = await new Promise((resolve, reject) => {
+      const child = spawn(options.command ?? "codex", args, {
+        cwd,
+        env: options.env ?? process.env,
+        stdio: ["pipe", logFd, logFd],
+        // Own process group: the deadline can terminate the whole Codex tree, and
+        // a signal aimed at the parent shell does not take the run down with it.
+        detached: process.platform !== "win32",
+        windowsHide: true
+      });
+
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        terminateProcessTree(child.pid ?? Number.NaN);
+      }, timeoutMs);
+
+      child.on("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      child.on("close", (code, signal) => {
+        clearTimeout(timer);
+        resolve({
+          exitCode: timedOut ? TIMED_OUT_EXIT_CODE : normalizeExitCode(code, signal),
+          signal: signal ?? null,
+          timedOut
+        });
+      });
+
+      child.stdin.on("error", () => {});
+      child.stdin.end(prompt);
+    });
+
+    const finalOutput = fs.existsSync(outputFile) ? fs.readFileSync(outputFile, "utf8").trim() : "";
+    return {
+      ...outcome,
+      timeoutMs,
+      cwd,
+      skipGitRepoCheck,
+      promptFile,
+      outputFile,
+      logFile,
+      finalOutput,
+      durationMs: Date.now() - startedAt,
+      queueWaitMs: lease.queueWaitMs
+    };
+  } finally {
+    fs.closeSync(logFd);
+    lease.release();
+  }
+}

--- a/plugins/codex/scripts/lib/exec-launcher.mjs
+++ b/plugins/codex/scripts/lib/exec-launcher.mjs
@@ -10,6 +10,22 @@ import { acquireWorkloadLease } from "./scheduler.mjs";
 export const TIMED_OUT_EXIT_CODE = 124;
 const DEFAULT_EXEC_TIMEOUT_MS = 1800000;
 const DEFAULT_QUEUE_WAIT_MS = 900000;
+const DEFAULT_KILL_GRACE_MS = 10000;
+
+function forceKill(child) {
+  if (!child.pid) {
+    return;
+  }
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch {
+    try {
+      child.kill("SIGKILL");
+    } catch {
+      // Already gone.
+    }
+  }
+}
 
 export function isInsideGitWorktree(cwd) {
   const result = runCommand("git", ["-C", cwd, "rev-parse", "--is-inside-work-tree"]);
@@ -71,22 +87,64 @@ export function describeExecOutcome(result) {
   return "Codex completed.";
 }
 
+function spawnCodexExec({ command, args, cwd, env, logFd, timeoutMs, killGraceMs, stdinText }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command ?? "codex", args, {
+      cwd,
+      env: env ?? process.env,
+      stdio: ["pipe", logFd, logFd],
+      // Own process group: the deadline can terminate the whole Codex tree, and
+      // a signal aimed at the parent shell does not take the run down with it.
+      detached: process.platform !== "win32",
+      windowsHide: true
+    });
+
+    let timedOut = false;
+    let killTimer = null;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      terminateProcessTree(child.pid ?? Number.NaN);
+      // A SIGTERM-resistant child must not outlive its deadline.
+      killTimer = setTimeout(() => {
+        forceKill(child);
+      }, killGraceMs);
+      killTimer.unref?.();
+    }, timeoutMs);
+
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      clearTimeout(killTimer);
+      reject(error);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      clearTimeout(killTimer);
+      resolve({
+        exitCode: timedOut ? TIMED_OUT_EXIT_CODE : normalizeExitCode(code, signal),
+        signal: signal ?? null,
+        timedOut
+      });
+    });
+
+    // stdin is a pipe this process owns and closes immediately.
+    child.stdin.on("error", () => {});
+    child.stdin.end(stdinText ?? "");
+  });
+}
+
 /**
- * The single blessed way for plugin code to launch `codex exec`:
- * prompt from a file, stdin never inherited, one global queue slot, an execution
- * deadline, and separate final-answer and transcript files.
+ * Run a prepared `codex exec` argument list under the global queue and a
+ * deadline. Callers that need their own argument shape (collab's resume form,
+ * for example) use this; everything else uses runHardenedCodexExec.
  */
-export async function runHardenedCodexExec(options = {}) {
+export async function runQueuedCodexExec(options = {}) {
   const cwd = options.cwd ?? process.cwd();
   const timeoutMs = Number(options.timeoutMs) > 0 ? Number(options.timeoutMs) : DEFAULT_EXEC_TIMEOUT_MS;
-  const promptFile = options.promptFile;
-  if (!promptFile || !fs.existsSync(promptFile)) {
-    throw new Error(`A readable --prompt-file is required; ${promptFile ?? "none"} was not found.`);
+  const killGraceMs = Number(options.killGraceMs) > 0 ? Number(options.killGraceMs) : DEFAULT_KILL_GRACE_MS;
+  const logFile = options.logFile;
+  if (!logFile) {
+    throw new Error("runQueuedCodexExec requires a logFile for the transcript.");
   }
-  const prompt = fs.readFileSync(promptFile, "utf8");
-  const logFile = options.logFile ?? path.join(path.dirname(promptFile), "run.log");
-  const outputFile = options.outputFile ?? path.join(path.dirname(promptFile), "final.md");
-  const { args, skipGitRepoCheck } = buildCodexExecArgs({ ...options, cwd, outputFile });
 
   const lease = await acquireWorkloadLease({
     jobId: options.jobId ?? `exec-${process.pid}`,
@@ -100,52 +158,23 @@ export async function runHardenedCodexExec(options = {}) {
   });
 
   const startedAt = Date.now();
-  const logFd = fs.openSync(logFile, "a");
+  const logFd = fs.openSync(logFile, options.appendLog === false ? "w" : "a");
   try {
-    const outcome = await new Promise((resolve, reject) => {
-      const child = spawn(options.command ?? "codex", args, {
-        cwd,
-        env: options.env ?? process.env,
-        stdio: ["pipe", logFd, logFd],
-        // Own process group: the deadline can terminate the whole Codex tree, and
-        // a signal aimed at the parent shell does not take the run down with it.
-        detached: process.platform !== "win32",
-        windowsHide: true
-      });
-
-      let timedOut = false;
-      const timer = setTimeout(() => {
-        timedOut = true;
-        terminateProcessTree(child.pid ?? Number.NaN);
-      }, timeoutMs);
-
-      child.on("error", (error) => {
-        clearTimeout(timer);
-        reject(error);
-      });
-      child.on("close", (code, signal) => {
-        clearTimeout(timer);
-        resolve({
-          exitCode: timedOut ? TIMED_OUT_EXIT_CODE : normalizeExitCode(code, signal),
-          signal: signal ?? null,
-          timedOut
-        });
-      });
-
-      child.stdin.on("error", () => {});
-      child.stdin.end(prompt);
+    const outcome = await spawnCodexExec({
+      command: options.command,
+      args: options.args ?? [],
+      cwd,
+      env: options.env,
+      logFd,
+      timeoutMs,
+      killGraceMs,
+      stdinText: options.stdinText
     });
-
-    const finalOutput = fs.existsSync(outputFile) ? fs.readFileSync(outputFile, "utf8").trim() : "";
     return {
       ...outcome,
       timeoutMs,
       cwd,
-      skipGitRepoCheck,
-      promptFile,
-      outputFile,
       logFile,
-      finalOutput,
       durationMs: Date.now() - startedAt,
       queueWaitMs: lease.queueWaitMs
     };
@@ -153,4 +182,38 @@ export async function runHardenedCodexExec(options = {}) {
     fs.closeSync(logFd);
     lease.release();
   }
+}
+
+/**
+ * The single blessed way for plugin code to launch `codex exec`:
+ * prompt from a file, stdin never inherited, one global queue slot, an execution
+ * deadline, and separate final-answer and transcript files.
+ */
+export async function runHardenedCodexExec(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const promptFile = options.promptFile;
+  if (!promptFile || !fs.existsSync(promptFile)) {
+    throw new Error(`A readable --prompt-file is required; ${promptFile ?? "none"} was not found.`);
+  }
+  const prompt = fs.readFileSync(promptFile, "utf8");
+  const logFile = options.logFile ?? path.join(path.dirname(promptFile), "run.log");
+  const outputFile = options.outputFile ?? path.join(path.dirname(promptFile), "final.md");
+  const { args, skipGitRepoCheck } = buildCodexExecArgs({ ...options, cwd, outputFile });
+
+  const outcome = await runQueuedCodexExec({
+    ...options,
+    cwd,
+    args,
+    logFile,
+    stdinText: prompt
+  });
+
+  const finalOutput = fs.existsSync(outputFile) ? fs.readFileSync(outputFile, "utf8").trim() : "";
+  return {
+    ...outcome,
+    skipGitRepoCheck,
+    promptFile,
+    outputFile,
+    finalOutput
+  };
 }

--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -170,7 +170,7 @@ export function enrichJob(job, options = {}) {
         : [],
     elapsed: formatElapsedDuration(job.startedAt ?? job.createdAt, job.completedAt ?? null),
     duration:
-      job.status === "completed" || job.status === "failed" || job.status === "cancelled"
+      job.status !== "queued" && job.status !== "running"
         ? formatElapsedDuration(job.startedAt ?? job.createdAt, job.completedAt ?? job.updatedAt)
         : null
   };
@@ -262,7 +262,8 @@ export function resolveResultJob(cwd, reference) {
   const selected = matchJobReference(
     jobs,
     reference,
-    (job) => job.status === "completed" || job.status === "failed" || job.status === "cancelled"
+    // A timed-out job is finished too: its partial result must stay reachable.
+    (job) => job.status !== "queued" && job.status !== "running"
   );
 
   if (selected) {

--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 
 import { getSessionRuntimeStatus } from "./codex.mjs";
+import { getQueuePosition, readSchedulerSnapshot } from "./scheduler.mjs";
 import { getConfig, listJobs, readJobFile, resolveJobFile } from "./state.mjs";
 import { SESSION_ID_ENV } from "./tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./workspace.mjs";
@@ -176,6 +177,7 @@ export function enrichJob(job, options = {}) {
 
   return {
     ...enriched,
+    queuePosition: job.status === "queued" || job.status === "running" ? getQueuePosition(job.id) : null,
     phase: enriched.phase ?? inferLegacyJobPhase(enriched, enriched.progressPreview)
   };
 }
@@ -232,6 +234,7 @@ export function buildStatusSnapshot(cwd, options = {}) {
     workspaceRoot,
     config,
     sessionRuntime: getSessionRuntimeStatus(options.env, workspaceRoot),
+    scheduler: readSchedulerSnapshot({ env: options.env }),
     running,
     latestFinished,
     recent,

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -416,15 +416,40 @@ export function renderJobStatusReport(job) {
   return `${lines.join("\n").trimEnd()}\n`;
 }
 
+/**
+ * A run that timed out, failed, or was cancelled must never read as a clean
+ * result, so its output is prefixed with what actually happened.
+ */
+function unfinishedRunBanner(job, storedJob) {
+  const status = job?.status ?? storedJob?.status ?? null;
+  if (!status || status === "completed") {
+    return "";
+  }
+
+  const exitCode = storedJob?.exitCode ?? null;
+  const lines = [`Status: ${status}${exitCode == null ? "" : ` (exit ${exitCode})`}`];
+  const errorMessage = job?.errorMessage ?? storedJob?.errorMessage ?? null;
+  if (errorMessage) {
+    lines.push(errorMessage);
+  }
+  const logFile = storedJob?.logFile ?? job?.logFile ?? null;
+  if (logFile) {
+    lines.push(`Log: ${logFile}`);
+  }
+  lines.push("Any output below is partial.", "");
+  return `${lines.join("\n")}\n`;
+}
+
 export function renderStoredJobResult(job, storedJob) {
   const threadId = storedJob?.threadId ?? job.threadId ?? null;
   const resumeCommand = threadId ? `codex resume ${threadId}` : null;
+  const banner = unfinishedRunBanner(job, storedJob);
   if (isStructuredReviewStoredResult(storedJob) && storedJob?.rendered) {
     const output = storedJob.rendered.endsWith("\n") ? storedJob.rendered : `${storedJob.rendered}\n`;
     if (!threadId) {
-      return output;
+      return `${banner}${output}`;
     }
-    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
+    return `${banner}${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
   }
 
   const rawOutput =
@@ -434,17 +459,17 @@ export function renderStoredJobResult(job, storedJob) {
   if (rawOutput) {
     const output = rawOutput.endsWith("\n") ? rawOutput : `${rawOutput}\n`;
     if (!threadId) {
-      return output;
+      return `${banner}${output}`;
     }
-    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
+    return `${banner}${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
   }
 
   if (storedJob?.rendered) {
     const output = storedJob.rendered.endsWith("\n") ? storedJob.rendered : `${storedJob.rendered}\n`;
     if (!threadId) {
-      return output;
+      return `${banner}${output}`;
     }
-    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
+    return `${banner}${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
   }
 
   const lines = [

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -121,6 +121,13 @@ function appendActiveJobsTable(lines, jobs) {
   }
 }
 
+function formatSeverityTally(tally) {
+  if (!tally || typeof tally !== "object") {
+    return null;
+  }
+  return `critical ${tally.critical ?? 0}, high ${tally.high ?? 0}, medium ${tally.medium ?? 0}, low ${tally.low ?? 0}`;
+}
+
 function pushJobDetails(lines, job, options = {}) {
   lines.push(`- ${formatJobLine(job)}`);
   if (job.summary) {
@@ -128,6 +135,19 @@ function pushJobDetails(lines, job, options = {}) {
   }
   if (job.phase) {
     lines.push(`  Phase: ${job.phase}`);
+  }
+  if (job.queuePosition) {
+    lines.push(`  Queue position: ${job.queuePosition}`);
+  }
+  if (job.verdict) {
+    lines.push(`  Verdict: ${job.verdict}`);
+  }
+  const tally = formatSeverityTally(job.severityTally);
+  if (tally) {
+    lines.push(`  Findings: ${tally}`);
+  }
+  if (job.finalOutputPath) {
+    lines.push(`  Result file: ${job.finalOutputPath}`);
   }
   if (options.showElapsed && job.elapsed) {
     lines.push(`  Elapsed: ${job.elapsed}`);
@@ -330,6 +350,15 @@ export function renderStatusReport(report) {
     `Review gate: ${report.config.stopReviewGate ? "enabled" : "disabled"}`,
     ""
   ];
+
+  if (report.scheduler?.active || report.scheduler?.queue?.length) {
+    lines.push(
+      `Codex queue: ${report.scheduler.active ? `${report.scheduler.active.jobId} running` : "idle"}, ${
+        report.scheduler.queue.length
+      } waiting`,
+      ""
+    );
+  }
 
   if (report.running.length > 0) {
     appendActiveJobsTable(lines, report.running);

--- a/plugins/codex/scripts/lib/scheduler.mjs
+++ b/plugins/codex/scripts/lib/scheduler.mjs
@@ -1,0 +1,393 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+export const SCHEDULER_DIR_ENV = "CODEX_COMPANION_SCHEDULER_DIR";
+export const DEFAULT_QUEUE_WAIT_MS = 1800000;
+
+const HEARTBEAT_INTERVAL_MS = 1000;
+const STALE_HEARTBEAT_MS = 5000;
+const STALE_LOCK_MS = 5000;
+const POLL_INTERVAL_MS = 100;
+const LOCK_RETRY_MS = 20;
+const LOCK_WAIT_MS = 10000;
+
+export class QueueWaitTimeoutError extends Error {
+  constructor(waitedMs, position) {
+    super(
+      `Codex is already running another workload. Gave up after waiting ${Math.round(waitedMs / 1000)}s in the global queue${
+        position ? ` (position ${position})` : ""
+      }.`
+    );
+    this.name = "QueueWaitTimeoutError";
+    this.waitedMs = waitedMs;
+    this.position = position;
+  }
+}
+
+export class QueueCancelledError extends Error {
+  constructor(jobId) {
+    super(`Codex workload ${jobId} was cancelled while it waited in the global queue.`);
+    this.name = "QueueCancelledError";
+    this.jobId = jobId;
+  }
+}
+
+export function resolveSchedulerDir(env = process.env) {
+  const override = env[SCHEDULER_DIR_ENV];
+  if (typeof override === "string" && override.trim()) {
+    return path.resolve(override.trim());
+  }
+  return path.join(os.homedir(), ".claude", "cache", "codex-companion", "scheduler");
+}
+
+function queueDir(root) {
+  return path.join(root, "queue");
+}
+
+function activeFile(root) {
+  return path.join(root, "active.json");
+}
+
+function lockFile(root) {
+  return path.join(root, "scheduler.lock");
+}
+
+function sequenceFile(root) {
+  return path.join(root, "sequence");
+}
+
+function ensureSchedulerDirs(root) {
+  fs.mkdirSync(queueDir(root), { recursive: true });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function writeJsonAtomic(filePath, value) {
+  const tempPath = `${filePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  fs.renameSync(tempPath, filePath);
+}
+
+function readJsonOrNull(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function removeIfExists(filePath) {
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    // Already gone.
+  }
+}
+
+export function isProcessAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+async function withSchedulerLock(root, fn) {
+  const lockPath = lockFile(root);
+  const deadline = Date.now() + LOCK_WAIT_MS;
+
+  for (;;) {
+    try {
+      const handle = fs.openSync(lockPath, "wx");
+      fs.writeSync(handle, `${process.pid}\n`);
+      fs.closeSync(handle);
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") {
+        throw error;
+      }
+      let stale = false;
+      try {
+        stale = Date.now() - fs.statSync(lockPath).mtimeMs > STALE_LOCK_MS;
+      } catch {
+        stale = false;
+      }
+      if (stale) {
+        removeIfExists(lockPath);
+        continue;
+      }
+      if (Date.now() > deadline) {
+        // The lock holder is wedged; break in rather than blocking Codex forever.
+        removeIfExists(lockPath);
+        continue;
+      }
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    removeIfExists(lockPath);
+  }
+}
+
+function nextSequence(root) {
+  const current = Number.parseInt(String(readTextOrEmpty(sequenceFile(root))).trim(), 10);
+  const next = Number.isFinite(current) ? current + 1 : 1;
+  fs.writeFileSync(sequenceFile(root), `${next}\n`, "utf8");
+  return next;
+}
+
+function readTextOrEmpty(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function recordFileName(record) {
+  return `${String(record.seq).padStart(12, "0")}-${record.jobId}.json`;
+}
+
+function listQueueRecords(root) {
+  let entries = [];
+  try {
+    entries = fs.readdirSync(queueDir(root));
+  } catch {
+    return [];
+  }
+
+  return entries
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => {
+      const filePath = path.join(queueDir(root), entry);
+      const record = readJsonOrNull(filePath);
+      return record ? { ...record, file: filePath } : null;
+    })
+    .filter(Boolean)
+    .sort((left, right) => Number(left.seq) - Number(right.seq));
+}
+
+function readActiveRecord(root) {
+  return readJsonOrNull(activeFile(root));
+}
+
+function isActiveRecordLive(active) {
+  if (!active) {
+    return false;
+  }
+  const heartbeatAt = Date.parse(active.heartbeatAt ?? "");
+  const heartbeatStale = !Number.isFinite(heartbeatAt) || Date.now() - heartbeatAt > STALE_HEARTBEAT_MS;
+  // A lease may only be reclaimed when the heartbeat is stale AND the owner is gone.
+  return !(heartbeatStale && !isProcessAlive(active.pid));
+}
+
+function pruneDeadRecords(root) {
+  const active = readActiveRecord(root);
+  if (active && !isActiveRecordLive(active)) {
+    removeIfExists(activeFile(root));
+  }
+
+  for (const record of listQueueRecords(root)) {
+    if (record.jobId === readActiveRecord(root)?.jobId) {
+      continue;
+    }
+    if (!isProcessAlive(record.pid)) {
+      removeIfExists(record.file);
+    }
+  }
+}
+
+function startHeartbeat(root, record) {
+  const timer = setInterval(() => {
+    const active = readActiveRecord(root);
+    if (!active || active.jobId !== record.jobId) {
+      return;
+    }
+    try {
+      writeJsonAtomic(activeFile(root), { ...active, heartbeatAt: new Date().toISOString() });
+    } catch {
+      // Heartbeat is best effort.
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+  timer.unref?.();
+  return timer;
+}
+
+/**
+ * Join the user-global FIFO queue and wait for the single Codex workload lease.
+ * The execution deadline of the caller must only start once this resolves.
+ */
+export async function acquireWorkloadLease(options = {}) {
+  const root = options.schedulerDir ?? resolveSchedulerDir(options.env ?? process.env);
+  const jobId = options.jobId ?? `anon-${process.pid}`;
+  const waitTimeoutMs = Math.max(0, Number(options.waitTimeoutMs) || DEFAULT_QUEUE_WAIT_MS);
+  const pollIntervalMs = Math.max(10, Number(options.pollIntervalMs) || POLL_INTERVAL_MS);
+  const enqueuedAt = Date.now();
+
+  ensureSchedulerDirs(root);
+
+  const record = await withSchedulerLock(root, async () => {
+    const next = {
+      jobId,
+      seq: nextSequence(root),
+      pid: options.pid ?? process.pid,
+      kind: options.kind ?? "codex",
+      workspace: options.workspace ?? null,
+      timeoutMs: options.timeoutMs ?? null,
+      createdAt: new Date().toISOString(),
+      heartbeatAt: new Date().toISOString()
+    };
+    const file = path.join(queueDir(root), recordFileName(next));
+    writeJsonAtomic(file, next);
+    return { ...next, file };
+  });
+
+  const deadline = enqueuedAt + waitTimeoutMs;
+
+  for (;;) {
+    const outcome = await withSchedulerLock(root, async () => {
+      pruneDeadRecords(root);
+      if (!fs.existsSync(record.file)) {
+        return { acquired: false, cancelled: true };
+      }
+      const active = readActiveRecord(root);
+      if (active && active.jobId !== jobId && isActiveRecordLive(active)) {
+        return { acquired: false, active };
+      }
+
+      const waiting = listQueueRecords(root);
+      const head = waiting[0] ?? null;
+      if (!head || head.jobId !== jobId) {
+        return { acquired: false, active: null };
+      }
+
+      writeJsonAtomic(activeFile(root), {
+        ...record,
+        leaseAcquiredAt: new Date().toISOString(),
+        heartbeatAt: new Date().toISOString()
+      });
+      return { acquired: true };
+    });
+
+    if (outcome.acquired) {
+      const queueWaitMs = Date.now() - enqueuedAt;
+      const heartbeat = startHeartbeat(root, record);
+      return {
+        jobId,
+        seq: record.seq,
+        schedulerDir: root,
+        queueWaitMs,
+        acquiredAt: new Date().toISOString(),
+        release: () => {
+          clearInterval(heartbeat);
+          releaseWorkloadLease({ jobId, schedulerDir: root, file: record.file });
+        }
+      };
+    }
+
+    if (outcome.cancelled) {
+      throw new QueueCancelledError(jobId);
+    }
+
+    if (options.noWait) {
+      releaseWorkloadLease({ jobId, schedulerDir: root, file: record.file });
+      throw new QueueWaitTimeoutError(Date.now() - enqueuedAt, getQueuePosition(jobId, { schedulerDir: root }));
+    }
+
+    if (Date.now() >= deadline) {
+      const position = getQueuePosition(jobId, { schedulerDir: root });
+      releaseWorkloadLease({ jobId, schedulerDir: root, file: record.file });
+      throw new QueueWaitTimeoutError(Date.now() - enqueuedAt, position);
+    }
+
+    await sleep(pollIntervalMs);
+  }
+}
+
+export function releaseWorkloadLease(lease) {
+  if (!lease) {
+    return;
+  }
+  const root = lease.schedulerDir ?? resolveSchedulerDir();
+  const active = readActiveRecord(root);
+  if (active && active.jobId === lease.jobId) {
+    removeIfExists(activeFile(root));
+  }
+  if (lease.file) {
+    removeIfExists(lease.file);
+    return;
+  }
+  for (const record of listQueueRecords(root)) {
+    if (record.jobId === lease.jobId) {
+      removeIfExists(record.file);
+    }
+  }
+}
+
+/**
+ * Remove a queued job from the global queue. Never touches the active lease:
+ * cancelling the active workload is the caller's job (interrupt, then terminate).
+ */
+export function cancelQueuedWorkload(jobId, options = {}) {
+  const root = options.schedulerDir ?? resolveSchedulerDir(options.env ?? process.env);
+  const active = readActiveRecord(root);
+  if (active && active.jobId === jobId) {
+    return { removed: false, wasActive: true };
+  }
+
+  let removed = false;
+  for (const record of listQueueRecords(root)) {
+    if (record.jobId === jobId) {
+      removeIfExists(record.file);
+      removed = true;
+    }
+  }
+  return { removed, wasActive: false };
+}
+
+export function readSchedulerSnapshot(options = {}) {
+  const root = options.schedulerDir ?? resolveSchedulerDir(options.env ?? process.env);
+  const activeRaw = readActiveRecord(root);
+  const active = activeRaw && isActiveRecordLive(activeRaw) ? activeRaw : null;
+  const waiting = listQueueRecords(root).filter((record) => record.jobId !== active?.jobId);
+
+  return {
+    schedulerDir: root,
+    active: active
+      ? {
+          jobId: active.jobId,
+          kind: active.kind ?? null,
+          workspace: active.workspace ?? null,
+          pid: active.pid ?? null,
+          leaseAcquiredAt: active.leaseAcquiredAt ?? null
+        }
+      : null,
+    queue: waiting.map((record, index) => ({
+      jobId: record.jobId,
+      kind: record.kind ?? null,
+      workspace: record.workspace ?? null,
+      seq: record.seq,
+      position: index + 1,
+      createdAt: record.createdAt ?? null
+    }))
+  };
+}
+
+export function getQueuePosition(jobId, options = {}) {
+  const snapshot = readSchedulerSnapshot(options);
+  if (snapshot.active?.jobId === jobId) {
+    return 0;
+  }
+  return snapshot.queue.find((entry) => entry.jobId === jobId)?.position ?? null;
+}

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -109,6 +109,7 @@ export function saveState(cwd, state) {
     }
     removeJobFile(resolveJobFile(cwd, job.id));
     removeFileIfExists(job.logFile);
+    removeFileIfExists(job.finalOutputPath);
   }
 
   fs.writeFileSync(resolveStateFile(cwd), `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
@@ -183,6 +184,11 @@ function removeJobFile(jobFile) {
 export function resolveJobLogFile(cwd, jobId) {
   ensureStateDir(cwd);
   return path.join(resolveJobsDir(cwd), `${jobId}.log`);
+}
+
+export function resolveJobFinalOutputFile(cwd, jobId) {
+  ensureStateDir(cwd);
+  return path.join(resolveJobsDir(cwd), `${jobId}.final.md`);
 }
 
 export function resolveJobFile(cwd, jobId) {

--- a/plugins/codex/scripts/lib/tracked-jobs.mjs
+++ b/plugins/codex/scripts/lib/tracked-jobs.mjs
@@ -41,11 +41,19 @@ export function appendLogLine(logFile, message) {
   fs.appendFileSync(logFile, `[${nowIso()}] ${normalized}\n`, "utf8");
 }
 
-export function appendLogBlock(logFile, title, body) {
+export const MAX_LOGGED_BLOCK_BYTES = 8192;
+
+export function appendLogBlock(logFile, title, body, options = {}) {
   if (!logFile || !body) {
     return;
   }
-  fs.appendFileSync(logFile, `\n[${nowIso()}] ${title}\n${String(body).trimEnd()}\n`, "utf8");
+  const text = String(body).trimEnd();
+  const maxBytes = Number.isFinite(options.maxBytes) ? options.maxBytes : 0;
+  const bounded =
+    maxBytes > 0 && Buffer.byteLength(text, "utf8") > maxBytes
+      ? `${text.slice(0, maxBytes)}\n[truncated; the complete output is stored with the job]`
+      : text;
+  fs.appendFileSync(logFile, `\n[${nowIso()}] ${title}\n${bounded}\n`, "utf8");
 }
 
 export function createJobLogFile(workspaceRoot, jobId, title) {
@@ -153,7 +161,8 @@ export async function runTrackedJob(job, runner, options = {}) {
 
   try {
     const execution = await runner();
-    const completionStatus = execution.exitStatus === 0 ? "completed" : "failed";
+    const completionStatus = execution.jobStatus ?? (execution.exitStatus === 0 ? "completed" : "failed");
+    const phase = completionStatus === "completed" ? "done" : completionStatus;
     const completedAt = nowIso();
     writeJobFile(job.workspaceRoot, job.id, {
       ...runningRecord,
@@ -161,8 +170,12 @@ export async function runTrackedJob(job, runner, options = {}) {
       threadId: execution.threadId ?? null,
       turnId: execution.turnId ?? null,
       pid: null,
-      phase: completionStatus === "completed" ? "done" : "failed",
+      phase,
       completedAt,
+      exitCode: execution.exitStatus ?? null,
+      envelope: execution.envelope ?? null,
+      finalOutputPath: execution.finalOutputPath ?? null,
+      queueWaitMs: execution.queueWaitMs ?? null,
       result: execution.payload,
       rendered: execution.rendered
     });
@@ -172,11 +185,16 @@ export async function runTrackedJob(job, runner, options = {}) {
       threadId: execution.threadId ?? null,
       turnId: execution.turnId ?? null,
       summary: execution.summary,
-      phase: completionStatus === "completed" ? "done" : "failed",
+      phase,
       pid: null,
-      completedAt
+      completedAt,
+      verdict: execution.envelope?.verdict ?? null,
+      severityTally: execution.envelope?.severity_tally ?? null,
+      finalOutputPath: execution.finalOutputPath ?? null
     });
-    appendLogBlock(options.logFile ?? job.logFile ?? null, "Final output", execution.rendered);
+    appendLogBlock(options.logFile ?? job.logFile ?? null, "Final output", execution.rendered, {
+      maxBytes: MAX_LOGGED_BLOCK_BYTES
+    });
     return execution;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);

--- a/plugins/codex/scripts/lib/tracked-jobs.mjs
+++ b/plugins/codex/scripts/lib/tracked-jobs.mjs
@@ -134,7 +134,9 @@ export function createProgressReporter({ stderr = false, logFile = null, onEvent
       process.stderr.write(`[codex] ${stderrMessage}\n`);
     }
     appendLogLine(logFile, event.message);
-    appendLogBlock(logFile, event.logTitle, event.logBody);
+    // Progress blocks carry whole assistant and review messages: cap them too,
+    // or the log grows to the size of the transcript.
+    appendLogBlock(logFile, event.logTitle, event.logBody, { maxBytes: MAX_LOGGED_BLOCK_BYTES });
     onEvent?.(event);
   };
 }

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -13,7 +13,10 @@ import { sortJobsNewestFirst } from "./lib/job-control.mjs";
 import { SESSION_ID_ENV } from "./lib/tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
 
-const STOP_REVIEW_TIMEOUT_MS = 15 * 60 * 1000;
+// The companion enforces the real deadline; this outer guard only exists as a
+// backstop and stays a minute longer than the workload it wraps.
+const STOP_REVIEW_EXECUTION_TIMEOUT_MS = 14 * 60 * 1000;
+const STOP_REVIEW_TIMEOUT_MS = STOP_REVIEW_EXECUTION_TIMEOUT_MS + 60 * 1000;
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(SCRIPT_DIR, "..");
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
@@ -102,12 +105,16 @@ function runStopReview(cwd, input = {}) {
     ...process.env,
     ...(input.session_id ? { [SESSION_ID_ENV]: input.session_id } : {})
   };
-  const result = spawnSync(process.execPath, [scriptPath, "task", "--json", prompt], {
-    cwd,
-    env: childEnv,
-    encoding: "utf8",
-    timeout: STOP_REVIEW_TIMEOUT_MS
-  });
+  const result = spawnSync(
+    process.execPath,
+    [scriptPath, "task", "--json", "--timeout-ms", String(STOP_REVIEW_EXECUTION_TIMEOUT_MS), prompt],
+    {
+      cwd,
+      env: childEnv,
+      encoding: "utf8",
+      timeout: STOP_REVIEW_TIMEOUT_MS
+    }
+  );
 
   if (result.error?.code === "ETIMEDOUT") {
     return {

--- a/plugins/codex/skills/claude-fable-5-prompting/SKILL.md
+++ b/plugins/codex/skills/claude-fable-5-prompting/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: claude-fable-5-prompting
+description: Internal guidance for composing prompts and collaboration messages addressed to Claude Fable 5 (Claude 5 family)
+user-invocable: false
+---
+
+# Claude Fable 5 Prompting
+
+Use this when composing a prompt, review request, rebuttal, or protocol message whose reader is Claude Fable 5 — the counterpart to `gpt-5-6-prompting`. Based on Anthropic's official "Prompting Claude Fable 5" guidance.
+
+Core rules:
+
+- Brief, high-trust instructions beat enumerated lists. One short scope or brevity instruction reliably curbs unwanted behavior; prescriptive micromanagement written for older models degrades Fable 5 output.
+- Effort: `high` is the right default; reserve `xhigh` for the most capability-sensitive work. Over-provisioning effort causes overplanning and unrequested tidying, not better answers.
+- State authorization boundaries explicitly. Distinguish "assess and report" from "do the fix"; add "don't do X unless asked" for actions you don't want volunteered — Fable 5 will otherwise take reasonable-but-unrequested actions.
+- Give reasons, not just requests. One line of intent framing ("this feeds X, which needs Y") measurably improves how it connects the task to relevant context.
+- Require grounded progress claims: "audit each claim against a tool result from this session before reporting it" — this nearly eliminates fabricated status reports on long runs.
+- For ambiguous tasks add "when you have enough information to act, act" — stops overplanning.
+- Prefer async patterns: long-lived context, message-and-continue, check on results later. Do not design blocking waits into prompts.
+- Never ask it to transcribe or echo its reasoning into the response — that can trigger the `reasoning_extraction` refusal classifier. Ask for conclusions and evidence instead.
+- Ask for outcome-first final answers in complete sentences; permit terse shorthand only mid-work, never in the final summary.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -16,7 +16,7 @@ Execution rules:
 - Prefer the helper over hand-rolled `git`, direct Codex CLI strings, or any other Bash activity.
 - Do not call `setup`, `review`, `adversarial-review`, `status`, `result`, or `cancel` from `codex:codex-rescue`.
 - Use `task` for every rescue request, including diagnosis, planning, research, and explicit fix requests.
-- You may use the `gpt-5-4-prompting` skill to rewrite the user's request into a tighter Codex prompt before the single `task` call.
+- You may use the `gpt-5-6-prompting` skill to rewrite the user's request into a tighter Codex prompt before the single `task` call.
 - That prompt drafting is the only Claude-side work allowed. Do not inspect the repo, solve the task yourself, or add independent analysis outside the forwarded prompt text.
 - Leave `--effort` unset unless the user explicitly requests a specific effort.
 - Leave model unset by default. Add `--model` only when the user explicitly asks for one.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -20,13 +20,13 @@ Execution rules:
 - That prompt drafting is the only Claude-side work allowed. Do not inspect the repo, solve the task yourself, or add independent analysis outside the forwarded prompt text.
 - Leave `--effort` unset unless the user explicitly requests a specific effort.
 - Leave model unset by default. Add `--model` only when the user explicitly asks for one.
-- Map `spark` to `--model gpt-5.3-codex-spark`.
+- Map `spark` to `--model gpt-5.6-luna` (fast tier). `gpt-5.3-codex-spark` is rejected on ChatGPT-account auth (verified 2026-07-22); note the substitution when you reply.
 - Default to a write-capable Codex run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
 
 Command selection:
 - Use exactly one `task` invocation per rescue handoff.
 - If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only. Strip it before calling `task`, and do not treat it as part of the natural-language task text.
-- If the forwarded request includes `--model`, normalize `spark` to `gpt-5.3-codex-spark` and pass it through to `task`.
+- If the forwarded request includes `--model`, normalize `spark` to `gpt-5.6-luna` and pass it through to `task`.
 - If the forwarded request includes `--effort`, pass it through to `task`.
 - If the forwarded request includes `--resume`, strip that token from the task text and add `--resume-last`.
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -11,6 +11,15 @@ Use this skill only inside the `codex:codex-rescue` subagent.
 Primary helper:
 - `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task "<raw arguments>"`
 
+Runtime contract:
+- The companion owns queueing and deadlines. Every workload joins one user-global FIFO queue with a single Codex slot, and every run carries its own execution deadline (`--timeout-ms`, default 1800000 for `task`).
+- A foreground call must use an outer Bash timeout at least 60s longer than the companion's internal deadline, so the wrapper's own normalization is what reports a timeout.
+- Review and one-shot second-opinion work never uses raw `codex exec`. Use `review` / `adversarial-review`, or the stateless read-only entry point for a one-shot judgment:
+  `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" consult --prompt-file "<absolute-prompt-path>" --cwd "<absolute-project-path>" --model gpt-5.6-luna --effort high --timeout-ms 420000 --json < /dev/null`
+- `consult` takes its prompt only from an absolute `--prompt-file`, ignores inherited stdin, is read-only, works outside a Git repository, and returns a bounded envelope. A `verdict` of `inconclusive` means timeout, launch failure, or unparseable output — never an approval.
+- A failed companion call returns a normalized failure envelope, not nothing. Empty output would make an exit 143/144 indistinguishable from a routing failure.
+- All documented invocations use absolute paths and an explicit deadline.
+
 Execution rules:
 - The rescue subagent is a forwarder, not an orchestrator. Its only job is to invoke `task` once and return that stdout unchanged.
 - Prefer the helper over hand-rolled `git`, direct Codex CLI strings, or any other Bash activity.
@@ -40,4 +49,4 @@ Safety rules:
 - Preserve the user's task text as-is apart from stripping routing flags.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
 - Return the stdout of the `task` command exactly as-is.
-- If the Bash call fails or Codex cannot be invoked, return nothing.
+- If the Bash call fails or Codex cannot be invoked, return the failure envelope the companion printed, or — if there was no output at all — one line naming the command, its exit code, and that no Codex result was produced. Never return silence.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -32,7 +32,7 @@ Command selection:
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.
 - `--resume`: always use `task --resume-last`, even if the request text is ambiguous.
 - `--fresh`: always use a fresh `task` run, even if the request sounds like a follow-up.
-- `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`.
+- `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`. (GPT-5.6's native scale is none/low/medium/high/xhigh/max; the companion caps at `xhigh` and still accepts legacy `minimal`. If the user asks for `max`, use `xhigh` and note the cap.)
 - `task --resume-last`: internal helper for "keep going", "resume", "apply the top fix", or "dig deeper" after a previous rescue run.
 
 Safety rules:

--- a/plugins/codex/skills/codex-image-gen/SKILL.md
+++ b/plugins/codex/skills/codex-image-gen/SKILL.md
@@ -11,14 +11,20 @@ native image-generation tool, exposed headlessly through `codex exec`.
 ## Invocation contract
 
 ```
-cd <target-dir> && codex exec -m gpt-5.6-sol --sandbox workspace-write \
+codex exec -C <absolute-target-dir> -m gpt-5.6-sol --sandbox workspace-write \
   [--skip-git-repo-check] \
-  "<image brief>. Save as <name>.png in the current directory. Reply DONE when written."
+  "<image brief>. Save as <name>.png in the current directory. Reply DONE when written." \
+  < /dev/null
 ```
 
 - `--sandbox workspace-write` is REQUIRED. The default sandbox is read-only and
   cannot save into the workspace.
-- Run with cwd = the directory that should receive the files.
+- Use absolute paths for the target directory, every reference image, and every
+  brief file.
+- Always redirect stdin from `/dev/null`. An inherited open stdin makes Codex wait
+  for EOF that never comes.
+- Always give the Bash call an explicit timeout of about 1800000ms; image runs have
+  no internal deadline of their own.
 - `--skip-git-repo-check` when the cwd is not a git repo (scratchpads, temp dirs).
 - Mechanics: images land first in `~/.codex/generated_images/<uuid>/*.png`; the
   model then copies them into the cwd — so ALWAYS specify exact output filenames.

--- a/plugins/codex/skills/codex-image-gen/SKILL.md
+++ b/plugins/codex/skills/codex-image-gen/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: codex-image-gen
+description: Generate raster image assets (logo concepts, illustrations, icons, OG images, textures, placeholder art) via the Codex CLI's native image generation. Use whenever an image needs to be generated rather than authored as code — the user asks for a picture, artwork, logo exploration, or any visual asset that SVG/HTML rendering cannot produce. Requires codex-cli >= 0.144.
+---
+
+# Image generation via Codex CLI
+
+Verified 2026-07-21 (codex-cli 0.144.1, model gpt-5.6-sol): the Codex model has a
+native image-generation tool, exposed headlessly through `codex exec`.
+
+## Invocation contract
+
+```
+cd <target-dir> && codex exec -m gpt-5.6-sol --sandbox workspace-write \
+  [--skip-git-repo-check] \
+  "<image brief>. Save as <name>.png in the current directory. Reply DONE when written."
+```
+
+- `--sandbox workspace-write` is REQUIRED. The default sandbox is read-only and
+  cannot save into the workspace.
+- Run with cwd = the directory that should receive the files.
+- `--skip-git-repo-check` when the cwd is not a git repo (scratchpads, temp dirs).
+- Mechanics: images land first in `~/.codex/generated_images/<uuid>/*.png`; the
+  model then copies them into the cwd — so ALWAYS specify exact output filenames.
+- Reference images: include absolute paths in the prompt; the model can view them
+  (style references, existing screenshots, brand pages).
+- Cost: roughly 25-30k Codex tokens per simple image. Batch related concepts into
+  one run when possible.
+
+## Prompt checklist (keep briefs in a versioned file)
+
+- One concept per image; exact filename for each; canvas size (e.g. 1024x1024);
+  background (transparent, or explicit hex).
+- Full palette as hex values; style constraints stated (e.g. flat fills, no
+  gradients) — mandatory if the asset must be vectorized later.
+- Store the brief as a .md file in the repo (e.g. experimentation/brand/logo-prompt.md)
+  and have Codex read it by path. Rerunning the same file reproduces the run.
+
+## Mandatory verification loop
+
+1. Read every produced PNG and actually look at it — never report unseen output.
+2. Check: matches the brief, correct background, no diffusion speckle where it
+   matters, legible at the target display size.
+3. Iterate by editing the brief file and rerunning, not by ad-hoc prompt drift.
+
+## Caveats
+
+- Generated rasters carry diffusion artifacts (soft edges, background speckle).
+  NEVER ship them as final logos/icons: pick the winning concept, then hand-author
+  a clean SVG as code (Claude or Codex writes the vector; do not autotrace).
+- Apple-touch/iOS icons need solid backgrounds (iOS blackens transparency);
+  favicons must survive 16px.
+- If `codex` is missing, outdated (< 0.144), or unauthenticated: stop and report.
+  There is no local fallback image generator.

--- a/plugins/codex/skills/codex-image-gen/SKILL.md
+++ b/plugins/codex/skills/codex-image-gen/SKILL.md
@@ -10,22 +10,30 @@ native image-generation tool, exposed headlessly through `codex exec`.
 
 ## Invocation contract
 
+Go through the companion, never `codex exec` directly. It takes the single global
+Codex slot, closes stdin, and enforces the deadline:
+
 ```
-codex exec -C <absolute-target-dir> -m gpt-5.6-sol --sandbox workspace-write \
-  [--skip-git-repo-check] \
-  "<image brief>. Save as <name>.png in the current directory. Reply DONE when written." \
+node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" task --write \
+  --cwd <absolute-target-dir> \
+  --model gpt-5.6-sol \
+  --timeout-ms 1800000 \
+  --prompt-file <absolute-brief-path> \
   < /dev/null
 ```
 
-- `--sandbox workspace-write` is REQUIRED. The default sandbox is read-only and
-  cannot save into the workspace.
-- Use absolute paths for the target directory, every reference image, and every
+- `--write` is REQUIRED. A read-only run cannot save into the workspace.
+- `--cwd` is the directory that should receive the files; it may be a scratch
+  directory outside any Git repository, and the companion handles that itself —
+  there is no `--skip-git-repo-check` for you to remember.
+- Use absolute paths for the target directory, every reference image, and the
   brief file.
 - Always redirect stdin from `/dev/null`. An inherited open stdin makes Codex wait
   for EOF that never comes.
-- Always give the Bash call an explicit timeout of about 1800000ms; image runs have
-  no internal deadline of their own.
-- `--skip-git-repo-check` when the cwd is not a git repo (scratchpads, temp dirs).
+- Keep the outer Bash timeout at least 60s above `--timeout-ms`; the companion's
+  own deadline is what should fire first.
+- A direct `codex exec` launch bypasses the queue and can run a second Codex
+  workload alongside a companion job. Do not do it.
 - Mechanics: images land first in `~/.codex/generated_images/<uuid>/*.png`; the
   model then copies them into the cwd — so ALWAYS specify exact output filenames.
 - Reference images: include absolute paths in the prompt; the model can view them

--- a/plugins/codex/skills/gpt-5-6-prompting/SKILL.md
+++ b/plugins/codex/skills/gpt-5-6-prompting/SKILL.md
@@ -12,17 +12,19 @@ Model selection (GPT-5.6 family, requires codex-cli >= 0.144):
 - `gpt-5.6-sol` — flagship. Default for all delegated coding, review, diagnosis, and research tasks.
 - `gpt-5.6-terra` — mid tier. Use when latency matters more than depth on routine tasks.
 - `gpt-5.6-luna` — fast tier. Mechanical transforms, quick lookups, high-volume small calls.
-- Reasoning effort: `-c model_reasoning_effort="high"` by default; `xhigh` for the hardest diagnosis or adversarial-review runs; `minimal`/`low`/`medium` for mechanical work. Effort is a config flag, not part of the model name.
+- Reasoning effort: GPT-5.6's native scale is `none`/`low`/`medium`/`high`/`xhigh`/`max` (`minimal` was dropped, `max` added). Default `high` via `-c model_reasoning_effort="high"`; try one level lower than your old baseline before raising. The companion's `--effort` flag caps at `xhigh` and still accepts legacy `minimal`; `max` requires a direct `-c model_reasoning_effort` config.
 - Prefer tightening the prompt contract before raising model tier or effort.
 
-Prompt Codex like an operator, not a collaborator. Keep prompts compact and block-structured with XML tags. State the task, the output contract, the follow-through defaults, and the small set of extra constraints that matter.
+Prompt Codex like an operator, not a collaborator. Keep prompts lean: OpenAI measured ~10-15% better evals and 41-66% fewer tokens from leaner system prompts. State each instruction exactly once — GPT-5.6 tries to reconcile repeated or conflicting rules and burns reasoning tokens doing it. Use XML-tagged blocks only where they add a real contract.
 
 Core rules:
+- Start every prompt with one plain-text title line (≤50 chars, e.g. `Fix flaky auth test retry logic`) before any XML block. The companion names the persistent Codex thread from the prompt's first characters, and that name is what appears in the `codex resume` picker and the Codex desktop app — a leading `<task>` tag turns every thread name into identical noise.
 - Prefer one clear task per Codex run. Split unrelated asks into separate runs.
 - Tell Codex what done looks like. Do not assume it will infer the desired end state.
+- State what the run is authorized to do. Review, diagnosis, explanation, and planning requests mean inspect and report — say no changes are authorized. Write-capable runs get the inverse: name the authorized change scope.
 - Add explicit grounding and verification rules for any task where unsupported guesses would hurt quality.
+- GPT-5.6 is more concise by default than earlier 5.x models. Do not add blanket brevity orders; constrain length only where a specific output shape requires it.
 - Prefer better prompt contracts over raising reasoning or adding long natural-language explanations.
-- Use XML tags consistently so the prompt has stable internal structure.
 
 Default prompt recipe:
 - `<task>`: the concrete job and the relevant repository or failure context.
@@ -31,11 +33,12 @@ Default prompt recipe:
 - `<verification_loop>` or `<completeness_contract>`: required for debugging, implementation, or risky fixes.
 - `<grounding_rules>` or `<citation_rules>`: required for review, research, or anything that could drift into unsupported claims.
 
-When to add blocks:
-- Coding or debugging: add `completeness_contract`, `verification_loop`, and `missing_context_gating`.
-- Review or adversarial review: add `grounding_rules`, `structured_output_contract`, and `dig_deeper_nudge`.
+When to add blocks — pick at most one block per concern; overlapping blocks (`completeness_contract` vs `verification_loop`, a brevity line repeated across contracts) cost tokens and can conflict:
+- Coding or debugging: add `verification_loop`; add `missing_context_gating` only when guessing is a real risk.
+- Review or adversarial review: add `grounding_rules` and `structured_output_contract`; add `dig_deeper_nudge` only for adversarial passes.
 - Research or recommendation tasks: add `research_mode` and `citation_rules`.
 - Write-capable tasks: add `action_safety` so Codex stays narrow and avoids unrelated refactors.
+- Every run: state the authorization boundary — inline in `<task>` or via the `authorization_boundary` block.
 
 How to choose prompt shape:
 - Use built-in `review` or `adversarial-review` commands when the job is reviewing local git changes. Those prompts already carry the review contract.

--- a/plugins/codex/skills/gpt-5-6-prompting/SKILL.md
+++ b/plugins/codex/skills/gpt-5-6-prompting/SKILL.md
@@ -1,12 +1,19 @@
 ---
-name: gpt-5-4-prompting
-description: Internal guidance for composing Codex and GPT-5.4 prompts for coding, review, diagnosis, and research tasks inside the Codex Claude Code plugin
+name: gpt-5-6-prompting
+description: Internal guidance for composing Codex and GPT-5.6 prompts for coding, review, diagnosis, and research tasks inside the Codex Claude Code plugin
 user-invocable: false
 ---
 
-# GPT-5.4 Prompting
+# GPT-5.6 Prompting
 
-Use this skill when `codex:codex-rescue` needs to ask Codex or another GPT-5.4-based workflow for help.
+Use this skill when `codex:codex-rescue` needs to ask Codex or another GPT-5.6-based workflow for help.
+
+Model selection (GPT-5.6 family, requires codex-cli >= 0.144):
+- `gpt-5.6-sol` — flagship. Default for all delegated coding, review, diagnosis, and research tasks.
+- `gpt-5.6-terra` — mid tier. Use when latency matters more than depth on routine tasks.
+- `gpt-5.6-luna` — fast tier. Mechanical transforms, quick lookups, high-volume small calls.
+- Reasoning effort: `-c model_reasoning_effort="high"` by default; `xhigh` for the hardest diagnosis or adversarial-review runs; `minimal`/`low`/`medium` for mechanical work. Effort is a config flag, not part of the model name.
+- Prefer tightening the prompt contract before raising model tier or effort.
 
 Prompt Codex like an operator, not a collaborator. Keep prompts compact and block-structured with XML tags. State the task, the output contract, the follow-through defaults, and the small set of extra constraints that matter.
 

--- a/plugins/codex/skills/gpt-5-6-prompting/references/codex-prompt-antipatterns.md
+++ b/plugins/codex/skills/gpt-5-6-prompting/references/codex-prompt-antipatterns.md
@@ -1,6 +1,6 @@
 # Codex Prompt Anti-Patterns
 
-Avoid these when prompting Codex or GPT-5.4.
+Avoid these when prompting Codex or GPT-5.6.
 
 ## Vague task framing
 

--- a/plugins/codex/skills/gpt-5-6-prompting/references/codex-prompt-antipatterns.md
+++ b/plugins/codex/skills/gpt-5-6-prompting/references/codex-prompt-antipatterns.md
@@ -82,6 +82,30 @@ Better:
 - Run a separate fix prompt if needed.
 - Use a third run for docs or roadmap work.
 
+## Repeating the same rule across blocks
+
+Bad:
+
+```text
+<completeness_contract>Verify before finishing.</completeness_contract>
+<verification_loop>Verify before finalizing.</verification_loop>
+<task>... and verify everything at the end.</task>
+```
+
+Better:
+- State the rule once, in the one block that owns it. GPT-5.6 tries to reconcile repeated or conflicting instructions and spends reasoning tokens doing it.
+
+## Blanket brevity orders
+
+Bad:
+
+```text
+Be concise. Keep it short. No fluff.
+```
+
+Better:
+- GPT-5.6 is more concise by default than earlier 5.x models; blanket brevity orders under-deliver detail. Specify the output shape you want, or leave length alone.
+
 ## Unsupported certainty
 
 Bad:

--- a/plugins/codex/skills/gpt-5-6-prompting/references/codex-prompt-recipes.md
+++ b/plugins/codex/skills/gpt-5-6-prompting/references/codex-prompt-recipes.md
@@ -1,6 +1,6 @@
 # Codex Prompt Recipes
 
-Use these as starting templates for Codex task prompts or other Codex/GPT-5.4 prompt construction.
+Use these as starting templates for Codex task prompts or other Codex/GPT-5.6 prompt construction.
 Copy the smallest recipe that fits the task, then trim anything you do not need.
 In `codex:codex-rescue`, run diagnosis and fix-oriented recipes in write mode by default unless the user explicitly asked for read-only behavior.
 
@@ -128,7 +128,7 @@ Prefer primary sources.
 
 ```xml
 <task>
-Diagnose why this existing prompt is underperforming and propose the smallest high-leverage changes to improve it for Codex or GPT-5.4.
+Diagnose why this existing prompt is underperforming and propose the smallest high-leverage changes to improve it for Codex or GPT-5.6.
 </task>
 
 <structured_output_contract>

--- a/plugins/codex/skills/gpt-5-6-prompting/references/codex-prompt-recipes.md
+++ b/plugins/codex/skills/gpt-5-6-prompting/references/codex-prompt-recipes.md
@@ -2,6 +2,7 @@
 
 Use these as starting templates for Codex task prompts or other Codex/GPT-5.6 prompt construction.
 Copy the smallest recipe that fits the task, then trim anything you do not need.
+Always put a one-line plain-text task title above the first XML block — it becomes the persistent thread's name in `codex resume` and the Codex desktop app.
 In `codex:codex-rescue`, run diagnosis and fix-oriented recipes in write mode by default unless the user explicitly asked for read-only behavior.
 
 ## Diagnosis
@@ -20,13 +21,9 @@ Return a compact diagnosis with:
 </compact_output_contract>
 
 <default_follow_through_policy>
-Keep going until you have enough evidence to identify the root cause confidently.
+Keep going until you have enough evidence to identify the root cause confidently, and verify the proposed cause against the observed evidence before finalizing.
 Only stop to ask questions when a missing detail changes correctness materially.
 </default_follow_through_policy>
-
-<verification_loop>
-Before finalizing, verify that the proposed root cause matches the observed evidence.
-</verification_loop>
 
 <missing_context_gating>
 Do not guess missing repository facts.
@@ -52,12 +49,8 @@ Return:
 
 <default_follow_through_policy>
 Default to the most reasonable low-risk interpretation and keep going.
-</default_follow_through_policy>
-
-<completeness_contract>
-Resolve the task fully before stopping.
 Do not stop after identifying the issue without applying the fix.
-</completeness_contract>
+</default_follow_through_policy>
 
 <verification_loop>
 Before finalizing, verify that the fix matches the task requirements and that the changed code is coherent.
@@ -75,6 +68,7 @@ Avoid unrelated refactors or cleanup.
 <task>
 Analyze this change for the most likely correctness or regression issues.
 Focus on the provided repository context only.
+Report findings only. Do not modify files.
 </task>
 
 <structured_output_contract>
@@ -122,6 +116,20 @@ Prefer breadth first, then go deeper only where the evidence changes the recomme
 Back important claims with explicit references to the sources you inspected.
 Prefer primary sources.
 </citation_rules>
+```
+
+## Bounded Aggregation
+
+Use when the task is filtering, joining, ranking, or aggregating many tool or command outputs. Avoid it when intermediate outputs need fresh judgment or an approval checkpoint.
+
+```xml
+<task>
+Process the results of the bounded stage in code instead of reading every result yourself: run the eligible commands, filter/join/rank the outputs in a script, and return only the reduced result.
+</task>
+
+<structured_output_contract>
+Return exactly the requested output schema. Do not include raw intermediate outputs.
+</structured_output_contract>
 ```
 
 ## Prompt-Patching

--- a/plugins/codex/skills/gpt-5-6-prompting/references/prompt-blocks.md
+++ b/plugins/codex/skills/gpt-5-6-prompting/references/prompt-blocks.md
@@ -1,6 +1,6 @@
 # Prompt Blocks
 
-Use these blocks selectively when composing Codex or GPT-5.4 prompts.
+Use these blocks selectively when composing Codex or GPT-5.6 prompts.
 Wrap each block in the XML tag shown in its heading.
 
 ## Core Wrapper

--- a/plugins/codex/skills/gpt-5-6-prompting/references/prompt-blocks.md
+++ b/plugins/codex/skills/gpt-5-6-prompting/references/prompt-blocks.md
@@ -2,6 +2,7 @@
 
 Use these blocks selectively when composing Codex or GPT-5.6 prompts.
 Wrap each block in the XML tag shown in its heading.
+Pick at most one block per concern, and never restate a rule that already appears in another block — GPT-5.6 reconciles repeated or conflicting instructions at the cost of reasoning tokens.
 
 ## Core Wrapper
 
@@ -31,7 +32,7 @@ Put the highest-value findings or decisions first.
 
 ### `compact_output_contract`
 
-Use when you want concise prose instead of a schema.
+Use only when a specific shape or brevity requirement exists. GPT-5.6 is concise by default — blanket brevity orders under-deliver detail.
 
 ```xml
 <compact_output_contract>
@@ -113,6 +114,17 @@ Prefer primary sources.
 ```
 
 ## Safety and Scope
+
+### `authorization_boundary`
+
+Use in every run to state what the request authorizes.
+
+```xml
+<authorization_boundary>
+For requests to answer, explain, review, diagnose, or plan: inspect the relevant materials and report the result. Do not implement changes.
+For fix or implementation requests: edits within the stated scope are authorized. Confirm before destructive or irreversible actions.
+</authorization_boundary>
+```
 
 ### `action_safety`
 

--- a/tests/collab.test.mjs
+++ b/tests/collab.test.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { makeTempDir, run } from "./helpers.mjs";
+import { makeTempDir, run, writeExecutable } from "./helpers.mjs";
 
 const COLLAB_CLI = path.resolve("plugins/codex/scripts/collab.mjs");
 
@@ -81,6 +81,41 @@ test("assign creates a worktree, branch, and registry entry", () => {
   assert.equal(assignments["fix-auth"].base, "main");
   const duplicate = collab(repo, ["assign", "--agent", "claude", "--issue", "fix-auth"]);
   assert.notEqual(duplicate.status, 0);
+});
+
+test("a successful codex run is reported as success, not failure", () => {
+  const repo = makeRepo();
+  const binDir = makeTempDir();
+  const schedulerDir = makeTempDir("codex-collab-scheduler-");
+  writeExecutable(
+    path.join(binDir, "codex"),
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const outputIndex = args.indexOf("-o");
+if (outputIndex >= 0) {
+  fs.writeFileSync(args[outputIndex + 1], "Implemented the change.\\n");
+}
+console.log("session id: 11111111-2222-3333-4444-555555555555");
+process.exit(0);
+`
+  );
+  collab(repo, ["assign", "--agent", "codex", "--issue", "add-guard", "--title", "Add guard"]);
+
+  const result = run("node", [COLLAB_CLI, "run", "--issue", "add-guard", "--prompt", "add the guard"], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      CODEX_COMPANION_SCHEDULER_DIR: schedulerDir
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Implemented the change\./);
+  assert.doesNotMatch(result.stderr, /codex exec failed/);
+  const assignments = JSON.parse(fs.readFileSync(path.join(repo, ".codex-claude", "assignments.json"), "utf8"));
+  assert.deepEqual(assignments["add-guard"].sessions, ["11111111-2222-3333-4444-555555555555"]);
 });
 
 test("merge requires an approving review from the non-author agent", () => {

--- a/tests/collab.test.mjs
+++ b/tests/collab.test.mjs
@@ -1,0 +1,125 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { makeTempDir, run } from "./helpers.mjs";
+
+const COLLAB_CLI = path.resolve("plugins/codex/scripts/collab.mjs");
+
+function makeRepo() {
+  const repo = path.join(makeTempDir(), "mainrepo");
+  fs.mkdirSync(repo, { recursive: true });
+  run("git", ["-C", repo, "init", "-q", "-b", "main"]);
+  run("git", ["-C", repo, "config", "user.email", "test@test"]);
+  run("git", ["-C", repo, "config", "user.name", "test"]);
+  run("git", ["-C", repo, "commit", "-q", "--allow-empty", "-m", "init"]);
+  return repo;
+}
+
+function collab(repo, args) {
+  return run("node", [COLLAB_CLI, ...args], { cwd: repo });
+}
+
+test("init creates the shared workspace and excludes it from git", () => {
+  const repo = makeRepo();
+  const result = collab(repo, ["init"]);
+  assert.equal(result.status, 0);
+  assert.equal(fs.existsSync(path.join(repo, ".codex-claude", "mailbox.jsonl")), true);
+  assert.equal(fs.existsSync(path.join(repo, ".codex-claude", "decisions.md")), true);
+  const exclude = fs.readFileSync(path.join(repo, ".git", "info", "exclude"), "utf8");
+  assert.match(exclude, /\.codex-claude\//);
+  const gitState = run("git", ["-C", repo, "status", "--porcelain"]);
+  assert.equal(gitState.stdout.trim(), "");
+});
+
+test("post and inbox deliver peer messages once, own messages never", () => {
+  const repo = makeRepo();
+  collab(repo, ["init"]);
+  collab(repo, ["post", "--from", "codex", "--type", "status", "--body", "step one done"]);
+  collab(repo, ["post", "--from", "claude", "--type", "status", "--body", "own note"]);
+
+  const first = collab(repo, ["inbox", "--for", "claude"]);
+  assert.equal(first.status, 0);
+  assert.match(first.stdout, /step one done/);
+  assert.doesNotMatch(first.stdout, /own note/);
+
+  const second = collab(repo, ["inbox", "--for", "claude"]);
+  assert.match(second.stdout, /No new messages/);
+});
+
+test("inbox --peek does not advance the cursor", () => {
+  const repo = makeRepo();
+  collab(repo, ["init"]);
+  collab(repo, ["post", "--from", "codex", "--type", "question", "--body", "which schema?"]);
+  const peek = collab(repo, ["inbox", "--for", "claude", "--peek"]);
+  assert.match(peek.stdout, /which schema\?/);
+  const again = collab(repo, ["inbox", "--for", "claude"]);
+  assert.match(again.stdout, /which schema\?/);
+});
+
+test("overlapping claims from both agents are reported as conflicts", () => {
+  const repo = makeRepo();
+  collab(repo, ["init"]);
+  collab(repo, ["claim", "--agent", "codex", "--issue", "a", "--paths", "src/auth/,src/db.ts"]);
+  const result = collab(repo, ["claim", "--agent", "claude", "--issue", "b", "--paths", "src/auth/login.ts"]);
+  assert.match(result.stdout, /CONFLICT/);
+  const conflicts = collab(repo, ["conflicts"]);
+  assert.match(conflicts.stdout, /src\/auth/);
+});
+
+test("assign creates a worktree, branch, and registry entry", () => {
+  const repo = makeRepo();
+  const result = collab(repo, ["assign", "--agent", "codex", "--issue", "fix-auth", "--title", "Fix auth"]);
+  assert.equal(result.status, 0);
+  const worktree = path.join(path.dirname(repo), "mainrepo--codex-fix-auth");
+  assert.equal(fs.existsSync(worktree), true);
+  const branches = run("git", ["-C", repo, "branch", "--list", "codex/fix-auth"]);
+  assert.match(branches.stdout, /codex\/fix-auth/);
+  const assignments = JSON.parse(fs.readFileSync(path.join(repo, ".codex-claude", "assignments.json"), "utf8"));
+  assert.equal(assignments["fix-auth"].agent, "codex");
+  assert.equal(assignments["fix-auth"].base, "main");
+  const duplicate = collab(repo, ["assign", "--agent", "claude", "--issue", "fix-auth"]);
+  assert.notEqual(duplicate.status, 0);
+});
+
+test("merge requires an approving review from the non-author agent", () => {
+  const repo = makeRepo();
+  collab(repo, ["assign", "--agent", "codex", "--issue", "feat-x", "--title", "Feature X"]);
+  const worktree = path.join(path.dirname(repo), "mainrepo--codex-feat-x");
+  fs.writeFileSync(path.join(worktree, "x.txt"), "x\n", "utf8");
+  run("git", ["-C", worktree, "add", "x.txt"]);
+  run("git", ["-C", worktree, "-c", "user.email=test@test", "-c", "user.name=test", "commit", "-q", "-m", "add x"]);
+
+  const blocked = collab(repo, ["merge", "--issue", "feat-x"]);
+  assert.notEqual(blocked.status, 0);
+
+  collab(repo, ["post", "--from", "claude", "--type", "review", "--issue", "feat-x", "--body", "needs work: rename x"]);
+  const stillBlocked = collab(repo, ["merge", "--issue", "feat-x"]);
+  assert.notEqual(stillBlocked.status, 0);
+
+  collab(repo, ["post", "--from", "claude", "--type", "review", "--issue", "feat-x", "--body", "approve — verified x.txt lands"]);
+  const merged = collab(repo, ["merge", "--issue", "feat-x"]);
+  assert.equal(merged.status, 0);
+  assert.equal(fs.existsSync(path.join(repo, "x.txt")), true);
+  assert.equal(fs.existsSync(worktree), false);
+});
+
+test("decision messages are appended to decisions.md", () => {
+  const repo = makeRepo();
+  collab(repo, ["init"]);
+  collab(repo, [
+    "post",
+    "--from",
+    "claude",
+    "--type",
+    "decision",
+    "--issue",
+    "feat-x",
+    "--body",
+    "Contested: retry semantics. Codex favors idempotency keys; I favor dedup table. Default: idempotency keys."
+  ]);
+  const decisions = fs.readFileSync(path.join(repo, ".codex-claude", "decisions.md"), "utf8");
+  assert.match(decisions, /feat-x/);
+  assert.match(decisions, /idempotency keys/);
+});

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -230,7 +230,7 @@ test("result command documents the bounded envelope and the full-output escape h
   assert.match(result, /Never report it as an approval/i);
 });
 
-test("every documented codex exec invocation closes stdin and states a deadline", () => {
+test("no plugin doc instructs a direct codex exec launch", () => {
   const docRoots = ["commands", "skills", "prompts", "agents"];
   const offenders = [];
 
@@ -245,17 +245,25 @@ test("every documented codex exec invocation closes stdin and states a deadline"
         continue;
       }
       const source = fs.readFileSync(file, "utf8");
-      const invokesRawExec = /^\s*(cd .*&&\s*)?codex exec /m.test(source);
-      if (!invokesRawExec) {
-        continue;
-      }
-      if (!/< \/dev\/null/.test(source) || !/timeout/i.test(source)) {
+      // Prose about codex exec is fine; a line that launches it is not.
+      if (/^\s*(cd .*&&\s*)?codex exec /m.test(source)) {
         offenders.push(path.relative(PLUGIN_ROOT, file));
       }
     }
   }
 
   assert.deepEqual(offenders, []);
+});
+
+test("the image generation skill routes through the companion, queue included", () => {
+  const skill = read("skills/codex-image-gen/SKILL.md");
+
+  assert.match(skill, /Go through the companion, never `codex exec` directly/i);
+  assert.match(skill, /codex-companion\.mjs" task --write/);
+  assert.match(skill, /--timeout-ms 1800000/);
+  assert.match(skill, /< \/dev\/null/);
+  assert.match(skill, /there is no `--skip-git-repo-check` for you to remember/i);
+  assert.match(skill, /bypasses the queue/i);
 });
 
 test("hooks keep session-end cleanup and stop gating enabled", () => {

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -135,15 +135,15 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(agent, /Leave `--effort` unset unless the user explicitly requests a specific reasoning effort/i);
   assert.match(agent, /Leave model unset by default/i);
   assert.match(agent, /If the user asks for `spark`, map that to `--model gpt-5\.3-codex-spark`/i);
-  assert.match(agent, /If the user asks for a concrete model name such as `gpt-5\.4-mini`, pass it through with `--model`/i);
+  assert.match(agent, /If the user asks for a concrete model name such as `gpt-5\.6-luna`, pass it through with `--model`/i);
   assert.match(agent, /Return the stdout of the `codex-companion` command exactly as-is/i);
   assert.match(agent, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
-  assert.match(agent, /gpt-5-4-prompting/);
+  assert.match(agent, /gpt-5-6-prompting/);
   assert.match(agent, /only to tighten the user's request into a better Codex prompt/i);
   assert.match(agent, /Do not use that skill to inspect the repository, reason through the problem yourself, draft a solution, or do any independent work/i);
   assert.match(runtimeSkill, /only job is to invoke `task` once and return that stdout unchanged/i);
   assert.match(runtimeSkill, /Do not call `setup`, `review`, `adversarial-review`, `status`, `result`, or `cancel`/i);
-  assert.match(runtimeSkill, /use the `gpt-5-4-prompting` skill to rewrite the user's request into a tighter Codex prompt/i);
+  assert.match(runtimeSkill, /use the `gpt-5-6-prompting` skill to rewrite the user's request into a tighter Codex prompt/i);
   assert.match(runtimeSkill, /That prompt drafting is the only Claude-side work allowed/i);
   assert.match(runtimeSkill, /Leave `--effort` unset unless the user explicitly requests a specific effort/i);
   assert.match(runtimeSkill, /Leave model unset by default/i);
@@ -155,7 +155,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
   assert.match(readme, /`codex:codex-rescue` subagent/i);
   assert.match(readme, /if you do not pass `--model` or `--effort`, Codex chooses its own defaults/i);
-  assert.match(readme, /--model gpt-5\.4-mini --effort medium/i);
+  assert.match(readme, /--model gpt-5\.6-luna --effort medium/i);
   assert.match(readme, /`spark`, the plugin maps that to `gpt-5\.3-codex-spark`/i);
   assert.match(readme, /continue a previous Codex task/i);
   assert.match(readme, /### `\/codex:setup`/);
@@ -189,8 +189,8 @@ test("transfer, result, and cancel commands are exposed as deterministic runtime
 
 test("internal docs use task terminology for rescue runs", () => {
   const runtimeSkill = read("skills/codex-cli-runtime/SKILL.md");
-  const promptingSkill = read("skills/gpt-5-4-prompting/SKILL.md");
-  const promptRecipes = read("skills/gpt-5-4-prompting/references/codex-prompt-recipes.md");
+  const promptingSkill = read("skills/gpt-5-6-prompting/SKILL.md");
+  const promptRecipes = read("skills/gpt-5-6-prompting/references/codex-prompt-recipes.md");
 
   assert.match(runtimeSkill, /codex-companion\.mjs" task "<raw arguments>"/);
   assert.match(runtimeSkill, /Use `task` for every rescue request/i);

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -114,7 +114,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /Do not forward them to `task`/i);
   assert.match(rescue, /`--model` and `--effort` are runtime-selection flags/i);
   assert.match(rescue, /Leave `--effort` unset unless the user explicitly asks for a specific reasoning effort/i);
-  assert.match(rescue, /If they ask for `spark`, map it to `gpt-5\.3-codex-spark`/i);
+  assert.match(rescue, /If they ask for `spark`, map it to `gpt-5\.6-luna`/i);
   assert.match(rescue, /If the request includes `--resume`, do not ask whether to continue/i);
   assert.match(rescue, /If the request includes `--fresh`, do not ask whether to continue/i);
   assert.match(rescue, /If the user chooses continue, add `--resume`/i);
@@ -134,7 +134,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(agent, /Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`/i);
   assert.match(agent, /Leave `--effort` unset unless the user explicitly requests a specific reasoning effort/i);
   assert.match(agent, /Leave model unset by default/i);
-  assert.match(agent, /If the user asks for `spark`, map that to `--model gpt-5\.3-codex-spark`/i);
+  assert.match(agent, /If the user asks for `spark`, map that to `--model gpt-5\.6-luna`/i);
   assert.match(agent, /If the user asks for a concrete model name such as `gpt-5\.6-luna`, pass it through with `--model`/i);
   assert.match(agent, /Return the stdout of the `codex-companion` command exactly as-is/i);
   assert.match(agent, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
@@ -147,7 +147,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /That prompt drafting is the only Claude-side work allowed/i);
   assert.match(runtimeSkill, /Leave `--effort` unset unless the user explicitly requests a specific effort/i);
   assert.match(runtimeSkill, /Leave model unset by default/i);
-  assert.match(runtimeSkill, /Map `spark` to `--model gpt-5\.3-codex-spark`/i);
+  assert.match(runtimeSkill, /Map `spark` to `--model gpt-5\.6-luna`/i);
   assert.match(runtimeSkill, /If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only/i);
   assert.match(runtimeSkill, /Strip it before calling `task`/i);
   assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`/i);
@@ -156,7 +156,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(readme, /`codex:codex-rescue` subagent/i);
   assert.match(readme, /if you do not pass `--model` or `--effort`, Codex chooses its own defaults/i);
   assert.match(readme, /--model gpt-5\.6-luna --effort medium/i);
-  assert.match(readme, /`spark`, the plugin maps that to `gpt-5\.3-codex-spark`/i);
+  assert.match(readme, /`spark`, the plugin maps that to `gpt-5\.6-luna`/i);
   assert.match(readme, /continue a previous Codex task/i);
   assert.match(readme, /### `\/codex:setup`/);
   assert.match(readme, /### `\/codex:review`/);

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -32,8 +32,10 @@ test("review command uses AskUserQuestion and background Bash while staying revi
   assert.match(source, /Treat untracked files or directories as reviewable work/i);
   assert.match(source, /Recommend waiting only when the review is clearly tiny, roughly 1-2 files total/i);
   assert.match(source, /In every other case, including unclear size, recommend background/i);
-  assert.match(source, /The companion script parses `--wait` and `--background`/i);
-  assert.match(source, /Claude Code's `Bash\(..., run_in_background: true\)` is what actually detaches the run/i);
+  assert.match(source, /The companion script owns detachment/i);
+  assert.match(source, /returns a job id immediately, and keeps running even if this shell exits/i);
+  assert.match(source, /--timeout-ms <ms>/);
+  assert.equal(/is what actually detaches the run/i.test(source), false);
   assert.match(source, /When in doubt, run the review/i);
   assert.match(source, /\(Recommended\)/);
   assert.match(source, /does not support staged-only review, unstaged-only review, or extra focus text/i);
@@ -60,8 +62,10 @@ test("adversarial review command uses AskUserQuestion and background Bash while 
   assert.match(source, /Treat untracked files or directories as reviewable work/i);
   assert.match(source, /Recommend waiting only when the scoped review is clearly tiny, roughly 1-2 files total/i);
   assert.match(source, /In every other case, including unclear size, recommend background/i);
-  assert.match(source, /The companion script parses `--wait` and `--background`/i);
-  assert.match(source, /Claude Code's `Bash\(..., run_in_background: true\)` is what actually detaches the run/i);
+  assert.match(source, /The companion script owns detachment/i);
+  assert.match(source, /returns a job id immediately, and keeps running even if this shell exits/i);
+  assert.match(source, /--timeout-ms <ms>/);
+  assert.equal(/is what actually detaches the run/i.test(source), false);
   assert.match(source, /When in doubt, run the review/i);
   assert.match(source, /\(Recommended\)/);
   assert.match(source, /uses the same review target selection as `\/codex:review`/i);
@@ -152,7 +156,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /Strip it before calling `task`/i);
   assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`/i);
   assert.match(runtimeSkill, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
-  assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
+  assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return the failure envelope/i);
   assert.match(readme, /`codex:codex-rescue` subagent/i);
   assert.match(readme, /if you do not pass `--model` or `--effort`, Codex chooses its own defaults/i);
   assert.match(readme, /--model gpt-5\.6-luna --effort medium/i);
@@ -200,6 +204,58 @@ test("internal docs use task terminology for rescue runs", () => {
   assert.match(promptRecipes, /Use these as starting templates for Codex task prompts/i);
   assert.match(promptRecipes, /## Diagnosis/);
   assert.match(promptRecipes, /## Narrow Fix/);
+});
+
+test("runtime docs point one-shot judgments at consult instead of raw codex exec", () => {
+  const runtimeSkill = read("skills/codex-cli-runtime/SKILL.md");
+
+  assert.match(runtimeSkill, /The companion owns queueing and deadlines/i);
+  assert.match(runtimeSkill, /outer Bash timeout at least 60s longer than the companion's internal deadline/i);
+  assert.match(runtimeSkill, /never uses raw `codex exec`/i);
+  assert.match(runtimeSkill, /codex-companion\.mjs" consult --prompt-file "<absolute-prompt-path>"/);
+  assert.match(runtimeSkill, /--timeout-ms 420000/);
+  assert.match(runtimeSkill, /< \/dev\/null/);
+  assert.match(runtimeSkill, /returns a normalized failure envelope, not nothing/i);
+  assert.match(runtimeSkill, /Never return silence/i);
+  assert.equal(/return nothing\./i.test(runtimeSkill), false);
+});
+
+test("result command documents the bounded envelope and the full-output escape hatch", () => {
+  const result = read("commands/result.md");
+
+  assert.match(result, /bounded result envelope/i);
+  assert.match(result, /severity tally/i);
+  assert.match(result, /result <job-id> --full/);
+  assert.match(result, /`--json` returns the same envelope as JSON/);
+  assert.match(result, /Never report it as an approval/i);
+});
+
+test("every documented codex exec invocation closes stdin and states a deadline", () => {
+  const docRoots = ["commands", "skills", "prompts", "agents"];
+  const offenders = [];
+
+  for (const root of docRoots) {
+    const dir = path.join(PLUGIN_ROOT, root);
+    if (!fs.existsSync(dir)) {
+      continue;
+    }
+    for (const entry of fs.readdirSync(dir, { recursive: true })) {
+      const file = path.join(dir, String(entry));
+      if (!file.endsWith(".md") || !fs.statSync(file).isFile()) {
+        continue;
+      }
+      const source = fs.readFileSync(file, "utf8");
+      const invokesRawExec = /^\s*(cd .*&&\s*)?codex exec /m.test(source);
+      if (!invokesRawExec) {
+        continue;
+      }
+      if (!/< \/dev\/null/.test(source) || !/timeout/i.test(source)) {
+        offenders.push(path.relative(PLUGIN_ROOT, file));
+      }
+    }
+  }
+
+  assert.deepEqual(offenders, []);
 });
 
 test("hooks keep session-end cleanup and stop gating enabled", () => {

--- a/tests/envelope.test.mjs
+++ b/tests/envelope.test.mjs
@@ -71,6 +71,92 @@ test("a huge transcript still renders a bounded envelope on stdout", () => {
   assert.match(rendered, /Log: \/tmp\/run\.log/);
 });
 
+test("a parsed object missing required fields is malformed, not an approval", () => {
+  for (const parsed of [
+    { verdict: "approve" },
+    { verdict: "approve", summary: "ok" },
+    { verdict: "approve", summary: "ok", findings: [] },
+    { verdict: "approve", summary: "", findings: [], next_steps: [] },
+    { summary: "ok", findings: [], next_steps: [] },
+    { verdict: "approve", summary: "ok", findings: [{ body: "no severity or title" }], next_steps: [] }
+  ]) {
+    const envelope = buildResultEnvelope({ jobId: "j", kind: "consult", status: "completed", parsed });
+    assert.equal(envelope.verdict, "inconclusive", JSON.stringify(parsed));
+    assert.equal(typeof envelope.parse_error, "string", JSON.stringify(parsed));
+    assert.equal(envelope.structured, false);
+    assert.equal(envelope.finding_count, 0);
+  }
+
+  const valid = buildResultEnvelope({
+    jobId: "j",
+    kind: "consult",
+    status: "completed",
+    parsed: { verdict: "approve", summary: "All good.", findings: [], next_steps: [] }
+  });
+  assert.equal(valid.verdict, "approve");
+  assert.equal(valid.structured, true);
+  assert.equal(valid.parse_error, undefined);
+});
+
+test("the envelope stays inside its byte budget even with hostile field values", () => {
+  const envelope = buildResultEnvelope({
+    jobId: "review-3",
+    kind: "review",
+    status: "completed",
+    parsed: {
+      verdict: "needs-attention",
+      summary: "🙂".repeat(5000),
+      findings: Array.from({ length: 40 }, (_, index) => ({
+        severity: "critical".repeat(50),
+        title: "t".repeat(5000),
+        body: "b",
+        file: `src/${"nested-directory/".repeat(200)}file-${index}.ts`,
+        line_start: index + 1,
+        line_end: index + 1
+      })),
+      next_steps: []
+    },
+    finalOutputPath: "/tmp/final.md",
+    logPath: "/tmp/run.log"
+  });
+
+  assert.equal(Buffer.byteLength(JSON.stringify(envelope), "utf8") < MAX_ENVELOPE_STDOUT_BYTES, true);
+  assert.equal(Buffer.byteLength(renderResultEnvelope(envelope), "utf8") < MAX_ENVELOPE_STDOUT_BYTES, true);
+  assert.equal(Buffer.byteLength(envelope.summary, "utf8") <= 2000, true);
+  for (const finding of envelope.findings_preview) {
+    assert.equal(Buffer.byteLength(finding.file, "utf8") <= 201, true);
+    assert.equal(Buffer.byteLength(finding.title, "utf8") <= 201, true);
+    assert.equal(["critical", "high", "medium", "low"].includes(finding.severity), true);
+  }
+  assert.equal(envelope.finding_count, 40);
+  assert.equal(envelope.truncated, true);
+});
+
+test("a workload that answers in prose reports a missing verdict, not a failed one", () => {
+  const completed = buildResultEnvelope({
+    jobId: "review-4",
+    kind: "review",
+    status: "completed",
+    parsed: null,
+    unstructuredKind: true,
+    summaryText: "Reviewed uncommitted changes. No material issues found."
+  });
+  assert.equal(completed.verdict, "not-applicable");
+  assert.equal(completed.structured, false);
+  assert.equal(completed.parse_error, undefined);
+  assert.match(completed.summary, /No material issues found/);
+
+  const timedOut = buildResultEnvelope({
+    jobId: "review-5",
+    kind: "review",
+    status: "timed-out",
+    parsed: null,
+    unstructuredKind: false,
+    parseError: "The review deadline expired before Codex finished."
+  });
+  assert.equal(timedOut.verdict, "inconclusive");
+});
+
 test("malformed structured output is inconclusive, never approved", () => {
   const envelope = buildResultEnvelope({
     jobId: "consult-1",

--- a/tests/envelope.test.mjs
+++ b/tests/envelope.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   buildResultEnvelope,
   buildSeverityTally,
+  emittedJsonBytes,
   MAX_ENVELOPE_STDOUT_BYTES,
   MAX_FINDINGS_PREVIEW,
   renderResultEnvelope
@@ -16,7 +17,9 @@ function makeFindings(count, severity = "medium") {
     body: "Body",
     file: "src/app.js",
     line_start: index + 1,
-    line_end: index + 1
+    line_end: index + 1,
+    confidence: 0.5,
+    recommendation: "Fix it."
   }));
 }
 
@@ -64,7 +67,7 @@ test("a huge transcript still renders a bounded envelope on stdout", () => {
   });
 
   const rendered = renderResultEnvelope(envelope);
-  assert.equal(Buffer.byteLength(JSON.stringify(envelope), "utf8") < MAX_ENVELOPE_STDOUT_BYTES, true);
+  assert.equal(emittedJsonBytes(envelope) < MAX_ENVELOPE_STDOUT_BYTES, true, `emitted ${emittedJsonBytes(envelope)} bytes`);
   assert.equal(Buffer.byteLength(rendered, "utf8") < MAX_ENVELOPE_STDOUT_BYTES, true);
   assert.equal(envelope.summary.length <= 2000, true);
   assert.match(rendered, /Full result: \/tmp\/final\.md/);
@@ -98,6 +101,53 @@ test("a parsed object missing required fields is malformed, not an approval", ()
   assert.equal(valid.parse_error, undefined);
 });
 
+test("a finding must carry the whole documented shape, not just a severity", () => {
+  const complete = {
+    severity: "high",
+    title: "Missing empty-state guard",
+    body: "The change assumes data is always present.",
+    file: "src/app.js",
+    line_start: 4,
+    line_end: 6,
+    confidence: 0.87,
+    recommendation: "Handle empty collections before indexing."
+  };
+
+  const valid = buildResultEnvelope({
+    jobId: "j",
+    kind: "review",
+    status: "completed",
+    parsed: { verdict: "needs-attention", summary: "One issue.", findings: [complete], next_steps: [] }
+  });
+  assert.equal(valid.verdict, "needs-attention");
+  assert.equal(valid.structured, true);
+  assert.equal(valid.finding_count, 1);
+
+  const brokenFindings = [
+    { severity: "high", title: "only these two" },
+    { ...complete, body: undefined },
+    { ...complete, file: "" },
+    { ...complete, line_start: "4" },
+    { ...complete, line_end: 2 },
+    { ...complete, confidence: 1.5 },
+    { ...complete, confidence: undefined },
+    { ...complete, recommendation: undefined },
+    { ...complete, severity: "blocker" }
+  ];
+
+  for (const finding of brokenFindings) {
+    const envelope = buildResultEnvelope({
+      jobId: "j",
+      kind: "review",
+      status: "completed",
+      parsed: { verdict: "approve", summary: "Looks fine.", findings: [finding], next_steps: [] }
+    });
+    assert.equal(envelope.verdict, "inconclusive", JSON.stringify(finding));
+    assert.equal(envelope.structured, false, JSON.stringify(finding));
+    assert.match(envelope.parse_error, /^Finding 1 /);
+  }
+});
+
 test("the envelope stays inside its byte budget even with hostile field values", () => {
   const envelope = buildResultEnvelope({
     jobId: "review-3",
@@ -107,12 +157,14 @@ test("the envelope stays inside its byte budget even with hostile field values",
       verdict: "needs-attention",
       summary: "🙂".repeat(5000),
       findings: Array.from({ length: 40 }, (_, index) => ({
-        severity: "critical".repeat(50),
+        severity: "critical",
         title: "t".repeat(5000),
         body: "b",
         file: `src/${"nested-directory/".repeat(200)}file-${index}.ts`,
         line_start: index + 1,
-        line_end: index + 1
+        line_end: index + 1,
+        confidence: 0.5,
+        recommendation: "r".repeat(3000)
       })),
       next_steps: []
     },
@@ -120,7 +172,7 @@ test("the envelope stays inside its byte budget even with hostile field values",
     logPath: "/tmp/run.log"
   });
 
-  assert.equal(Buffer.byteLength(JSON.stringify(envelope), "utf8") < MAX_ENVELOPE_STDOUT_BYTES, true);
+  assert.equal(emittedJsonBytes(envelope) < MAX_ENVELOPE_STDOUT_BYTES, true, `emitted ${emittedJsonBytes(envelope)} bytes`);
   assert.equal(Buffer.byteLength(renderResultEnvelope(envelope), "utf8") < MAX_ENVELOPE_STDOUT_BYTES, true);
   assert.equal(Buffer.byteLength(envelope.summary, "utf8") <= 2000, true);
   for (const finding of envelope.findings_preview) {

--- a/tests/envelope.test.mjs
+++ b/tests/envelope.test.mjs
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildResultEnvelope,
+  buildSeverityTally,
+  MAX_ENVELOPE_STDOUT_BYTES,
+  MAX_FINDINGS_PREVIEW,
+  renderResultEnvelope
+} from "../plugins/codex/scripts/lib/envelope.mjs";
+
+function makeFindings(count, severity = "medium") {
+  return Array.from({ length: count }, (_, index) => ({
+    severity,
+    title: `Finding ${index + 1}`,
+    body: "Body",
+    file: "src/app.js",
+    line_start: index + 1,
+    line_end: index + 1
+  }));
+}
+
+test("severity counts cover zero, one, and many findings", () => {
+  assert.deepEqual(buildSeverityTally([]), { critical: 0, high: 0, medium: 0, low: 0 });
+  assert.deepEqual(buildSeverityTally([{ severity: "high" }]), { critical: 0, high: 1, medium: 0, low: 0 });
+  assert.deepEqual(
+    buildSeverityTally([
+      { severity: "critical" },
+      { severity: "critical" },
+      { severity: "high" },
+      { severity: "medium" },
+      { severity: "low" },
+      { severity: "bogus" }
+    ]),
+    { critical: 2, high: 1, medium: 1, low: 2 }
+  );
+});
+
+test("findings are counted independently of preview truncation", () => {
+  const envelope = buildResultEnvelope({
+    jobId: "review-1",
+    kind: "review",
+    status: "completed",
+    parsed: { verdict: "needs-attention", summary: "Lots to fix.", findings: makeFindings(25), next_steps: [] }
+  });
+
+  assert.equal(envelope.finding_count, 25);
+  assert.equal(envelope.findings_preview.length, MAX_FINDINGS_PREVIEW);
+  assert.equal(envelope.truncated, true);
+  assert.equal(envelope.severity_tally.medium, 25);
+});
+
+test("a huge transcript still renders a bounded envelope on stdout", () => {
+  const huge = "x".repeat(715 * 1024 + 1);
+  const envelope = buildResultEnvelope({
+    jobId: "review-2",
+    kind: "review",
+    status: "completed",
+    rawOutput: huge,
+    summaryText: huge,
+    parsed: { verdict: "approve", summary: huge, findings: makeFindings(200, "low"), next_steps: [] },
+    finalOutputPath: "/tmp/final.md",
+    logPath: "/tmp/run.log"
+  });
+
+  const rendered = renderResultEnvelope(envelope);
+  assert.equal(Buffer.byteLength(JSON.stringify(envelope), "utf8") < MAX_ENVELOPE_STDOUT_BYTES, true);
+  assert.equal(Buffer.byteLength(rendered, "utf8") < MAX_ENVELOPE_STDOUT_BYTES, true);
+  assert.equal(envelope.summary.length <= 2000, true);
+  assert.match(rendered, /Full result: \/tmp\/final\.md/);
+  assert.match(rendered, /Log: \/tmp\/run\.log/);
+});
+
+test("malformed structured output is inconclusive, never approved", () => {
+  const envelope = buildResultEnvelope({
+    jobId: "consult-1",
+    kind: "consult",
+    status: "completed",
+    parsed: null,
+    parseError: "Unexpected token o in JSON at position 1",
+    rawOutput: "not valid json"
+  });
+
+  assert.equal(envelope.verdict, "inconclusive");
+  assert.match(envelope.parse_error, /Unexpected token/);
+  assert.equal(envelope.finding_count, 0);
+});
+
+test("a timeout keeps its non-success status even when the partial answer looks clean", () => {
+  const envelope = buildResultEnvelope({
+    jobId: "consult-2",
+    kind: "consult",
+    status: "timed-out",
+    exitCode: 124,
+    parsed: { verdict: "approve", summary: "Everything looks fine.", findings: [], next_steps: [] }
+  });
+
+  assert.equal(envelope.status, "timed-out");
+  assert.equal(envelope.verdict, "inconclusive");
+  assert.equal(envelope.partial_verdict, "approve");
+  assert.equal(envelope.exit_code, 124);
+});
+
+test("severity keys are always present and integer valued", () => {
+  const envelope = buildResultEnvelope({ jobId: "x", kind: "review", status: "failed" });
+  for (const key of ["critical", "high", "medium", "low"]) {
+    assert.equal(Number.isInteger(envelope.severity_tally[key]), true);
+  }
+  assert.equal(envelope.verdict, "inconclusive");
+});

--- a/tests/exec-launcher.test.mjs
+++ b/tests/exec-launcher.test.mjs
@@ -87,6 +87,27 @@ test("an over-running child is killed at the deadline and reported as timed out"
   assert.match(describeExecOutcome(result), /deadline expired/);
 });
 
+test("a SIGTERM-resistant child is escalated to SIGKILL after the grace period", async () => {
+  const dir = makeTempDir("codex-exec-");
+  const scriptPath = installFakeExec(
+    dir,
+    `  process.on("SIGTERM", () => {});
+  process.on("SIGINT", () => {});
+  setInterval(() => {}, 1000);`
+  );
+
+  const startedAt = Date.now();
+  const result = await runHardenedCodexExec(
+    launcherOptions(dir, scriptPath, { timeoutMs: 400, killGraceMs: 400 })
+  );
+  const elapsed = Date.now() - startedAt;
+
+  assert.equal(result.timedOut, true);
+  assert.equal(result.exitCode, 124);
+  assert.equal(result.signal, "SIGKILL");
+  assert.equal(elapsed < 10000, true, `the deadline took ${elapsed}ms to take effect`);
+});
+
 test("exit codes keep signals visible", () => {
   assert.equal(normalizeExitCode(0, null), 0);
   assert.equal(normalizeExitCode(2, null), 2);

--- a/tests/exec-launcher.test.mjs
+++ b/tests/exec-launcher.test.mjs
@@ -1,0 +1,120 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { initGitRepo, makeTempDir, writeExecutable } from "./helpers.mjs";
+import {
+  buildCodexExecArgs,
+  describeExecOutcome,
+  normalizeExitCode,
+  runHardenedCodexExec
+} from "../plugins/codex/scripts/lib/exec-launcher.mjs";
+
+function installFakeExec(dir, body) {
+  const scriptPath = path.join(dir, "fake-codex.mjs");
+  writeExecutable(
+    scriptPath,
+    `#!/usr/bin/env node
+import fs from "node:fs";
+const args = process.argv.slice(2);
+const outputIndex = args.indexOf("-o");
+const outputFile = outputIndex >= 0 ? args[outputIndex + 1] : null;
+let prompt = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { prompt += chunk; });
+process.stdin.on("end", () => {
+${body}
+});
+`
+  );
+  return scriptPath;
+}
+
+function launcherOptions(dir, scriptPath, overrides = {}) {
+  const promptFile = path.join(dir, "prompt.txt");
+  fs.writeFileSync(promptFile, "Answer this exact question.\n", "utf8");
+  return {
+    command: scriptPath,
+    cwd: dir,
+    promptFile,
+    outputFile: path.join(dir, "final.md"),
+    logFile: path.join(dir, "run.log"),
+    schedulerDir: path.join(dir, "scheduler"),
+    jobId: "exec-test",
+    timeoutMs: 15000,
+    ...overrides
+  };
+}
+
+test("the hardened launcher never leaves the child waiting on inherited stdin", async () => {
+  const dir = makeTempDir("codex-exec-");
+  const scriptPath = installFakeExec(
+    dir,
+    `  if (outputFile) { fs.writeFileSync(outputFile, "received:" + prompt.trim() + "\\n"); }
+  process.exit(0);`
+  );
+
+  const options = launcherOptions(dir, scriptPath);
+  const result = await runHardenedCodexExec(options);
+
+  assert.equal(result.timedOut, false);
+  assert.equal(result.exitCode, 0);
+  assert.match(result.finalOutput, /^received:Answer this exact question\.$/);
+  assert.equal(describeExecOutcome(result), "Codex completed.");
+});
+
+test("a signal-terminated run is normalized into a non-zero exit and a readable outcome", async () => {
+  const dir = makeTempDir("codex-exec-");
+  const scriptPath = installFakeExec(dir, `  process.kill(process.pid, "SIGTERM");`);
+
+  const result = await runHardenedCodexExec(launcherOptions(dir, scriptPath));
+
+  assert.equal(result.signal, "SIGTERM");
+  assert.notEqual(result.exitCode, 0);
+  assert.equal(result.finalOutput, "");
+  assert.match(describeExecOutcome(result), /terminated by SIGTERM/);
+});
+
+test("an over-running child is killed at the deadline and reported as timed out", async () => {
+  const dir = makeTempDir("codex-exec-");
+  const scriptPath = installFakeExec(dir, `  setTimeout(() => process.exit(0), 30000);`);
+
+  const result = await runHardenedCodexExec(launcherOptions(dir, scriptPath, { timeoutMs: 600 }));
+
+  assert.equal(result.timedOut, true);
+  assert.equal(result.exitCode, 124);
+  assert.match(describeExecOutcome(result), /deadline expired/);
+});
+
+test("exit codes keep signals visible", () => {
+  assert.equal(normalizeExitCode(0, null), 0);
+  assert.equal(normalizeExitCode(2, null), 2);
+  assert.notEqual(normalizeExitCode(null, "SIGTERM"), 0);
+  assert.equal(normalizeExitCode(null, null), 0);
+});
+
+test("--skip-git-repo-check is added only outside a Git worktree unless overridden", () => {
+  const repo = makeTempDir("codex-exec-repo-");
+  initGitRepo(repo);
+  const scratch = makeTempDir("codex-exec-scratch-");
+
+  assert.equal(buildCodexExecArgs({ cwd: repo }).args.includes("--skip-git-repo-check"), false);
+  assert.equal(buildCodexExecArgs({ cwd: scratch }).args.includes("--skip-git-repo-check"), true);
+  assert.equal(buildCodexExecArgs({ cwd: repo, skipGitRepoCheck: true }).args.includes("--skip-git-repo-check"), true);
+  assert.equal(buildCodexExecArgs({ cwd: scratch, skipGitRepoCheck: false }).skipGitRepoCheck, false);
+
+  const { args } = buildCodexExecArgs({ cwd: repo, model: "gpt-5.6-luna", effort: "high", outputFile: "/tmp/out.md" });
+  assert.deepEqual(args, [
+    "exec",
+    "-m",
+    "gpt-5.6-luna",
+    "-s",
+    "read-only",
+    "-c",
+    "model_reasoning_effort=high",
+    "-o",
+    "/tmp/out.md",
+    "-"
+  ]);
+});

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -181,6 +181,25 @@ function emitTurnCompletedLater(threadId, turnId, item, delayMs) {
 }
 
 function nativeReviewText(target) {
+  if (BEHAVIOR === "structured-native-review") {
+    return JSON.stringify({
+      verdict: "needs-attention",
+      summary: "The built-in reviewer returned a structured result.",
+      findings: [
+        {
+          severity: "medium",
+          title: "Unchecked index access",
+          body: "The change indexes a collection that can be empty.",
+          file: "app.js",
+          line_start: 1,
+          line_end: 1,
+          confidence: 0.8,
+          recommendation: "Guard the empty case."
+        }
+      ],
+      next_steps: ["Add a regression test."]
+    });
+  }
   if (BEHAVIOR === "huge-review") {
     return "Reviewed uncommitted changes.\\n" + "detail line about the change under review. ".repeat(20000);
   }

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -653,6 +653,9 @@ export function buildEnv(binDir) {
   const sep = process.platform === "win32" ? ";" : ":";
   return {
     ...process.env,
-    PATH: `${binDir}${sep}${process.env.PATH}`
+    PATH: `${binDir}${sep}${process.env.PATH}`,
+    // Keep the user-global Codex queue out of the developer's home directory:
+    // every fixture gets its own scheduler root, shared by the runs of one test.
+    CODEX_COMPANION_SCHEDULER_DIR: path.join(binDir, "scheduler")
   };
 }

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -181,6 +181,9 @@ function emitTurnCompletedLater(threadId, turnId, item, delayMs) {
 }
 
 function nativeReviewText(target) {
+  if (BEHAVIOR === "huge-review") {
+    return "Reviewed uncommitted changes.\\n" + "detail line about the change under review. ".repeat(20000);
+  }
   if (target.type === "baseBranch") {
     return "Reviewed changes against " + target.branch + ".\\nNo material issues found.";
   }
@@ -249,6 +252,10 @@ function taskPayload(prompt, resume) {
 
 const args = process.argv.slice(2);
 if (args[0] === "--version") {
+  if (BEHAVIOR === "unavailable") {
+    console.error("codex: command failed");
+    process.exit(1);
+  }
   console.log("codex-cli test");
   process.exit(0);
 }
@@ -308,6 +315,10 @@ rl.on("line", (line) => {
       case "thread/start": {
         if (BEHAVIOR === "auth-run-fails") {
           throw new Error("authentication expired; run codex login");
+        }
+        if (BEHAVIOR === "hang-before-turn") {
+          // Never answers: the setup phase hangs while holding the global lease.
+          break;
         }
         if (requiresExperimental("persistExtendedHistory", message, state) || requiresExperimental("persistFullHistory", message, state)) {
           throw new Error("thread/start.persistFullHistory requires experimentalApi capability");

--- a/tests/hardening.test.mjs
+++ b/tests/hardening.test.mjs
@@ -273,6 +273,32 @@ test("result returns the bounded envelope by default and the full answer with --
   assert.equal(envelope.verdict, "needs-attention");
 });
 
+test("every command answers --help with usage instead of launching a Codex run", () => {
+  for (const command of ["review", "adversarial-review", "task", "consult", "status", "result", "cancel", "setup"]) {
+    for (const flag of ["--help", "-h"]) {
+      const repo = makeTempDir();
+      const binDir = makeTempDir();
+      installFakeCodex(binDir);
+      initGitRepo(repo);
+      const env = buildEnv(binDir);
+
+      const help = run("node", [SCRIPT, command, flag], { cwd: repo, env });
+
+      assert.equal(help.status, 0, `${command} ${flag}: ${help.stderr}`);
+      assert.match(help.stdout, /^Usage:/);
+      assert.match(help.stdout, new RegExp(`codex-companion\\.mjs ${command} `));
+      // No app-server was started, so no thread was ever launched.
+      assert.equal(fs.existsSync(path.join(binDir, "fake-codex-state.json")), false, `${command} ${flag} started Codex`);
+
+      const status = run("node", [SCRIPT, "status", "--json"], { cwd: repo, env });
+      const snapshot = JSON.parse(status.stdout);
+      assert.deepEqual(snapshot.running, []);
+      assert.deepEqual(snapshot.recent, []);
+      assert.equal(snapshot.latestFinished, null);
+    }
+  }
+});
+
 test("a busy broker keeps waiting for the broker instead of starting a second Codex", () => {
   assert.equal(
     shouldRetryWithDirectAppServer({ rpcCode: BROKER_BUSY_RPC_CODE }, { transport: "broker", brokerRequested: true }),

--- a/tests/hardening.test.mjs
+++ b/tests/hardening.test.mjs
@@ -265,6 +265,14 @@ test("result returns the bounded envelope by default and the full answer with --
   assert.equal(envelope.verdict, "needs-attention");
 });
 
+test("the stop-gate review runs under its own deadline inside a longer hook guard", () => {
+  const source = fs.readFileSync(path.join(PLUGIN_ROOT, "scripts", "stop-review-gate-hook.mjs"), "utf8");
+
+  assert.match(source, /STOP_REVIEW_EXECUTION_TIMEOUT_MS = 14 \* 60 \* 1000/);
+  assert.match(source, /"--timeout-ms", String\(STOP_REVIEW_EXECUTION_TIMEOUT_MS\)/);
+  assert.match(source, /STOP_REVIEW_TIMEOUT_MS = STOP_REVIEW_EXECUTION_TIMEOUT_MS \+ 60 \* 1000/);
+});
+
 test("no plugin-owned codex exec launch site inherits the parent stdin", () => {
   const scriptsDir = path.join(PLUGIN_ROOT, "scripts");
   const files = fs

--- a/tests/hardening.test.mjs
+++ b/tests/hardening.test.mjs
@@ -198,6 +198,11 @@ test("an expired deadline interrupts the turn, stores a timed-out job, and relea
   assert.equal(snapshot.scheduler.active, null);
   assert.deepEqual(snapshot.scheduler.queue, []);
 
+  // A timed-out job is finished: its stored record stays reachable.
+  const stored = run("node", [SCRIPT, "result", job.id], { cwd: repo, env });
+  assert.equal(stored.status, 0, stored.stderr);
+  assert.match(stored.stdout, /timed-out/);
+
   // The lease is free again, so the next workload runs immediately.
   installFakeCodex(binDir);
   const promptPath = writePromptFile(repo, "Now answer quickly.");

--- a/tests/hardening.test.mjs
+++ b/tests/hardening.test.mjs
@@ -10,6 +10,7 @@ import { MAX_ENVELOPE_STDOUT_BYTES } from "../plugins/codex/scripts/lib/envelope
 import { BROKER_BUSY_RPC_CODE } from "../plugins/codex/scripts/lib/app-server.mjs";
 import { shouldRetryWithDirectAppServer } from "../plugins/codex/scripts/lib/codex.mjs";
 import { appendLogBlock, MAX_LOGGED_BLOCK_BYTES } from "../plugins/codex/scripts/lib/tracked-jobs.mjs";
+import { resolveStateDir } from "../plugins/codex/scripts/lib/state.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const PLUGIN_ROOT = path.join(ROOT, "plugins", "codex");
@@ -229,6 +230,12 @@ test("native review and adversarial review both produce the common envelope", ()
   const nativeEnvelope = JSON.parse(native.stdout).envelope;
   assert.equal(nativeEnvelope.kind, "review");
   assert.equal(nativeEnvelope.status, "completed");
+  // The built-in reviewer answers in prose: no verdict to report, and that is
+  // not the same as a failed or unparseable run.
+  assert.equal(nativeEnvelope.verdict, "not-applicable");
+  assert.equal(nativeEnvelope.structured, false);
+  assert.equal(nativeEnvelope.parse_error, undefined);
+  assert.match(nativeEnvelope.summary, /No material issues found/);
   assert.deepEqual(nativeEnvelope.severity_tally, { critical: 0, high: 0, medium: 0, low: 0 });
   assert.equal(fs.existsSync(nativeEnvelope.final_output_path), true);
 
@@ -271,6 +278,103 @@ test("result returns the bounded envelope by default and the full answer with --
   const envelope = JSON.parse(asJson.stdout);
   assert.equal(envelope.schema_version, 1);
   assert.equal(envelope.verdict, "needs-attention");
+});
+
+test("a huge review stays bounded on stdout in both text and JSON mode", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "huge-review");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "app.js"), "const a = 1;\n");
+  run("git", ["add", "app.js"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "app.js"), "const a = 2;\n");
+  const env = buildEnv(binDir);
+
+  const asJson = run("node", [SCRIPT, "review", "--json"], { cwd: repo, env });
+  assert.equal(asJson.status, 0, asJson.stderr);
+  assert.equal(
+    Buffer.byteLength(asJson.stdout, "utf8") < MAX_ENVELOPE_STDOUT_BYTES,
+    true,
+    `json stdout was ${Buffer.byteLength(asJson.stdout, "utf8")} bytes`
+  );
+  const envelope = JSON.parse(asJson.stdout);
+  assert.equal(envelope.schema_version, 1);
+  // The complete review is on disk, not on stdout.
+  assert.equal(fs.statSync(envelope.final_output_path).size > 715 * 1024, true);
+  assert.equal(fs.statSync(envelope.log_path).size < 128 * 1024, true);
+
+  const asText = run("node", [SCRIPT, "review", "--json=false"], { cwd: repo, env });
+  assert.equal(asText.status, 0, asText.stderr);
+  assert.equal(
+    Buffer.byteLength(asText.stdout, "utf8") < MAX_ENVELOPE_STDOUT_BYTES,
+    true,
+    `text stdout was ${Buffer.byteLength(asText.stdout, "utf8")} bytes`
+  );
+});
+
+test("a background task keeps the deadline it was given", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "slow-task");
+  initGitRepo(repo);
+  const env = buildEnv(binDir);
+
+  const launched = run("node", [SCRIPT, "task", "--background", "--timeout-ms", "123456", "--json", "look into the flake"], {
+    cwd: repo,
+    env
+  });
+  assert.equal(launched.status, 0, launched.stderr);
+  const jobId = JSON.parse(launched.stdout).jobId;
+
+  const stateDir = resolveStateDir(repo);
+  const stored = JSON.parse(fs.readFileSync(path.join(stateDir, "jobs", `${jobId}.json`), "utf8"));
+  assert.equal(stored.request.timeoutMs, 123456);
+});
+
+test("a consult that cannot launch persists its inconclusive envelope", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "unavailable");
+  initGitRepo(repo);
+  const env = buildEnv(binDir);
+  const promptPath = writePromptFile(repo, "Second opinion, please.");
+
+  const result = run("node", [SCRIPT, "consult", "--prompt-file", promptPath, "--json"], { cwd: repo, env });
+  assert.notEqual(result.status, 0);
+  const envelope = JSON.parse(result.stdout);
+  assert.equal(envelope.status, "failed");
+  assert.equal(envelope.verdict, "inconclusive");
+  assert.match(envelope.error_message, /Codex CLI is not installed/);
+
+  const stored = run("node", [SCRIPT, "result", envelope.job_id, "--json"], { cwd: repo, env });
+  assert.equal(stored.status, 0, stored.stderr);
+  const storedEnvelope = JSON.parse(stored.stdout);
+  assert.equal(storedEnvelope.job_id, envelope.job_id);
+  assert.equal(storedEnvelope.verdict, "inconclusive");
+  assert.equal(storedEnvelope.status, "failed");
+});
+
+test("the deadline covers thread setup, not just the turn", async () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "hang-before-turn");
+  initGitRepo(repo);
+  const env = buildEnv(binDir);
+
+  const startedAt = Date.now();
+  const result = run("node", [SCRIPT, "task", "--timeout-ms", "800", "--json", "investigate"], { cwd: repo, env });
+  const elapsed = Date.now() - startedAt;
+
+  assert.equal(result.status, 124, result.stderr);
+  assert.equal(elapsed < 20000, true, `the hung setup phase took ${elapsed}ms to give up`);
+
+  const status = run("node", [SCRIPT, "status", "--json"], { cwd: repo, env });
+  const snapshot = JSON.parse(status.stdout);
+  assert.equal(snapshot.latestFinished.status, "timed-out");
+  // The lease must not be left behind by a workload that never reached its turn.
+  assert.equal(snapshot.scheduler.active, null);
+  assert.deepEqual(snapshot.scheduler.queue, []);
 });
 
 test("every command answers --help with usage instead of launching a Codex run", () => {

--- a/tests/hardening.test.mjs
+++ b/tests/hardening.test.mjs
@@ -7,6 +7,9 @@ import { fileURLToPath } from "node:url";
 import { buildEnv, installFakeCodex } from "./fake-codex-fixture.mjs";
 import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
 import { MAX_ENVELOPE_STDOUT_BYTES } from "../plugins/codex/scripts/lib/envelope.mjs";
+import { BROKER_BUSY_RPC_CODE } from "../plugins/codex/scripts/lib/app-server.mjs";
+import { shouldRetryWithDirectAppServer } from "../plugins/codex/scripts/lib/codex.mjs";
+import { appendLogBlock, MAX_LOGGED_BLOCK_BYTES } from "../plugins/codex/scripts/lib/tracked-jobs.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const PLUGIN_ROOT = path.join(ROOT, "plugins", "codex");
@@ -268,6 +271,29 @@ test("result returns the bounded envelope by default and the full answer with --
   const envelope = JSON.parse(asJson.stdout);
   assert.equal(envelope.schema_version, 1);
   assert.equal(envelope.verdict, "needs-attention");
+});
+
+test("a busy broker keeps waiting for the broker instead of starting a second Codex", () => {
+  assert.equal(
+    shouldRetryWithDirectAppServer({ rpcCode: BROKER_BUSY_RPC_CODE }, { transport: "broker", brokerRequested: true }),
+    false
+  );
+  // A stale or unreachable broker is a different failure and keeps its recovery path.
+  assert.equal(shouldRetryWithDirectAppServer({ code: "ENOENT" }, { transport: null, brokerRequested: true }), true);
+  assert.equal(shouldRetryWithDirectAppServer({ code: "ECONNREFUSED" }, { transport: null, brokerRequested: true }), true);
+  assert.equal(shouldRetryWithDirectAppServer({ code: "ENOENT" }, { transport: null, brokerRequested: false }), false);
+});
+
+test("the progress log does not duplicate an arbitrarily large final result", () => {
+  const dir = makeTempDir("codex-log-");
+  const logFile = path.join(dir, "job.log");
+  fs.writeFileSync(logFile, "", "utf8");
+
+  appendLogBlock(logFile, "Final output", "x".repeat(715 * 1024), { maxBytes: MAX_LOGGED_BLOCK_BYTES });
+
+  const size = fs.statSync(logFile).size;
+  assert.equal(size < MAX_LOGGED_BLOCK_BYTES + 512, true, `log grew to ${size} bytes`);
+  assert.match(fs.readFileSync(logFile, "utf8"), /truncated; the complete output is stored with the job/);
 });
 
 test("the stop-gate review runs under its own deadline inside a longer hook guard", () => {

--- a/tests/hardening.test.mjs
+++ b/tests/hardening.test.mjs
@@ -293,6 +293,7 @@ test("a huge review stays bounded on stdout in both text and JSON mode", () => {
 
   const asJson = run("node", [SCRIPT, "review", "--json"], { cwd: repo, env });
   assert.equal(asJson.status, 0, asJson.stderr);
+  // Measured on what is actually written to stdout, pretty-printing included.
   assert.equal(
     Buffer.byteLength(asJson.stdout, "utf8") < MAX_ENVELOPE_STDOUT_BYTES,
     true,
@@ -313,6 +314,27 @@ test("a huge review stays bounded on stdout in both text and JSON mode", () => {
   );
 });
 
+test("a structured built-in review is parsed into the envelope", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "structured-native-review");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "app.js"), "const a = 1;\n");
+  run("git", ["add", "app.js"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "app.js"), "const a = 2;\n");
+
+  const review = run("node", [SCRIPT, "review", "--json"], { cwd: repo, env: buildEnv(binDir) });
+  assert.equal(review.status, 0, review.stderr);
+
+  const envelope = JSON.parse(review.stdout).envelope;
+  assert.equal(envelope.verdict, "needs-attention");
+  assert.equal(envelope.structured, true);
+  assert.equal(envelope.finding_count, 1);
+  assert.deepEqual(envelope.severity_tally, { critical: 0, high: 0, medium: 1, low: 0 });
+  assert.equal(envelope.findings_preview[0].file, "app.js");
+});
+
 test("a background task keeps the deadline it was given", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
@@ -330,6 +352,26 @@ test("a background task keeps the deadline it was given", () => {
   const stateDir = resolveStateDir(repo);
   const stored = JSON.parse(fs.readFileSync(path.join(stateDir, "jobs", `${jobId}.json`), "utf8"));
   assert.equal(stored.request.timeoutMs, 123456);
+});
+
+test("a background task carries its queue wait budget too", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "slow-task");
+  initGitRepo(repo);
+  const env = buildEnv(binDir);
+
+  const launched = run(
+    "node",
+    [SCRIPT, "task", "--background", "--queue-wait-ms", "45000", "--json", "look into the flake"],
+    { cwd: repo, env }
+  );
+  assert.equal(launched.status, 0, launched.stderr);
+  const jobId = JSON.parse(launched.stdout).jobId;
+
+  const stateDir = resolveStateDir(repo);
+  const stored = JSON.parse(fs.readFileSync(path.join(stateDir, "jobs", `${jobId}.json`), "utf8"));
+  assert.equal(stored.request.queueWaitMs, 45000);
 });
 
 test("a consult that cannot launch persists its inconclusive envelope", () => {

--- a/tests/hardening.test.mjs
+++ b/tests/hardening.test.mjs
@@ -1,0 +1,292 @@
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+
+import { buildEnv, installFakeCodex } from "./fake-codex-fixture.mjs";
+import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
+import { MAX_ENVELOPE_STDOUT_BYTES } from "../plugins/codex/scripts/lib/envelope.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PLUGIN_ROOT = path.join(ROOT, "plugins", "codex");
+const SCRIPT = path.join(PLUGIN_ROOT, "scripts", "codex-companion.mjs");
+
+async function waitFor(predicate, { timeoutMs = 15000, intervalMs = 50 } = {}) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const value = await predicate();
+    if (value) {
+      return value;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error("Timed out waiting for condition.");
+}
+
+function readFakeState(binDir) {
+  return JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+}
+
+function writePromptFile(dir, text) {
+  const promptPath = path.join(dir, "consult-prompt.md");
+  fs.writeFileSync(promptPath, text, "utf8");
+  return promptPath;
+}
+
+test("consult reads the exact prompt from --prompt-file and ignores inherited stdin", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  const promptPath = writePromptFile(repo, "Is the retry loop idempotent?\nExplain briefly.");
+
+  const result = run("node", [SCRIPT, "consult", "--prompt-file", promptPath, "--json"], {
+    cwd: repo,
+    env: buildEnv(binDir),
+    input: "THIS STDIN MUST NEVER REACH CODEX"
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const state = readFakeState(binDir);
+  assert.equal(state.lastTurnStart.prompt, "Is the retry loop idempotent?\nExplain briefly.");
+  assert.equal(state.lastTurnStart.prompt.includes("THIS STDIN MUST NEVER REACH CODEX"), false);
+});
+
+test("consult returns a bounded envelope with a verdict, tally, and on-disk paths", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  const promptPath = writePromptFile(repo, "Give me a second opinion on this plan.");
+
+  const result = run("node", [SCRIPT, "consult", "--prompt-file", promptPath, "--model", "gpt-5.6-luna", "--effort", "high", "--timeout-ms", "420000", "--json"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(Buffer.byteLength(result.stdout, "utf8") < MAX_ENVELOPE_STDOUT_BYTES, true);
+  const envelope = JSON.parse(result.stdout);
+  assert.equal(envelope.schema_version, 1);
+  assert.equal(envelope.kind, "consult");
+  assert.equal(envelope.status, "completed");
+  assert.equal(envelope.verdict, "approve");
+  assert.deepEqual(envelope.severity_tally, { critical: 0, high: 0, medium: 0, low: 0 });
+  assert.equal(envelope.finding_count, 0);
+  assert.equal(typeof envelope.duration_ms, "number");
+  assert.equal(typeof envelope.queue_wait_ms, "number");
+  assert.equal(fs.existsSync(envelope.final_output_path), true);
+  assert.equal(fs.existsSync(envelope.log_path), true);
+
+  const state = readFakeState(binDir);
+  assert.equal(state.lastTurnStart.model, "gpt-5.6-luna");
+  assert.equal(state.lastTurnStart.effort, "high");
+});
+
+test("consult always uses a fresh ephemeral thread and cannot resume", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  const promptPath = writePromptFile(repo, "First question.");
+  const env = buildEnv(binDir);
+
+  run("node", [SCRIPT, "consult", "--prompt-file", promptPath, "--json"], { cwd: repo, env });
+  run("node", [SCRIPT, "consult", "--prompt-file", promptPath, "--json"], { cwd: repo, env });
+
+  const state = readFakeState(binDir);
+  assert.equal(state.threads.length, 2);
+  for (const thread of state.threads) {
+    assert.equal(thread.ephemeral, true);
+    assert.equal(thread.name, null);
+  }
+
+  const resumed = run("node", [SCRIPT, "consult", "--prompt-file", promptPath, "--resume-last"], { cwd: repo, env });
+  assert.notEqual(resumed.status, 0);
+  assert.match(resumed.stderr, /only from --prompt-file/);
+});
+
+test("consult --write is rejected before anything joins the queue", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  const promptPath = writePromptFile(repo, "Please edit my files.");
+
+  const result = run("node", [SCRIPT, "consult", "--prompt-file", promptPath, "--write"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /read-only and does not accept --write/);
+  assert.equal(fs.existsSync(path.join(binDir, "scheduler", "queue")), false);
+});
+
+test("consult requires a prompt file instead of a positional prompt", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  const result = run("node", [SCRIPT, "consult", "what do you think?"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /requires --prompt-file/);
+});
+
+test("consult runs in a non-Git directory without any caller-supplied flag", () => {
+  const scratch = makeTempDir("codex-non-git-");
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  const promptPath = writePromptFile(scratch, "Review this idea from a scratch directory.");
+
+  assert.equal(fs.existsSync(path.join(scratch, ".git")), false);
+  const result = run("node", [SCRIPT, "consult", "--prompt-file", promptPath, "--cwd", scratch, "--json"], {
+    cwd: scratch,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const envelope = JSON.parse(result.stdout);
+  assert.equal(envelope.status, "completed");
+  assert.equal(envelope.final_output_path.startsWith(path.sep) || /^[A-Za-z]:/.test(envelope.final_output_path), true);
+});
+
+test("consult returns inconclusive when Codex output cannot be parsed", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "invalid-json");
+  initGitRepo(repo);
+  const promptPath = writePromptFile(repo, "Second opinion please.");
+
+  const result = run("node", [SCRIPT, "consult", "--prompt-file", promptPath, "--json"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  const envelope = JSON.parse(result.stdout);
+  assert.equal(envelope.verdict, "inconclusive");
+  assert.equal(typeof envelope.parse_error, "string");
+});
+
+test("an expired deadline interrupts the turn, stores a timed-out job, and releases the lease", async () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "interruptible-slow-task");
+  initGitRepo(repo);
+  const env = buildEnv(binDir);
+
+  const timedOut = run("node", [SCRIPT, "task", "--timeout-ms", "600", "investigate the slow path"], {
+    cwd: repo,
+    env
+  });
+
+  assert.equal(timedOut.status, 124, timedOut.stderr);
+  const interrupted = await waitFor(() => readFakeState(binDir).lastInterrupt ?? null, { timeoutMs: 5000 });
+  assert.equal(typeof interrupted.turnId, "string");
+
+  const status = run("node", [SCRIPT, "status", "--json"], { cwd: repo, env });
+  const snapshot = JSON.parse(status.stdout);
+  const job = snapshot.latestFinished;
+  assert.equal(job.status, "timed-out");
+  assert.equal(job.phase, "timed-out");
+  assert.equal(snapshot.scheduler.active, null);
+  assert.deepEqual(snapshot.scheduler.queue, []);
+
+  // The lease is free again, so the next workload runs immediately.
+  installFakeCodex(binDir);
+  const promptPath = writePromptFile(repo, "Now answer quickly.");
+  const consult = run("node", [SCRIPT, "consult", "--prompt-file", promptPath, "--json"], { cwd: repo, env });
+  assert.equal(consult.status, 0, consult.stderr);
+});
+
+test("native review and adversarial review both produce the common envelope", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "app.js"), "const a = 1;\n");
+  run("git", ["add", "app.js"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "app.js"), "const a = 2;\n");
+  const env = buildEnv(binDir);
+
+  const native = run("node", [SCRIPT, "review", "--json"], { cwd: repo, env });
+  assert.equal(native.status, 0, native.stderr);
+  const nativeEnvelope = JSON.parse(native.stdout).envelope;
+  assert.equal(nativeEnvelope.kind, "review");
+  assert.equal(nativeEnvelope.status, "completed");
+  assert.deepEqual(nativeEnvelope.severity_tally, { critical: 0, high: 0, medium: 0, low: 0 });
+  assert.equal(fs.existsSync(nativeEnvelope.final_output_path), true);
+
+  const adversarial = run("node", [SCRIPT, "adversarial-review", "--json"], { cwd: repo, env });
+  assert.equal(adversarial.status, 0, adversarial.stderr);
+  const adversarialEnvelope = JSON.parse(adversarial.stdout).envelope;
+  assert.equal(adversarialEnvelope.kind, "adversarial-review");
+  assert.equal(adversarialEnvelope.verdict, "needs-attention");
+  assert.deepEqual(adversarialEnvelope.severity_tally, { critical: 0, high: 1, medium: 0, low: 0 });
+  assert.equal(adversarialEnvelope.finding_count, 1);
+  assert.equal(adversarialEnvelope.findings_preview[0].file, "src/app.js");
+});
+
+test("result returns the bounded envelope by default and the full answer with --full", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "app.js"), "const a = 1;\n");
+  run("git", ["add", "app.js"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "app.js"), "const a = 2;\n");
+  const env = buildEnv(binDir);
+
+  const review = run("node", [SCRIPT, "adversarial-review", "--json"], { cwd: repo, env });
+  const jobId = JSON.parse(review.stdout).envelope.job_id;
+
+  const summary = run("node", [SCRIPT, "result", jobId], { cwd: repo, env });
+  assert.equal(summary.status, 0, summary.stderr);
+  assert.match(summary.stdout, /Verdict: needs-attention/);
+  assert.match(summary.stdout, /Findings: 1 \(critical 0, high 1, medium 0, low 0\)/);
+  assert.equal(summary.stdout.includes("The change assumes data is always present."), false);
+  assert.equal(Buffer.byteLength(summary.stdout, "utf8") < MAX_ENVELOPE_STDOUT_BYTES, true);
+
+  const full = run("node", [SCRIPT, "result", jobId, "--full"], { cwd: repo, env });
+  assert.equal(full.status, 0, full.stderr);
+  assert.match(full.stdout, /The change assumes data is always present\./);
+
+  const asJson = run("node", [SCRIPT, "result", jobId, "--json"], { cwd: repo, env });
+  const envelope = JSON.parse(asJson.stdout);
+  assert.equal(envelope.schema_version, 1);
+  assert.equal(envelope.verdict, "needs-attention");
+});
+
+test("no plugin-owned codex exec launch site inherits the parent stdin", () => {
+  const scriptsDir = path.join(PLUGIN_ROOT, "scripts");
+  const files = fs
+    .readdirSync(scriptsDir, { recursive: true })
+    .filter((entry) => String(entry).endsWith(".mjs"))
+    .map((entry) => path.join(scriptsDir, String(entry)));
+
+  const offenders = [];
+  for (const file of files) {
+    const source = fs.readFileSync(file, "utf8");
+    const segments = source.split(/spawnSync\(|spawn\(/).slice(1);
+    for (const segment of segments) {
+      const call = segment.slice(0, 600);
+      const launchesCodexExec = /["']codex["']/.test(call) && /["']exec["']/.test(call);
+      if (!launchesCodexExec) {
+        continue;
+      }
+      if (!/stdio:\s*\[\s*["']ignore["']/.test(call)) {
+        offenders.push(path.relative(ROOT, file));
+      }
+    }
+  }
+
+  assert.deepEqual(offenders, []);
+});

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -8,6 +8,20 @@ export function makeTempDir(prefix = "codex-plugin-test-") {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 }
 
+// Hermetic plugin state, for this test process and every companion it spawns.
+// Without this the suite reads and writes the plugin data directory of the
+// developer's live Claude Code session: a real broker registered there for the
+// checkout under test makes `setup` and `status` report a shared runtime, and
+// jobs from real runs show up in status assertions. Tests that need a specific
+// value still pass their own CLAUDE_PLUGIN_DATA in the child environment.
+process.env.CLAUDE_PLUGIN_DATA = fs.mkdtempSync(path.join(os.tmpdir(), "codex-plugin-test-data-"));
+
+// Same reason: a live session id makes the companion filter jobs to that
+// session, so the suite's own jobs disappear from status and result output.
+// Tests that exercise session scoping set these explicitly per child.
+delete process.env.CODEX_COMPANION_SESSION_ID;
+delete process.env.CODEX_COMPANION_TRANSCRIPT_PATH;
+
 export function writeExecutable(filePath, source) {
   fs.writeFileSync(filePath, source, { encoding: "utf8", mode: 0o755 });
 }

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1031,35 +1031,42 @@ test("adversarial review rejects staged-only scope to match review target select
   assert.match(result.stderr, /Use one of: auto, working-tree, branch, or pass --base <ref>/i);
 });
 
-test("review accepts --background while still running as a tracked review job", () => {
+test("review --background returns a job id immediately and its own worker finishes the review", async () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
-  installFakeCodex(binDir);
+  installFakeCodex(binDir, "slow-task");
   initGitRepo(repo);
   fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
   run("git", ["add", "README.md"], { cwd: repo });
   run("git", ["commit", "-m", "init"], { cwd: repo });
   fs.writeFileSync(path.join(repo, "README.md"), "hello again\n");
+  const env = buildEnv(binDir);
 
   const launched = run("node", [SCRIPT, "review", "--background", "--json"], {
     cwd: repo,
-    env: buildEnv(binDir)
+    env
   });
 
   assert.equal(launched.status, 0, launched.stderr);
   const launchPayload = JSON.parse(launched.stdout);
-  assert.equal(launchPayload.review, "Review");
-  assert.match(launchPayload.codex.stdout, /No material issues found/);
+  assert.match(launchPayload.jobId, /^review-/);
+  assert.equal(launchPayload.status, "queued");
+  assert.equal(launchPayload.codex, undefined);
 
-  const status = run("node", [SCRIPT, "status"], {
-    cwd: repo,
-    env: buildEnv(binDir)
-  });
+  const finished = await waitFor(() => {
+    const status = run("node", [SCRIPT, "status", launchPayload.jobId, "--json"], { cwd: repo, env });
+    if (status.status !== 0) {
+      return null;
+    }
+    const snapshot = JSON.parse(status.stdout);
+    return snapshot.job.status === "completed" ? snapshot.job : null;
+  }, { timeoutMs: 20000 });
 
-  assert.equal(status.status, 0, status.stderr);
-  assert.match(status.stdout, /# Codex Status/);
-  assert.match(status.stdout, /Codex Review/);
-  assert.match(status.stdout, /completed/);
+  assert.equal(finished.kindLabel, "review");
+
+  const result = run("node", [SCRIPT, "result", launchPayload.jobId, "--full"], { cwd: repo, env });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /No material issues found/);
 });
 
 test("status shows phases, hints, and the latest finished job", () => {

--- a/tests/scheduler.test.mjs
+++ b/tests/scheduler.test.mjs
@@ -1,0 +1,246 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { makeTempDir } from "./helpers.mjs";
+import {
+  acquireWorkloadLease,
+  cancelQueuedWorkload,
+  getQueuePosition,
+  QueueWaitTimeoutError,
+  readSchedulerSnapshot,
+  releaseWorkloadLease,
+  resolveSchedulerDir
+} from "../plugins/codex/scripts/lib/scheduler.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SCHEDULER_MODULE = path.join(ROOT, "plugins", "codex", "scripts", "lib", "scheduler.mjs");
+
+function writeQueueRecord(schedulerDir, record) {
+  fs.mkdirSync(path.join(schedulerDir, "queue"), { recursive: true });
+  const file = path.join(schedulerDir, "queue", `${String(record.seq).padStart(12, "0")}-${record.jobId}.json`);
+  fs.writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+  return file;
+}
+
+function writeActiveRecord(schedulerDir, record) {
+  fs.mkdirSync(schedulerDir, { recursive: true });
+  fs.writeFileSync(path.join(schedulerDir, "active.json"), `${JSON.stringify(record, null, 2)}\n`, "utf8");
+}
+
+test("the scheduler directory is user-global rather than per repository or plugin data dir", () => {
+  const fallback = resolveSchedulerDir({ CLAUDE_PLUGIN_DATA: "/tmp/some-plugin-data" });
+  assert.equal(fallback, path.join(os.homedir(), ".claude", "cache", "codex-companion", "scheduler"));
+
+  const override = resolveSchedulerDir({ CODEX_COMPANION_SCHEDULER_DIR: "/tmp/custom-scheduler" });
+  assert.equal(override, path.resolve("/tmp/custom-scheduler"));
+});
+
+test("only one workload holds the lease at a time and queue position is reported", async () => {
+  const schedulerDir = makeTempDir("codex-scheduler-");
+  const first = await acquireWorkloadLease({ schedulerDir, jobId: "job-a", kind: "task" });
+  assert.equal(first.queueWaitMs >= 0, true);
+
+  const secondPromise = acquireWorkloadLease({ schedulerDir, jobId: "job-b", kind: "review" });
+  await new Promise((resolve) => setTimeout(resolve, 250));
+
+  const snapshot = readSchedulerSnapshot({ schedulerDir });
+  assert.equal(snapshot.active.jobId, "job-a");
+  assert.deepEqual(
+    snapshot.queue.map((entry) => entry.jobId),
+    ["job-b"]
+  );
+  assert.equal(getQueuePosition("job-b", { schedulerDir }), 1);
+  assert.equal(getQueuePosition("job-a", { schedulerDir }), 0);
+
+  first.release();
+  const second = await secondPromise;
+  assert.equal(second.jobId, "job-b");
+  // Queue wait is measured separately so it can never consume the execution deadline.
+  assert.equal(second.queueWaitMs >= 200, true);
+  second.release();
+
+  assert.equal(readSchedulerSnapshot({ schedulerDir }).active, null);
+});
+
+test("the queue is FIFO by monotonic sequence, not by filesystem timestamp", async () => {
+  const schedulerDir = makeTempDir("codex-scheduler-");
+  const held = await acquireWorkloadLease({ schedulerDir, jobId: "holder" });
+
+  const waiters = [];
+  for (const jobId of ["first", "second", "third"]) {
+    waiters.push(acquireWorkloadLease({ schedulerDir, jobId }));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+
+  const queued = readSchedulerSnapshot({ schedulerDir }).queue;
+  assert.deepEqual(
+    queued.map((entry) => entry.jobId),
+    ["first", "second", "third"]
+  );
+  assert.deepEqual(
+    queued.map((entry) => entry.seq),
+    [...queued.map((entry) => entry.seq)].sort((left, right) => left - right)
+  );
+
+  // Rewrite mtimes in reverse order: ordering must still follow the sequence numbers.
+  const queueFiles = fs
+    .readdirSync(path.join(schedulerDir, "queue"))
+    .map((entry) => path.join(schedulerDir, "queue", entry));
+  let offset = queueFiles.length;
+  for (const file of queueFiles) {
+    const when = new Date(Date.now() + offset * 1000);
+    fs.utimesSync(file, when, when);
+    offset -= 1;
+  }
+
+  const order = [];
+  held.release();
+  for (const waiter of waiters) {
+    const lease = await waiter;
+    order.push(lease.jobId);
+    lease.release();
+  }
+  assert.deepEqual(order, ["first", "second", "third"]);
+});
+
+test("six concurrent workloads from different workspaces run one at a time", async () => {
+  const schedulerDir = makeTempDir("codex-scheduler-");
+  const workerPath = path.join(schedulerDir, "worker.mjs");
+  const eventsPath = path.join(schedulerDir, "events.log");
+  fs.writeFileSync(
+    workerPath,
+    `import fs from "node:fs";
+import { acquireWorkloadLease } from ${JSON.stringify(SCHEDULER_MODULE)};
+
+const jobId = process.argv[2];
+const lease = await acquireWorkloadLease({ schedulerDir: ${JSON.stringify(schedulerDir)}, jobId, workspace: "/repo/" + jobId });
+fs.appendFileSync(${JSON.stringify(eventsPath)}, \`start \${jobId} \${Date.now()}\\n\`);
+await new Promise((resolve) => setTimeout(resolve, 120));
+fs.appendFileSync(${JSON.stringify(eventsPath)}, \`end \${jobId} \${Date.now()}\\n\`);
+lease.release();
+`,
+    "utf8"
+  );
+
+  const jobs = ["w1", "w2", "w3", "w4", "w5", "w6"];
+  await Promise.all(
+    jobs.map(
+      (jobId) =>
+        new Promise((resolve, reject) => {
+          const child = spawn(process.execPath, [workerPath, jobId], { stdio: ["ignore", "ignore", "pipe"] });
+          let stderr = "";
+          child.stderr.on("data", (chunk) => {
+            stderr += chunk;
+          });
+          child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`worker ${jobId} failed: ${stderr}`))));
+        })
+    )
+  );
+
+  const events = fs
+    .readFileSync(eventsPath, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => line.split(" "));
+  assert.equal(events.length, jobs.length * 2);
+
+  let open = 0;
+  for (const [kind] of events) {
+    open += kind === "start" ? 1 : -1;
+    assert.equal(open <= 1, true, "two Codex workloads held the lease at the same time");
+  }
+  assert.equal(readSchedulerSnapshot({ schedulerDir }).active, null);
+});
+
+test("cancelling a queued job never interrupts the active job and promotes the next waiter", async () => {
+  const schedulerDir = makeTempDir("codex-scheduler-");
+  const active = await acquireWorkloadLease({ schedulerDir, jobId: "active-job" });
+  const queued = acquireWorkloadLease({ schedulerDir, jobId: "queued-job" }).catch((error) => error);
+  const nextUp = acquireWorkloadLease({ schedulerDir, jobId: "next-job" });
+  await new Promise((resolve) => setTimeout(resolve, 200));
+
+  const cancelledQueued = cancelQueuedWorkload("queued-job", { schedulerDir });
+  assert.deepEqual(cancelledQueued, { removed: true, wasActive: false });
+  assert.equal(readSchedulerSnapshot({ schedulerDir }).active.jobId, "active-job");
+
+  const cancelActive = cancelQueuedWorkload("active-job", { schedulerDir });
+  assert.deepEqual(cancelActive, { removed: false, wasActive: true });
+
+  active.release();
+  const promoted = await nextUp;
+  assert.equal(promoted.jobId, "next-job");
+  promoted.release();
+
+  const cancelledWaiter = await queued;
+  assert.match(String(cancelledWaiter.message), /cancelled while it waited/i);
+});
+
+test("a live lease is not stolen when its heartbeat is briefly delayed", async () => {
+  const schedulerDir = makeTempDir("codex-scheduler-");
+  writeActiveRecord(schedulerDir, {
+    jobId: "live-owner",
+    seq: 1,
+    pid: process.pid,
+    heartbeatAt: new Date(Date.now() - 60000).toISOString()
+  });
+  writeQueueRecord(schedulerDir, {
+    jobId: "live-owner",
+    seq: 1,
+    pid: process.pid,
+    heartbeatAt: new Date(Date.now() - 60000).toISOString()
+  });
+
+  await assert.rejects(
+    acquireWorkloadLease({ schedulerDir, jobId: "waiter", waitTimeoutMs: 300, pollIntervalMs: 50 }),
+    QueueWaitTimeoutError
+  );
+  assert.equal(readSchedulerSnapshot({ schedulerDir }).active.jobId, "live-owner");
+});
+
+test("a dead owner with a stale heartbeat has its lease reclaimed", async () => {
+  const schedulerDir = makeTempDir("codex-scheduler-");
+  const deadPid = 2147483646;
+  writeActiveRecord(schedulerDir, {
+    jobId: "dead-owner",
+    seq: 1,
+    pid: deadPid,
+    heartbeatAt: new Date(Date.now() - 60000).toISOString()
+  });
+  writeQueueRecord(schedulerDir, { jobId: "dead-owner", seq: 1, pid: deadPid });
+
+  const lease = await acquireWorkloadLease({ schedulerDir, jobId: "waiter", waitTimeoutMs: 3000 });
+  assert.equal(lease.jobId, "waiter");
+  assert.equal(readSchedulerSnapshot({ schedulerDir }).active.jobId, "waiter");
+  lease.release();
+});
+
+test("concurrent enqueue and cancel keep the queue consistent", async () => {
+  const schedulerDir = makeTempDir("codex-scheduler-");
+  const active = await acquireWorkloadLease({ schedulerDir, jobId: "holder" });
+
+  const waiters = ["a", "b", "c", "d"].map((jobId) =>
+    acquireWorkloadLease({ schedulerDir, jobId, waitTimeoutMs: 5000 }).catch((error) => error)
+  );
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  cancelQueuedWorkload("b", { schedulerDir });
+  cancelQueuedWorkload("c", { schedulerDir });
+
+  const remaining = readSchedulerSnapshot({ schedulerDir }).queue.map((entry) => entry.jobId);
+  assert.deepEqual(remaining, ["a", "d"]);
+
+  active.release();
+  for (const waiter of waiters) {
+    const result = await waiter;
+    if (result instanceof Error) {
+      continue;
+    }
+    result.release();
+  }
+  releaseWorkloadLease({ schedulerDir, jobId: "holder" });
+  assert.equal(readSchedulerSnapshot({ schedulerDir }).active, null);
+});


### PR DESCRIPTION
Hardens the companion runtime against the invocation failures I kept hitting in practice (stdin-open hangs, silent timeouts, unbounded review logs, overlapping codex processes), per the amendment spec from the 2026-08-13 setup checkpoint.

What's in here:

- **User-global FIFO queue** for every Codex workload, with a queue-wait budget (`--queue-wait-ms`) and a busy-broker wait instead of a second concurrent Codex.
- **One hardened launcher** for every plugin-owned `codex exec` call — stdin never inherited, whole-run deadline that covers broker connect/initialize (not just the turn), SIGTERM→SIGKILL escalation, exit codes keep signals visible. Collab and image-gen now route through it too.
- **New stateless `consult` command** — read-only, fresh ephemeral thread, prompt from `--prompt-file` only, own execution timeout, works in non-Git cwd without caller flags, rejects `--write`. Returns a bounded result envelope; timeout/launch-failure/invalid-output all become `verdict: inconclusive` and the failure envelope is persisted for `result`.
- **Bounded output everywhere** — structured review output validated against the full documented finding shape (malformed output can never become an approval), envelopes byte-capped per field and in total, JSON mode measured on the pretty-printed bytes actually emitted, progress logs capped, timed-out runs stay reachable in `result`.
- **`--help` answered at dispatch** for every command — previously `review --help` launched a real blocking review (it hung an adversarial reviewer for 70 minutes, which is how I found it).
- Native built-in reviews now parse into the same envelope as adversarial ones.

Review: two adversarial GPT-5.6 rounds on the diff; round 1 found one blocker (permissive envelope validation) and six highs, round 2 confirmed five closed and caught a collab `status`-vs-`exitCode` bug that would have made every successful collab run report failure — all closed in the final round with tests.

Tests: 577+ new test lines (hardening, scheduler, exec-launcher, consult). Also fixed the suite inheriting a live Claude session's state, which turns out to have been the cause of four long-standing "environment-dependent" failures. Known remaining failure that predates this branch: `continue is not exposed as a user-facing command`. One watch item: the SIGKILL-escalation test flaked once under full parallel suite load (passes in isolation and on repeat full runs).

Follow-up (not in this PR): point the subagent guardrails at `consult` as the blessed second-opinion entry point once this is on the branch the live plugin loads from.
