### PR TITLE
feat: recognize OrcaRouter as a first-class provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,3 +318,19 @@ Yes. If you already use Codex, the plugin picks up the same [configuration](#com
 Yes. Because the plugin uses your local Codex CLI, your existing sign-in method and config still apply.
 
 If you need to point the built-in OpenAI provider at a different endpoint, set `openai_base_url` in your [Codex config](https://developers.openai.com/codex/config-advanced/#config-and-state-locations).
+
+### Can I use another model provider?
+
+Yes. The plugin reflects the active provider from your Codex config, so you can route Codex through any provider Codex supports by defining it under `[model_providers]`. For example, to use [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible AI gateway, add this to your `~/.codex/config.toml`:
+
+```toml
+model = "anthropic/claude-sonnet-5"
+model_provider = "orcarouter"
+
+[model_providers.orcarouter]
+name = "OrcaRouter"
+base_url = "https://api.orcarouter.ai/v1"
+env_key = "ORCAROUTER_API_KEY"
+```
+
+After that, `/codex:setup` and `/codex:status` show `OrcaRouter` as the active provider.

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -758,7 +758,8 @@ function buildResultStatus(turnState) {
 const BUILTIN_PROVIDER_LABELS = new Map([
   ["openai", "OpenAI"],
   ["ollama", "Ollama"],
-  ["lmstudio", "LM Studio"]
+  ["lmstudio", "LM Studio"],
+  ["orcarouter", "OrcaRouter"]
 ]);
 
 function normalizeProviderId(value) {

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -72,6 +72,7 @@ function buildAccountReadResult() {
       return { account: null, requiresOpenaiAuth: true };
     case "provider-no-auth":
     case "env-key-provider":
+    case "orcarouter-provider":
       return { account: null, requiresOpenaiAuth: false };
     case "api-key-account-only":
       return { account: { type: "apiKey" }, requiresOpenaiAuth: true };
@@ -98,6 +99,21 @@ function buildConfigReadResult() {
             "openai-custom": {
               name: "OpenAI custom",
               env_key: "OPENAI_API_KEY",
+              requires_openai_auth: false
+            }
+          }
+        },
+        origins: {}
+      };
+    case "orcarouter-provider":
+      return {
+        config: {
+          model_provider: "orcarouter",
+          model_providers: {
+            orcarouter: {
+              name: "OrcaRouter",
+              base_url: "https://api.orcarouter.ai/v1",
+              env_key: "ORCAROUTER_API_KEY",
               requires_openai_auth: false
             }
           }

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -119,6 +119,43 @@ test("setup treats custom providers with app-server-ready config as ready", () =
   assert.match(payload.auth.detail, /configured and does not require OpenAI authentication/i);
 });
 
+test("setup recognizes OrcaRouter as the active provider without OpenAI auth", () => {
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "orcarouter-provider");
+
+  const result = run("node", [SCRIPT, "setup", "--json"], {
+    cwd: ROOT,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.ready, true);
+  assert.equal(payload.auth.loggedIn, true);
+  assert.equal(payload.auth.authMethod, null);
+  assert.equal(payload.auth.source, "app-server");
+  assert.equal(payload.auth.provider, "orcarouter");
+  assert.match(payload.auth.detail, /OrcaRouter is configured and does not require OpenAI authentication/i);
+});
+
+test("task runs when OrcaRouter is the active provider", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "orcarouter-provider");
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const result = run("node", [SCRIPT, "task", "check orcarouter provider"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Handled the requested task/);
+});
+
 test("setup reports not ready when app-server config read fails", () => {
   const binDir = makeTempDir();
   installFakeCodex(binDir, "config-read-fails");


### PR DESCRIPTION
## Summary

The Codex plugin for Claude Code is for Claude Code users who want an easy way to start using Codex from the workflow they already have. It delegates everything through your local Codex CLI, which means the model provider you use is the one Codex itself is configured with.

Right now, when the active provider isn't one of the built-ins, `/codex:setup` and `/codex:status` just print the raw provider id — so a user pointing Codex at a custom OpenAI-compatible gateway sees an unfriendly identifier instead of the service they actually configured.

This PR makes [OrcaRouter](https://www.orcarouter.ai) a first-class, named provider in the same way the plugin already treats OpenAI, Ollama, and LM Studio.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`plugins/codex/scripts/lib/codex.mjs`** — added `orcarouter` to the built-in provider label map (mirroring `openai` / `ollama` / `lmstudio`), so a user whose Codex config selects `model_provider = "orcarouter"` sees **OrcaRouter** as the active provider in `/codex:setup` and `/codex:status` instead of the raw id.
- **`README.md`** — added a "Can I use another model provider?" FAQ entry that shows the exact `config.toml` snippet for routing Codex through OrcaRouter (`base_url = "https://api.orcarouter.ai/v1"`, `env_key = "ORCAROUTER_API_KEY"`), alongside the existing `openai_base_url` guidance.
- **`tests/fake-codex-fixture.mjs` + `tests/runtime.test.mjs`** — new `orcarouter-provider` fixture and two tests covering setup readiness and task execution when OrcaRouter is the active provider.

## Validation

- `npm test` — 93/93 passing (91 baseline + 2 new).
- `npm run build` (tsc + `codex app-server generate-ts`) — clean.
- `npm run check-version` — version metadata consistent.
- Live check: ran the plugin's `/codex:setup` against a real Codex config pointed at `https://api.orcarouter.ai/v1` with `model_provider = "orcarouter"` — it reports `provider: orcarouter` and "OrcaRouter is configured and does not require OpenAI authentication".
- Live check: ran `codex exec` through that same config — Codex resolved `provider: orcarouter` and completed a real task against the OrcaRouter endpoint (HTTP 200).

## Usage

To route this plugin's Codex runs through OrcaRouter, add to `~/.codex/config.toml`:

```toml
model = "anthropic/claude-sonnet-5"
model_provider = "orcarouter"

[model_providers.orcarouter]
name = "OrcaRouter"
base_url = "https://api.orcarouter.ai/v1"
env_key = "ORCAROUTER_API_KEY"
```

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
