### PR TITLE
Fix duplicate SessionStart exports in CLAUDE_ENV_FILE

### DIFF
--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -37,18 +37,27 @@ function appendEnvVar(name, value) {
     return;
   }
 
-  const line = `export ${name}=${shellEscape(value)}\n`;
+  const line = `export ${name}=${shellEscape(value)}`;
+
+  let lines = [];
 
   try {
-    const existing = fs.readFileSync(process.env.CLAUDE_ENV_FILE, "utf8");
-    if (existing.includes(line)) {
-      return;
-    }
+    lines = fs
+      .readFileSync(process.env.CLAUDE_ENV_FILE, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .filter((l) => !l.startsWith(`export ${name}=`));
   } catch {
-    // File doesn't exist yet
+    // File doesn't exist yet.
   }
 
-  fs.appendFileSync(process.env.CLAUDE_ENV_FILE, line, "utf8");
+  lines.push(line);
+
+  fs.writeFileSync(
+    process.env.CLAUDE_ENV_FILE,
+    lines.join("\n") + "\n",
+    "utf8"
+  );
 }
 
 function cleanupSessionJobs(cwd, sessionId) {

--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -36,7 +36,19 @@ function appendEnvVar(name, value) {
   if (!process.env.CLAUDE_ENV_FILE || value == null || value === "") {
     return;
   }
-  fs.appendFileSync(process.env.CLAUDE_ENV_FILE, `export ${name}=${shellEscape(value)}\n`, "utf8");
+
+  const line = `export ${name}=${shellEscape(value)}\n`;
+
+  try {
+    const existing = fs.readFileSync(process.env.CLAUDE_ENV_FILE, "utf8");
+    if (existing.includes(line)) {
+      return;
+    }
+  } catch {
+    // File doesn't exist yet
+  }
+
+  fs.appendFileSync(process.env.CLAUDE_ENV_FILE, line, "utf8");
 }
 
 function cleanupSessionJobs(cwd, sessionId) {


### PR DESCRIPTION
Closes #661

## Summary

Prevent duplicate environment variable exports from being appended to `CLAUDE_ENV_FILE` on every `SessionStart` event.

## Changes

- Make `appendEnvVar()` idempotent.
- Skip writing an export line if it already exists.

## Testing

- Ran the project's test suite.
- Verified repeated `SessionStart` events no longer append duplicate export lines.