### PR TITLE
fix: rewrite session env exports instead of appending them

### DIFF
--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -32,11 +32,51 @@ function shellEscape(value) {
   return `'${String(value).replace(/'/g, `'\"'\"'`)}'`;
 }
 
-function appendEnvVar(name, value) {
-  if (!process.env.CLAUDE_ENV_FILE || value == null || value === "") {
+const MANAGED_ENV_VARS = [SESSION_ID_ENV, TRANSCRIPT_PATH_ENV, PLUGIN_DATA_ENV];
+
+function isManagedExport(line) {
+  return MANAGED_ENV_VARS.some((name) => line.startsWith(`export ${name}=`));
+}
+
+// Rewrite this plugin's exports instead of appending them. SessionStart fires on
+// startup, on resume and on every compaction, so appending grew CLAUDE_ENV_FILE by
+// three lines every time and nothing ever pruned it. Only the last assignment of a
+// name takes effect, so every earlier copy did nothing but grow the file. Claude Code
+// inlines the whole file into the single `bash -c <script>` argument, so a long-running
+// session eventually pushed that argument past the operating system's limit on the
+// length of one argument, and no shell could be started at all.
+function writeManagedEnvVars(entries) {
+  const envFile = process.env.CLAUDE_ENV_FILE;
+  if (!envFile) {
     return;
   }
-  fs.appendFileSync(process.env.CLAUDE_ENV_FILE, `export ${name}=${shellEscape(value)}\n`, "utf8");
+
+  let existing = "";
+  try {
+    existing = fs.readFileSync(envFile, "utf8");
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  // Keep every line another plugin wrote, verbatim; drop only our own.
+  const lines = existing.split(/\r?\n/).filter((line) => line !== "" && !isManagedExport(line));
+  for (const [name, value] of entries) {
+    if (value != null && value !== "") {
+      lines.push(`export ${name}=${shellEscape(value)}`);
+    }
+  }
+
+  const next = lines.length > 0 ? `${lines.join("\n")}\n` : "";
+  if (next === existing) {
+    return;
+  }
+
+  // Write and rename, so that a reader never sees a half-written file.
+  const tmpFile = `${envFile}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpFile, next, "utf8");
+  fs.renameSync(tmpFile, envFile);
 }
 
 function cleanupSessionJobs(cwd, sessionId) {
@@ -75,9 +115,11 @@ function cleanupSessionJobs(cwd, sessionId) {
 }
 
 function handleSessionStart(input) {
-  appendEnvVar(SESSION_ID_ENV, input.session_id);
-  appendEnvVar(TRANSCRIPT_PATH_ENV, input.transcript_path);
-  appendEnvVar(PLUGIN_DATA_ENV, process.env[PLUGIN_DATA_ENV]);
+  writeManagedEnvVars([
+    [SESSION_ID_ENV, input.session_id],
+    [TRANSCRIPT_PATH_ENV, input.transcript_path],
+    [PLUGIN_DATA_ENV, process.env[PLUGIN_DATA_ENV]]
+  ]);
 }
 
 async function handleSessionEnd(input) {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -698,6 +698,126 @@ test("session start hook exports the Claude session id, transcript path, and plu
   );
 });
 
+function runSessionStartHook({ repo, envFile, pluginDataDir, sessionId, transcriptPath }) {
+  return run("node", [SESSION_HOOK, "SessionStart"], {
+    cwd: repo,
+    env: {
+      ...process.env,
+      CLAUDE_ENV_FILE: envFile,
+      CLAUDE_PLUGIN_DATA: pluginDataDir
+    },
+    input: JSON.stringify({
+      hook_event_name: "SessionStart",
+      session_id: sessionId,
+      transcript_path: transcriptPath,
+      cwd: repo
+    })
+  });
+}
+
+function managedExports({ sessionId, transcriptPath, pluginDataDir }) {
+  return (
+    `export CODEX_COMPANION_SESSION_ID='${sessionId}'\n` +
+    `export CODEX_COMPANION_TRANSCRIPT_PATH='${transcriptPath}'\n` +
+    `export CLAUDE_PLUGIN_DATA='${pluginDataDir}'\n`
+  );
+}
+
+test("session start hook does not accumulate exports when it fires repeatedly", () => {
+  const repo = makeTempDir();
+  const envFile = path.join(makeTempDir(), "claude-env.sh");
+  fs.writeFileSync(envFile, "", "utf8");
+  const pluginDataDir = makeTempDir();
+  const transcriptPath = path.join(repo, "session.jsonl");
+  const expected = managedExports({ sessionId: "sess-current", transcriptPath, pluginDataDir });
+
+  // SessionStart fires again on every resume and every compaction of the same session.
+  for (let firing = 1; firing <= 5; firing += 1) {
+    const result = runSessionStartHook({
+      repo,
+      envFile,
+      pluginDataDir,
+      sessionId: "sess-current",
+      transcriptPath
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.readFileSync(envFile, "utf8"), expected, `after firing ${firing}`);
+  }
+});
+
+test("session start hook prunes exports an earlier version left behind", () => {
+  const repo = makeTempDir();
+  const envFile = path.join(makeTempDir(), "claude-env.sh");
+  const pluginDataDir = makeTempDir();
+  const transcriptPath = path.join(repo, "session.jsonl");
+  const expected = managedExports({ sessionId: "sess-current", transcriptPath, pluginDataDir });
+
+  // The state a session is already in after a version that appended on every firing:
+  // hundreds of copies, of which only the last has any effect.
+  fs.writeFileSync(envFile, expected.repeat(500), "utf8");
+
+  const result = runSessionStartHook({
+    repo,
+    envFile,
+    pluginDataDir,
+    sessionId: "sess-current",
+    transcriptPath
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.readFileSync(envFile, "utf8"), expected);
+});
+
+test("session start hook keeps env file lines written by anything else", () => {
+  const repo = makeTempDir();
+  const envFile = path.join(makeTempDir(), "claude-env.sh");
+  const pluginDataDir = makeTempDir();
+  const transcriptPath = path.join(repo, "session.jsonl");
+  const expected = managedExports({ sessionId: "sess-current", transcriptPath, pluginDataDir });
+  const other = "export OTHER_PLUGIN_VALUE='keep-me'\n";
+
+  fs.writeFileSync(envFile, `${other}${expected.repeat(3)}`, "utf8");
+
+  for (let firing = 1; firing <= 2; firing += 1) {
+    const result = runSessionStartHook({
+      repo,
+      envFile,
+      pluginDataDir,
+      sessionId: "sess-current",
+      transcriptPath
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.readFileSync(envFile, "utf8"), `${other}${expected}`, `after firing ${firing}`);
+  }
+});
+
+test("session start hook replaces exports that hold a stale value", () => {
+  const repo = makeTempDir();
+  const envFile = path.join(makeTempDir(), "claude-env.sh");
+  const pluginDataDir = makeTempDir();
+  const transcriptPath = path.join(repo, "session.jsonl");
+
+  fs.writeFileSync(
+    envFile,
+    managedExports({ sessionId: "sess-previous", transcriptPath, pluginDataDir }),
+    "utf8"
+  );
+
+  const result = runSessionStartHook({
+    repo,
+    envFile,
+    pluginDataDir,
+    sessionId: "sess-current",
+    transcriptPath
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    fs.readFileSync(envFile, "utf8"),
+    managedExports({ sessionId: "sess-current", transcriptPath, pluginDataDir })
+  );
+});
+
 test("write task output focuses on the Codex result without generic follow-up hints", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
Fixes #528. #322 reported the same defect earlier and was closed without the fix landing, so this adds regression tests as well.

## The defect

`handleSessionStart` appends three `export` lines to `CLAUDE_ENV_FILE` every time it runs, and `SessionStart` fires on startup, on resume, and on every compaction. Nothing prunes. Only the last assignment of a name has any effect, so every earlier copy is dead weight.

Claude Code inlines the whole env file into the single `bash -c <script>` argument it spawns. On Linux a single argv element is capped at `MAX_ARG_STRLEN` = 32 pages = 131072 bytes — a separate limit from `ARG_MAX`, and `ulimit` doesn't move it. Once the accumulated prelude crosses it, `execve` fails with `E2BIG` and **no shell starts at all**: every Bash tool call fails regardless of how short the command is.

```
Error: Could not start /bin/bash: the command line plus environment exceed the OS exec argument limit (E2BIG).
At spawn: command line 133.3KB across 3 args (largest single arg 133.3KB); environment 4.5KB across 81 vars
```

The env file involved is `~/.claude/session-env/<session-id>/sessionstart-hook-0.sh`, one per session; the one that broke my session had reached 136770 bytes. On Windows the same growth truncates the command line at 8191 characters, which is how #528 was originally reported.

## The change

Rewrite this plugin's exports instead of appending them: drop lines that assign one of the three names this plugin owns, keep every other line verbatim, append the current values, and skip the write entirely when the result is byte-identical to what's already there. The write goes to a temp file and is renamed, so a reader never sees a half-written file.

## Why a rewrite rather than a skip-if-duplicate append

This is the part that matters for anyone already affected. Both #558 and #386 keep the append and return early when the last `export <name>=` line already matches. That stops *future* growth on a fresh file, but it never removes anything — and because the env file is per-session, the last assignment of each name in an already-bloated file *is* byte-identical to what the hook would write. So the early return fires, nothing is pruned, and a session that is already over the limit stays broken until the user deletes the file by hand.

Measured by firing the real hook against a seeded env file (one unrelated co-tenant line, same `session_id` every time, since the file is keyed by session id in its own path):

| after N firings, starting empty | current `main` | #558 / #386 | this PR |
|---|---|---|---|
| 1 | 4 lines / 302 B | 4 / 302 | 4 / 302 |
| 2 | 7 / 568 | 4 / 302 | 4 / 302 |
| 3 | 10 / 834 | 4 / 302 | 4 / 302 |
| 5 | 16 / 1366 | 4 / 302 | 4 / 302 |

| after N firings on a file already grown to 151 lines / 13336 B | #558 / #386 | this PR |
|---|---|---|
| 1 | 151 lines / 13336 B | **4 / 302** |
| 3 | 151 / 13336 | 4 / 302 |

## Trade-off worth knowing about

This is a read-modify-write on a file other plugins may also append to, so a sibling `SessionStart` hook appending between the read and the rename would lose that write. The current append is atomic and has no such window. The exposure is small — the read-filter-write-rename is microseconds, it happens at most once per session-start event, and the skip-if-unchanged check means the steady state performs no write at all — but it is real, and it is presumably why the other two PRs stayed append-only.

If that window is unacceptable, the two approaches can be combined: prune the plugin's own lines once, then keep the values in a plugin-owned file under `CLAUDE_PLUGIN_DATA` and leave a single constant `[ -f … ] && . …` line in the shared file. Steady state then never writes to the shared file, and a changed value is picked up by rewriting the owned file, which nobody else touches. I did not do that here because it makes the shared file depend on being executed as shell rather than parsed, which is a stronger assumption about the host than the current plain `export` lines need. Happy to switch if you'd prefer it.

## Tests

Four tests added to `tests/runtime.test.mjs`, all of which fail on `main` and pass with this change:

- repeated firings don't accumulate exports
- an env file left bloated by an earlier version is pruned back to one copy
- lines written by anything else are preserved verbatim
- a stale value is replaced rather than shadowed

The existing `session start hook exports the Claude session id, transcript path, and plugin data dir` test is unchanged and still passes — the output for a fresh env file is byte-identical to before.

Local `npm test`: 87 pass / 4 fail out of 91 on `main`, and 91 pass / 4 fail out of 95 with this change — four new tests, four new passes, and the same four failures before and after (`status shows phases…`, `status preserves adversarial review kind labels`, `result returns the stored output…`, `resolveStateDir uses a temp-backed per-workspace directory`). Those four are unrelated to this change and look like they need the real Codex CLI, which CI installs and my machine doesn't have.
