### PR TITLE
fix: allow SessionStart hook more time to restore state

### DIFF
--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-lifecycle-hook.mjs\" SessionStart",
-            "timeout": 5
+            "timeout": 60
           }
         ]
       }

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -210,6 +210,13 @@ test("hooks keep session-end cleanup and stop gating enabled", () => {
   assert.match(source, /session-lifecycle-hook\.mjs/);
 });
 
+test("session start hook allows enough time to restore session state", () => {
+  const hooks = JSON.parse(read("hooks/hooks.json"));
+  const sessionStartHook = hooks.hooks.SessionStart[0].hooks[0];
+
+  assert.equal(sessionStartHook.timeout, 60);
+});
+
 test("setup command can offer Codex install and still points users to codex login", () => {
   const setup = read("commands/setup.md");
   const readme = fs.readFileSync(path.join(ROOT, "README.md"), "utf8");


### PR DESCRIPTION
## Summary
- increase the Codex `SessionStart` hook timeout from 5 seconds to 60 seconds
- add a manifest-level regression test so the timeout does not regress

Fixes #670.

## Validation
- `npm test` (92 passed)
- `npx tsc -p tsconfig.app-server.json --noEmit`
- `python3 -m json.tool plugins/codex/hooks/hooks.json`
- `git diff --check`

`npm run build` could not run because the local prebuild command resolves a missing global Codex binary (`codex app-server generate-ts`, `ENOENT`).
