### PR TITLE
fix(broker): shut down the app-server broker after an idle timeout

### DIFF
--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -111,10 +111,18 @@ async function main() {
   const sockets = new Set();
   let idleTimer = null;
 
+  // Ownership can outlive its socket: a client can disconnect while its streaming request
+  // is still awaiting a response, and the response then assigns the already-closed socket
+  // to activeStreamSocket. A destroyed socket has nobody listening, so treating it as
+  // "busy" would pin the broker open forever if turn/completed never arrives.
+  function ownershipIsLive(socket) {
+    return socket !== null && !socket.destroyed;
+  }
+
   // Idle means nobody is connected AND nothing is in flight. Holding an open socket is
   // enough to keep the broker alive, so a long streaming turn can never be cut short.
   function isIdle() {
-    return sockets.size === 0 && activeRequestSocket === null && activeStreamSocket === null;
+    return sockets.size === 0 && !ownershipIsLive(activeRequestSocket) && !ownershipIsLive(activeStreamSocket);
   }
 
   function disarmIdleTimer() {
@@ -170,6 +178,9 @@ async function main() {
         if (activeRequestSocket === target) {
           activeRequestSocket = null;
         }
+        // The socket that owned this stream may already be gone, in which case no close
+        // handler will fire again -- schedule here or the broker never idles out.
+        armIdleTimer();
       }
     }
   }
@@ -288,6 +299,7 @@ async function main() {
           if (activeRequestSocket === socket) {
             activeRequestSocket = null;
           }
+          armIdleTimer();
         } catch (error) {
           send(socket, {
             id: message.id,
@@ -299,6 +311,7 @@ async function main() {
           if (activeStreamSocket === socket && !isStreaming) {
             activeStreamSocket = null;
           }
+          armIdleTimer();
         }
       }
     });

--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -17,6 +17,10 @@ const STREAMING_METHODS = new Set(["turn/start", "review/start", "thread/compact
 // whether it is serving anyone -- an external sweep cannot, and racing one is unsafe.
 const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 const IDLE_TIMEOUT_ENV = "CODEX_COMPANION_BROKER_IDLE_MS";
+// setTimeout() overflows above 2^31-1 ms: it warns and then fires after 1ms, so an
+// over-large timeout would shut the broker down almost immediately -- the exact opposite
+// of what was asked for. Reject instead, so the mistake is visible at startup.
+const MAX_IDLE_TIMEOUT_MS = 2147483647;
 
 function resolveIdleTimeoutMs(rawOption, env = {}) {
   const raw = rawOption ?? env[IDLE_TIMEOUT_ENV];
@@ -33,6 +37,11 @@ function resolveIdleTimeoutMs(rawOption, env = {}) {
   if (!Number.isFinite(parsed) || parsed < 0) {
     throw new Error(
       `Invalid idle timeout ${JSON.stringify(text)}: expected a non-negative number of milliseconds.`
+    );
+  }
+  if (parsed > MAX_IDLE_TIMEOUT_MS) {
+    throw new Error(
+      `Invalid idle timeout ${JSON.stringify(text)}: must be at most ${MAX_IDLE_TIMEOUT_MS} ms (Node timer limit).`
     );
   }
   return parsed;
@@ -166,11 +175,16 @@ async function main() {
   }
 
   async function shutdown(server) {
+    // Stop accepting FIRST. server.close() stops listening immediately and resolves once
+    // existing connections drain. Tearing down the app server first would leave the
+    // endpoint accepting throughout that await, so ensureBrokerSession's readiness probe
+    // could connect, judge a shutting-down broker "ready", and then lose the connection.
+    const closed = new Promise((resolve) => server.close(resolve));
     for (const socket of sockets) {
       socket.end();
     }
+    await closed;
     await appClient.close().catch(() => {});
-    await new Promise((resolve) => server.close(resolve));
     if (listenTarget.kind === "unix" && fs.existsSync(listenTarget.path)) {
       fs.unlinkSync(listenTarget.path);
     }

--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -113,16 +113,25 @@ async function main() {
 
   // Ownership can outlive its socket: a client can disconnect while its streaming request
   // is still awaiting a response, and the response then assigns the already-closed socket
-  // to activeStreamSocket. A destroyed socket has nobody listening, so treating it as
-  // "busy" would pin the broker open forever if turn/completed never arrives.
-  function ownershipIsLive(socket) {
-    return socket !== null && !socket.destroyed;
+  // to activeStreamSocket. Release it at every point where ownership is inspected, rather
+  // than teaching one check to tolerate it -- the idle check, the notification target and
+  // the busy guard must never disagree about whether the broker is in use. A stale owner
+  // that only the idle check ignored would leave the broker rejecting every new client
+  // with BROKER_BUSY while a connected client also kept it from ever shutting down.
+  function releaseDeadOwnership() {
+    if (activeRequestSocket !== null && activeRequestSocket.destroyed) {
+      activeRequestSocket = null;
+    }
+    if (activeStreamSocket !== null && activeStreamSocket.destroyed) {
+      activeStreamSocket = null;
+      activeStreamThreadIds = null;
+    }
   }
 
   // Idle means nobody is connected AND nothing is in flight. Holding an open socket is
   // enough to keep the broker alive, so a long streaming turn can never be cut short.
   function isIdle() {
-    return sockets.size === 0 && !ownershipIsLive(activeRequestSocket) && !ownershipIsLive(activeStreamSocket);
+    return sockets.size === 0 && activeRequestSocket === null && activeStreamSocket === null;
   }
 
   function disarmIdleTimer() {
@@ -134,11 +143,13 @@ async function main() {
 
   function armIdleTimer() {
     disarmIdleTimer();
+    releaseDeadOwnership();
     if (idleTimeoutMs <= 0 || !isIdle()) {
       return;
     }
     idleTimer = setTimeout(() => {
       idleTimer = null;
+      releaseDeadOwnership();
       // Re-check at fire time: a client may have connected while the timer was pending.
       if (!isIdle()) {
         armIdleTimer();
@@ -165,6 +176,7 @@ async function main() {
   }
 
   function routeNotification(message) {
+    releaseDeadOwnership();
     const target = activeRequestSocket ?? activeStreamSocket;
     if (!target) {
       return;
@@ -208,6 +220,7 @@ async function main() {
 
   const server = net.createServer((socket) => {
     disarmIdleTimer();
+    releaseDeadOwnership();
     sockets.add(socket);
     socket.setEncoding("utf8");
     let buffer = "";
@@ -259,6 +272,7 @@ async function main() {
           continue;
         }
 
+        releaseDeadOwnership();
         const allowInterruptDuringActiveStream =
           isInterruptRequest(message) && activeStreamSocket && activeStreamSocket !== socket && !activeRequestSocket;
 

--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -11,6 +11,33 @@ import { parseBrokerEndpoint } from "./lib/broker-endpoint.mjs";
 
 const STREAMING_METHODS = new Set(["turn/start", "review/start", "thread/compact/start"]);
 
+// A broker outlives the client that spawned it: nothing in the protocol tells it the
+// client is gone for good, so without this it stays resident forever holding its socket
+// dir. Idle shutdown is decided BY THE BROKER because it is the only party that can see
+// whether it is serving anyone -- an external sweep cannot, and racing one is unsafe.
+const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+const IDLE_TIMEOUT_ENV = "CODEX_COMPANION_BROKER_IDLE_MS";
+
+function resolveIdleTimeoutMs(rawOption, env = {}) {
+  const raw = rawOption ?? env[IDLE_TIMEOUT_ENV];
+  // Trim before the emptiness test: Number("  ") is 0, so a blank or whitespace-only
+  // value would otherwise DISABLE idle shutdown silently. Explicit "0" is the only
+  // way to turn it off; anything blank falls back to the default.
+  const text = raw === undefined || raw === null ? "" : String(raw).trim();
+  if (text === "") {
+    return DEFAULT_IDLE_TIMEOUT_MS;
+  }
+  const parsed = Number(text);
+  // Reject rather than silently falling back: a typo'd timeout that quietly became
+  // "never expire" would reintroduce the exact leak this exists to close.
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(
+      `Invalid idle timeout ${JSON.stringify(text)}: expected a non-negative number of milliseconds.`
+    );
+  }
+  return parsed;
+}
+
 function buildStreamThreadIds(method, params, result) {
   const threadIds = new Set();
   if (params?.threadId) {
@@ -48,11 +75,13 @@ function writePidFile(pidFile) {
 async function main() {
   const [subcommand, ...argv] = process.argv.slice(2);
   if (subcommand !== "serve") {
-    throw new Error("Usage: node scripts/app-server-broker.mjs serve --endpoint <value> [--cwd <path>] [--pid-file <path>]");
+    throw new Error(
+      "Usage: node scripts/app-server-broker.mjs serve --endpoint <value> [--cwd <path>] [--pid-file <path>] [--idle-timeout <ms>]"
+    );
   }
 
   const { options } = parseArgs(argv, {
-    valueOptions: ["cwd", "pid-file", "endpoint"]
+    valueOptions: ["cwd", "pid-file", "endpoint", "idle-timeout"]
   });
 
   if (!options.endpoint) {
@@ -63,6 +92,7 @@ async function main() {
   const endpoint = String(options.endpoint);
   const listenTarget = parseBrokerEndpoint(endpoint);
   const pidFile = options["pid-file"] ? path.resolve(options["pid-file"]) : null;
+  const idleTimeoutMs = resolveIdleTimeoutMs(options["idle-timeout"], process.env);
   writePidFile(pidFile);
 
   const appClient = await CodexAppServerClient.connect(cwd, { disableBroker: true });
@@ -70,6 +100,42 @@ async function main() {
   let activeStreamSocket = null;
   let activeStreamThreadIds = null;
   const sockets = new Set();
+  let idleTimer = null;
+
+  // Idle means nobody is connected AND nothing is in flight. Holding an open socket is
+  // enough to keep the broker alive, so a long streaming turn can never be cut short.
+  function isIdle() {
+    return sockets.size === 0 && activeRequestSocket === null && activeStreamSocket === null;
+  }
+
+  function disarmIdleTimer() {
+    if (idleTimer) {
+      clearTimeout(idleTimer);
+      idleTimer = null;
+    }
+  }
+
+  function armIdleTimer() {
+    disarmIdleTimer();
+    if (idleTimeoutMs <= 0 || !isIdle()) {
+      return;
+    }
+    idleTimer = setTimeout(() => {
+      idleTimer = null;
+      // Re-check at fire time: a client may have connected while the timer was pending.
+      if (!isIdle()) {
+        armIdleTimer();
+        return;
+      }
+      void shutdown(server).then(
+        () => process.exit(0),
+        () => process.exit(0)
+      );
+    }, idleTimeoutMs);
+    // The listening server keeps the event loop alive; the timer must not do so itself,
+    // or a broker with idle shutdown disabled could never exit cleanly.
+    idleTimer.unref();
+  }
 
   function clearSocketOwnership(socket) {
     if (activeRequestSocket === socket) {
@@ -116,6 +182,7 @@ async function main() {
   appClient.setNotificationHandler(routeNotification);
 
   const server = net.createServer((socket) => {
+    disarmIdleTimer();
     sockets.add(socket);
     socket.setEncoding("utf8");
     let buffer = "";
@@ -225,11 +292,13 @@ async function main() {
     socket.on("close", () => {
       sockets.delete(socket);
       clearSocketOwnership(socket);
+      armIdleTimer();
     });
 
     socket.on("error", () => {
       sockets.delete(socket);
       clearSocketOwnership(socket);
+      armIdleTimer();
     });
   });
 
@@ -243,7 +312,9 @@ async function main() {
     process.exit(0);
   });
 
-  server.listen(listenTarget.path);
+  server.listen(listenTarget.path, () => {
+    armIdleTimer();
+  });
 }
 
 main().catch((error) => {

--- a/tests/broker-idle.test.mjs
+++ b/tests/broker-idle.test.mjs
@@ -235,3 +235,43 @@ test("broker still idles out after a client abandons a streaming request", async
   assert.ok(result, `broker stayed resident after the client abandoned a stream: ${broker.stderr()}`);
   assert.equal(result.code, 0);
 });
+
+test("broker serves a reconnecting client after a stream was abandoned", async (t) => {
+  // Releasing a dead owner only inside the idle check is not enough: the busy guard still
+  // sees the non-null destroyed socket and answers every new client with BROKER_BUSY,
+  // while that connected client also keeps the broker from ever idling out. The result is
+  // a shared broker that is simultaneously "idle" and unusable.
+  const broker = startBroker({ idleTimeout: 0 });
+  t.after(() => broker.dispose());
+  assert.equal(await broker.listening(), true, `broker never listened: ${broker.stderr()}`);
+
+  const abandoned = await connectTo(broker.socketPath);
+  const started = readReply(abandoned, 1);
+  sendLine(abandoned, { id: 1, method: "thread/start", params: { cwd: process.cwd(), ephemeral: true } });
+  const threadId = (await started).result?.thread?.id;
+  assert.ok(threadId, "fake codex did not start a thread");
+
+  sendLine(abandoned, {
+    id: 2,
+    method: "turn/start",
+    params: { threadId, input: [{ type: "text", text: "hello" }] }
+  });
+  abandoned.destroy();
+
+  // Let the abandoned response land and assign the destroyed socket as the stream owner.
+  await delay(600);
+
+  const reconnect = await connectTo(broker.socketPath);
+  t.after(() => reconnect.destroy());
+  const replied = readReply(reconnect, 10);
+  sendLine(reconnect, { id: 10, method: "thread/start", params: { cwd: process.cwd(), ephemeral: true } });
+
+  const reply = await Promise.race([replied, delay(10000).then(() => null)]);
+  assert.ok(reply, "reconnecting client got no reply at all");
+  assert.equal(
+    reply.error?.message,
+    undefined,
+    `reconnecting client was rejected: ${reply.error?.message ?? ""}`
+  );
+  assert.ok(reply.result?.thread?.id, "reconnecting client did not get a usable thread");
+});

--- a/tests/broker-idle.test.mjs
+++ b/tests/broker-idle.test.mjs
@@ -123,8 +123,12 @@ test("broker with --idle-timeout 0 never idles out", async (t) => {
   await delay(1600);
   assert.equal(broker.alive(), true, "idle shutdown ran even though it was disabled");
 
+  // SIGTERM shares shutdown() with the idle path, so this also covers the ordering there.
   broker.child.kill("SIGTERM");
-  await broker.exitedWithin(8000);
+  const result = await broker.exitedWithin(8000);
+  assert.ok(result, "broker did not exit on SIGTERM");
+  assert.equal(fs.existsSync(broker.socketPath), false, "SIGTERM shutdown left the socket behind");
+  assert.equal(fs.existsSync(broker.pidFile), false, "SIGTERM shutdown left the pidfile behind");
 });
 
 test("broker rejects a non-numeric --idle-timeout instead of silently never expiring", async (t) => {
@@ -147,6 +151,30 @@ test("blank --idle-timeout falls back to the default instead of silently disabli
   // used elsewhere in this file.
   await delay(1600);
   assert.equal(broker.alive(), true, "a blank idle timeout disabled idle shutdown");
+
+  broker.child.kill("SIGTERM");
+  await broker.exitedWithin(8000);
+});
+
+test("broker rejects an idle timeout beyond Node's timer range", async (t) => {
+  // setTimeout() overflows above 2^31-1 and fires after 1ms, which would shut the broker
+  // down almost immediately. Asking for ~30 days must fail loudly, not silently invert.
+  const broker = startBroker({ idleTimeout: 30 * 24 * 60 * 60 * 1000 });
+  t.after(() => broker.dispose());
+
+  const result = await broker.exitedWithin(8000);
+  assert.ok(result, "broker did not exit on an out-of-range idle timeout");
+  assert.equal(result.code, 1);
+  assert.match(broker.stderr(), /must be at most 2147483647 ms/);
+});
+
+test("broker accepts an idle timeout exactly at the Node timer limit", async (t) => {
+  // Boundary: 2147483647 is valid, so the guard must not be off by one.
+  const broker = startBroker({ idleTimeout: 2147483647 });
+  t.after(() => broker.dispose());
+
+  assert.equal(await broker.listening(), true, `broker never listened: ${broker.stderr()}`);
+  assert.equal(broker.alive(), true, "broker rejected a timeout that is exactly at the limit");
 
   broker.child.kill("SIGTERM");
   await broker.exitedWithin(8000);

--- a/tests/broker-idle.test.mjs
+++ b/tests/broker-idle.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import test from "node:test";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import { makeTempDir } from "./helpers.mjs";
+import { buildEnv, installFakeCodex } from "./fake-codex-fixture.mjs";
+
+const ROOT = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const BROKER = path.join(ROOT, "plugins", "codex", "scripts", "app-server-broker.mjs");
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(predicate, { timeoutMs = 10000, intervalMs = 25 } = {}) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) {
+      return true;
+    }
+    await delay(intervalMs);
+  }
+  return false;
+}
+
+function startBroker({ idleTimeout } = {}) {
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  const sessionDir = makeTempDir("codex-broker-idle-");
+  const cwd = makeTempDir("codex-broker-cwd-");
+  const socketPath = path.join(sessionDir, "broker.sock");
+  const pidFile = path.join(sessionDir, "broker.pid");
+
+  const args = [BROKER, "serve", "--endpoint", `unix:${socketPath}`, "--cwd", cwd, "--pid-file", pidFile];
+  if (idleTimeout !== undefined) {
+    args.push("--idle-timeout", String(idleTimeout));
+  }
+
+  const child = spawn(process.execPath, args, { env: buildEnv(binDir), stdio: ["ignore", "pipe", "pipe"] });
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const exited = new Promise((resolve) => {
+    child.on("exit", (code, signal) => resolve({ code, signal }));
+  });
+
+  const alive = () => child.exitCode === null && child.signalCode === null;
+
+  // Bounded: a broker that never exits must turn into a RED test, not a hung run.
+  // Awaiting `exited` unbounded is what made this file hang against an unpatched broker.
+  const exitedWithin = (timeoutMs) =>
+    Promise.race([exited, delay(timeoutMs).then(() => null)]);
+
+  const dispose = () => {
+    if (alive()) {
+      child.kill("SIGKILL");
+    }
+  };
+
+  return {
+    child,
+    socketPath,
+    pidFile,
+    exited,
+    exitedWithin,
+    dispose,
+    stderr: () => stderr,
+    alive,
+    listening: () => waitFor(() => fs.existsSync(socketPath))
+  };
+}
+
+function connectTo(socketPath) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ path: socketPath });
+    socket.on("connect", () => resolve(socket));
+    socket.on("error", reject);
+  });
+}
+
+test("broker shuts itself down once it has been idle for the timeout", async (t) => {
+  const broker = startBroker({ idleTimeout: 400 });
+  t.after(() => broker.dispose());
+  assert.equal(await broker.listening(), true, `broker never listened: ${broker.stderr()}`);
+
+  const result = await broker.exitedWithin(8000);
+  assert.ok(result, `broker never exited after the idle timeout, stderr: ${broker.stderr()}`);
+  assert.equal(result.code, 0, `expected a clean idle exit, stderr: ${broker.stderr()}`);
+  // shutdown() must still clean up after itself on the idle path, or the next
+  // ensureBrokerSession would find a stale socket and a stale pidfile.
+  assert.equal(fs.existsSync(broker.socketPath), false, "idle shutdown left the socket behind");
+  assert.equal(fs.existsSync(broker.pidFile), false, "idle shutdown left the pidfile behind");
+});
+
+test("broker stays alive while a client is connected, then exits after it disconnects", async (t) => {
+  const broker = startBroker({ idleTimeout: 400 });
+  t.after(() => broker.dispose());
+  assert.equal(await broker.listening(), true, `broker never listened: ${broker.stderr()}`);
+
+  const socket = await connectTo(broker.socketPath);
+  // Well past the idle timeout: an open connection must hold the broker open, which is
+  // what stops a long streaming turn from being cut off mid-flight.
+  await delay(1600);
+  assert.equal(broker.alive(), true, "broker exited while a client was still connected");
+
+  socket.destroy();
+  const result = await broker.exitedWithin(8000);
+  assert.ok(result, `broker never exited after the client disconnected, stderr: ${broker.stderr()}`);
+  assert.equal(result.code, 0, `expected a clean idle exit after disconnect, stderr: ${broker.stderr()}`);
+});
+
+test("broker with --idle-timeout 0 never idles out", async (t) => {
+  const broker = startBroker({ idleTimeout: 0 });
+  t.after(() => broker.dispose());
+  assert.equal(await broker.listening(), true, `broker never listened: ${broker.stderr()}`);
+
+  await delay(1600);
+  assert.equal(broker.alive(), true, "idle shutdown ran even though it was disabled");
+
+  broker.child.kill("SIGTERM");
+  await broker.exitedWithin(8000);
+});
+
+test("broker rejects a non-numeric --idle-timeout instead of silently never expiring", async (t) => {
+  const broker = startBroker({ idleTimeout: "not-a-number" });
+  t.after(() => broker.dispose());
+  const result = await broker.exitedWithin(8000);
+  assert.ok(result, "broker did not exit on an invalid idle timeout");
+  assert.equal(result.code, 1);
+  assert.match(broker.stderr(), /Invalid idle timeout/);
+});
+
+test("blank --idle-timeout falls back to the default instead of silently disabling", async (t) => {
+  // Number("  ") === 0, so a whitespace value must NOT be read as "never expire".
+  // Only an explicit 0 disables idle shutdown.
+  const broker = startBroker({ idleTimeout: "  " });
+  t.after(() => broker.dispose());
+  assert.equal(await broker.listening(), true, `broker never listened: ${broker.stderr()}`);
+
+  // The default is 30 minutes, so it must still be alive well past the short timeouts
+  // used elsewhere in this file.
+  await delay(1600);
+  assert.equal(broker.alive(), true, "a blank idle timeout disabled idle shutdown");
+
+  broker.child.kill("SIGTERM");
+  await broker.exitedWithin(8000);
+});

--- a/tests/broker-idle.test.mjs
+++ b/tests/broker-idle.test.mjs
@@ -179,3 +179,59 @@ test("broker accepts an idle timeout exactly at the Node timer limit", async (t)
   broker.child.kill("SIGTERM");
   await broker.exitedWithin(8000);
 });
+
+function sendLine(socket, message) {
+  socket.write(`${JSON.stringify(message)}\n`);
+}
+
+function readReply(socket, id) {
+  return new Promise((resolve, reject) => {
+    let buffer = "";
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      let index;
+      while ((index = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, index);
+        buffer = buffer.slice(index + 1);
+        if (!line.trim()) continue;
+        let message;
+        try {
+          message = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (message.id === id) resolve(message);
+      }
+    });
+    socket.on("error", reject);
+  });
+}
+
+test("broker still idles out after a client abandons a streaming request", async (t) => {
+  // A client can disconnect while turn/start is still awaiting its response. The close
+  // handler arms the timer, but the response then assigns the already-closed socket to
+  // activeStreamSocket, so the timer finds the broker "busy" and does not re-arm. When
+  // turn/completed later clears that stale ownership nothing schedules again, and the
+  // empty broker stays resident forever.
+  const broker = startBroker({ idleTimeout: 400 });
+  t.after(() => broker.dispose());
+  assert.equal(await broker.listening(), true, `broker never listened: ${broker.stderr()}`);
+
+  const socket = await connectTo(broker.socketPath);
+  const started = readReply(socket, 1);
+  sendLine(socket, { id: 1, method: "thread/start", params: { cwd: process.cwd(), ephemeral: true } });
+  const threadId = (await started).result?.thread?.id;
+  assert.ok(threadId, "fake codex did not start a thread");
+
+  // Fire a streaming request and abandon it immediately, without reading the response.
+  sendLine(socket, {
+    id: 2,
+    method: "turn/start",
+    params: { threadId, input: [{ type: "text", text: "hello" }] }
+  });
+  socket.destroy();
+
+  const result = await broker.exitedWithin(15000);
+  assert.ok(result, `broker stayed resident after the client abandoned a stream: ${broker.stderr()}`);
+  assert.equal(result.code, 0);
+});


### PR DESCRIPTION
## Problem

`app-server-broker.mjs` has no idle timeout and no lifetime cap. It exits on exactly three paths — a `broker/shutdown` RPC, `SIGTERM`, or `SIGINT`. Nothing in the protocol tells a broker that its client is gone for good, so any broker whose client disappears without sending `broker/shutdown` stays resident until the machine reboots, holding its `/tmp/cxc-*` socket dir and ~40MB of RSS.

## This reproduces from the repo's own test suite

This is not a rare edge case — `npm test` causes it on every run.

Each test in `tests/runtime.test.mjs` creates a fresh temp workspace; `ensureBrokerSession` spawns one broker per workspace; nothing tears them down when the test ends. A single `node --test tests/runtime.test.mjs` run leaves **~58 brokers** behind.

Measured on one machine after three suite runs:

```
$ pgrep -fc 'app-server-broker\.mjs'
174

$ ps -eo time,cmd | grep '[a]pp-server-broker' | awk '{print $1}' | sort -u
00:00:00          # every one idle, zero CPU consumed

$ ss -xp | grep -c app-server-broker
0                 # zero established connections
```

All 174 had been reparented (their spawning shells were long gone) and together held ~2.9GB of unique resident memory on a 7.8GB host, which took available memory from 5.3GB down to 2.3GB.

## Fix

The broker now shuts itself down once it has been idle for `--idle-timeout` milliseconds (default **30 minutes**, overridable with `CODEX_COMPANION_BROKER_IDLE_MS`, explicit `0` disables).

Idle means **no connected sockets and nothing in flight** (`sockets.size === 0 && activeRequestSocket === null && activeStreamSocket === null`). Holding an open connection is sufficient to keep the broker alive, so a long streaming turn can never be cut off mid-flight.

### Why the broker decides, rather than an external sweeper

The broker is the only party that can observe whether it is currently serving anyone. Scanning a job registry from outside and then killing is racy by construction — a job can start between the scan and the kill — and on a machine running several clients concurrently, the broker processes and the `/tmp/cxc-*` namespace are shared, so a pattern-based sweep cannot distinguish one client's orphan from another's live runtime. Putting the decision inside the process removes the race entirely.

### Why it does not clear `broker.json`

An idle exit leaves the `broker.json` session record behind. That is already handled: `ensureBrokerSession` probes the recorded endpoint via `isBrokerEndpointReady` and, when it does not answer, calls `teardownBrokerSession` + `clearBrokerSession` and spawns a replacement. The cost is a single 150ms probe on next use.

The broker deliberately does **not** clear that record itself, even though it knows its own `--cwd`: a replacement broker may already have been spawned for the same cwd and rewritten the record, and clearing it would delete the live broker's endpoint.

### Input handling

Blank and whitespace-only values fall back to the default rather than parsing as `0`, because `Number("  ") === 0` would otherwise silently mean "never expire" — the exact failure this change exists to prevent. Non-numeric and negative values are rejected loudly instead of quietly defaulting.

## Known limitation

There is a narrow residual race: a client can connect between the timer's idle re-check and `shutdown()` completing. It is benign in practice, because a client that finds a dead endpoint goes through the existing teardown-and-respawn path rather than failing, but it is narrowed rather than eliminated, and I would rather state that than claim otherwise.

## Tests

Adds `tests/broker-idle.test.mjs` (5 tests), all spawning a real broker as a subprocess against the existing fake-codex fixture:

- exits on its own after the idle timeout, and `shutdown()` still removes the socket and pidfile
- stays alive while a client is connected, then exits after it disconnects
- `--idle-timeout 0` never idles out
- a non-numeric `--idle-timeout` is rejected rather than silently never expiring
- a blank `--idle-timeout` falls back to the default rather than disabling

Verified non-vacuous by running the new tests against the unpatched tree at `db52e28`: 3 of the 5 fail without the change. The `--idle-timeout 0` case passes both ways by design — it is a guard against idle shutdown becoming unconditional, not coverage of the feature.

Full suite: **100 passing / 0 failing of 100.**

_Correction: an earlier revision of this description reported 3 pre-existing failures on `main`. That was wrong. They were caused by `CODEX_COMPANION_SESSION_ID` being set in my shell: `filterJobsForCurrentClaudeSession` then filters jobs to `job.sessionId === sessionId`, and the `status`/`result` test fixtures are handcrafted without a `sessionId`, so they were all filtered out. With that variable unset the suite is green. There are no pre-existing failures._

## Compatibility

Default-on with a 30 minute timeout. Because `ensureBrokerSession` already respawns on a dead endpoint, the worst case for a client that returns after 30 idle minutes is one cold broker start, not a failure. Set `CODEX_COMPANION_BROKER_IDLE_MS=0` to restore the previous always-resident behaviour.

