### PR TITLE
feat(companion): handle --help per subcommand so it cannot start a run

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -87,11 +87,12 @@ const USAGE_LINES = new Map([
 // unrecognised token as a positional, so `adversarial-review --help` was joined into the
 // review's focus text and ran a full review -- minutes of wall clock and a model turn,
 // for someone who asked what the flags were.
-// freeFormPositionals marks the subcommands whose positionals are arbitrary user prose
-// (review focus text, task prompt). Only those need the "no positionals" rule, because
-// only there can a flag-looking token be something the user meant literally. status,
-// result and cancel take a structured job id instead, so help must win over it -- asking
-// for help while naming a job must never cancel that job.
+// positionalsAreFreeForm marks the subcommands whose positionals are arbitrary user
+// prose, which is the only case where a leftover positional should block a help request:
+// there, a --help token may be something the user meant literally. It is a predicate over
+// the parsed options rather than a flag, because for task it depends on whether
+// --prompt-file displaced the positional. Everything else -- a structured job id, or a
+// positional the handler discards -- must let help win.
 const REVIEW_PARSE_OPTIONS = {
   valueOptions: ["base", "scope", "model", "cwd"],
   booleanOptions: ["json", "background", "wait"],
@@ -111,14 +112,18 @@ const COMMAND_OPTION_SCHEMAS = new Map([
   // positional -- otherwise `review "--scope working-tree focus --help"` answers a help
   // request with a confusing complaint about custom focus text.
   ["review", REVIEW_PARSE_OPTIONS],
-  ["adversarial-review", { ...REVIEW_PARSE_OPTIONS, freeFormPositionals: true }],
+  ["adversarial-review", { ...REVIEW_PARSE_OPTIONS, positionalsAreFreeForm: () => true }],
   [
     "task",
     {
       valueOptions: ["model", "effort", "cwd", "prompt-file"],
       booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
       aliasMap: { m: "model" },
-      freeFormPositionals: true
+      // Only when the positional is actually the prompt. readTaskPrompt returns the file
+      // unconditionally when --prompt-file is given, so a positional alongside it is
+      // discarded -- there is no literal prompt text to protect, and suppressing help
+      // over it starts a real turn for someone who asked what the flags were.
+      positionalsAreFreeForm: (options) => !options["prompt-file"]
     }
   ],
   ["transfer", { valueOptions: ["cwd", "source"], booleanOptions: ["json"] }],
@@ -151,10 +156,13 @@ function isHelpRequest(subcommand, argv) {
   if (options.help !== true) {
     return false;
   }
-  // Only free-form subcommands need to defend against a flag-looking token that the user
-  // meant as prose. Where the positional is a structured job id, a leftover positional is
-  // not a reason to dispatch -- `cancel "job-1 --help"` must print usage, not cancel job-1.
-  return schema.freeFormPositionals !== true || positionals.length === 0;
+  // A positional only blocks help when it is genuinely free-form input the user may have
+  // meant literally. Where it is a structured job id (`cancel "job-1 --help"`), or where
+  // the handler discards it anyway (`task --prompt-file f.txt ignored`), it is not a
+  // reason to dispatch.
+  const freeForm =
+    typeof schema.positionalsAreFreeForm === "function" && schema.positionalsAreFreeForm(options);
+  return !freeForm || positionals.length === 0;
 }
 
 function printUsage(subcommand) {

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -87,8 +87,12 @@ const USAGE_LINES = new Map([
 // unrecognised token as a positional, so `adversarial-review --help` was joined into the
 // review's focus text and ran a full review -- minutes of wall clock and a model turn,
 // for someone who asked what the flags were.
+// Only the flags, never the bare word "help": argv is normalized before this runs, so a
+// focus string like "review the help system" tokenizes to include "help", and matching it
+// would print usage instead of running the review the user asked for. A bare `help`
+// subcommand is still handled separately, before dispatch.
 function isHelpRequest(argv) {
-  return argv.some((token) => token === "--help" || token === "-h" || token === "help");
+  return argv.some((token) => token === "--help" || token === "-h");
 }
 
 function printUsage(subcommand) {
@@ -1036,8 +1040,12 @@ async function main() {
     return;
   }
 
+  // Normalize first. The plugin commands pass "$ARGUMENTS" as ONE quoted argument, so
+  // `/codex:adversarial-review --base main --help` arrives here as a single string and a
+  // raw token comparison misses the flag -- the handler would then split it itself and
+  // start a full review with --help as focus text, which is exactly what this prevents.
   // Checked before the switch, so help can never reach a handler that would dispatch.
-  if (USAGE_LINES.has(subcommand) && isHelpRequest(argv)) {
+  if (USAGE_LINES.has(subcommand) && isHelpRequest(normalizeArgv(argv))) {
     printUsage(subcommand);
     return;
   }

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -123,8 +123,13 @@ function isHelpRequest(subcommand, argv) {
   if (!schema) {
     return false;
   }
-  const { options, positionals } = parseArgs(normalizeArgv(argv), {
-    valueOptions: schema.valueOptions ?? [],
+  // Detect through parseCommandInput, not parseArgs: the handlers reach the parser that
+  // way, so this inherits the shared `-C` alias and the argv normalization instead of
+  // restating them. Calling parseArgs directly is what missed `-C <dir> --help` -- the
+  // alias was unknown here, so the flag and its value became positionals, help was not
+  // detected, and the handler then dispatched with --help left as input.
+  const { options, positionals } = parseCommandInput(argv, {
+    ...schema,
     booleanOptions: [...(schema.booleanOptions ?? []), "help"],
     aliasMap: { ...(schema.aliasMap ?? {}), h: "help" }
   });

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -92,11 +92,10 @@ const USAGE_LINES = new Map([
 // only there can a flag-looking token be something the user meant literally. status,
 // result and cancel take a structured job id instead, so help must win over it -- asking
 // for help while naming a job must never cancel that job.
-const REVIEW_OPTION_SCHEMA = {
+const REVIEW_PARSE_OPTIONS = {
   valueOptions: ["base", "scope", "model", "cwd"],
   booleanOptions: ["json", "background", "wait"],
-  aliasMap: { m: "model" },
-  freeFormPositionals: true
+  aliasMap: { m: "model" }
 };
 
 // One schema per subcommand, read by BOTH the handler and help detection. Keeping a
@@ -106,8 +105,13 @@ const REVIEW_OPTION_SCHEMA = {
 // here is automatically known to both, so the two can never disagree again.
 const COMMAND_OPTION_SCHEMAS = new Map([
   ["setup", { valueOptions: ["cwd"], booleanOptions: ["json", "enable-review-gate", "disable-review-gate"] }],
-  ["review", REVIEW_OPTION_SCHEMA],
-  ["adversarial-review", REVIEW_OPTION_SCHEMA],
+  // Same parsing, different positional semantics. adversarial-review takes focus text, so
+  // a --help token there may be prose. Native review rejects ALL focus text in
+  // validateNativeReviewRequest, so it has no free-form use and help can win over any
+  // positional -- otherwise `review "--scope working-tree focus --help"` answers a help
+  // request with a confusing complaint about custom focus text.
+  ["review", REVIEW_PARSE_OPTIONS],
+  ["adversarial-review", { ...REVIEW_PARSE_OPTIONS, freeFormPositionals: true }],
   [
     "task",
     {
@@ -780,7 +784,7 @@ function enqueueBackgroundTask(cwd, job, request) {
 
 async function handleReviewCommand(argv, config) {
   const { options, positionals } = parseCommandInput(argv, {
-    ...REVIEW_OPTION_SCHEMA
+    ...REVIEW_PARSE_OPTIONS
   });
 
   const cwd = resolveCommandCwd(options);

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -72,20 +72,28 @@ const VALID_REASONING_EFFORTS = new Set(["none", "minimal", "low", "medium", "hi
 const MODEL_ALIASES = new Map([["spark", "gpt-5.3-codex-spark"]]);
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
 
-function printUsage() {
-  console.log(
-    [
-      "Usage:",
-      "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
-      "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
-      "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
-      "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
-      "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
-      "  node scripts/codex-companion.mjs result [job-id] [--json]",
-      "  node scripts/codex-companion.mjs cancel [job-id] [--json]"
-    ].join("\n")
-  );
+const USAGE_LINES = new Map([
+  ["setup", "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]"],
+  ["review", "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]"],
+  ["adversarial-review", "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]"],
+  ["task", "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]"],
+  ["transfer", "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]"],
+  ["status", "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]"],
+  ["result", "  node scripts/codex-companion.mjs result [job-id] [--json]"],
+  ["cancel", "  node scripts/codex-companion.mjs cancel [job-id] [--json]"]
+]);
+
+// A help request must never become a dispatch. Every subcommand parser treats an
+// unrecognised token as a positional, so `adversarial-review --help` was joined into the
+// review's focus text and ran a full review -- minutes of wall clock and a model turn,
+// for someone who asked what the flags were.
+function isHelpRequest(argv) {
+  return argv.some((token) => token === "--help" || token === "-h" || token === "help");
+}
+
+function printUsage(subcommand) {
+  const line = subcommand ? USAGE_LINES.get(subcommand) : null;
+  console.log(["Usage:", ...(line ? [line] : USAGE_LINES.values())].join("\n"));
 }
 
 function outputResult(value, asJson) {
@@ -1023,8 +1031,14 @@ async function handleCancel(argv) {
 
 async function main() {
   const [subcommand, ...argv] = process.argv.slice(2);
-  if (!subcommand || subcommand === "help" || subcommand === "--help") {
+  if (!subcommand || subcommand === "help" || subcommand === "--help" || subcommand === "-h") {
     printUsage();
+    return;
+  }
+
+  // Checked before the switch, so help can never reach a handler that would dispatch.
+  if (USAGE_LINES.has(subcommand) && isHelpRequest(argv)) {
+    printUsage(subcommand);
     return;
   }
 

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -87,7 +87,17 @@ const USAGE_LINES = new Map([
 // unrecognised token as a positional, so `adversarial-review --help` was joined into the
 // review's focus text and ran a full review -- minutes of wall clock and a model turn,
 // for someone who asked what the flags were.
-const REVIEW_OPTION_SCHEMA = { valueOptions: ["base", "scope", "model", "cwd"], booleanOptions: ["json", "background", "wait"], aliasMap: { m: "model" } };
+// freeFormPositionals marks the subcommands whose positionals are arbitrary user prose
+// (review focus text, task prompt). Only those need the "no positionals" rule, because
+// only there can a flag-looking token be something the user meant literally. status,
+// result and cancel take a structured job id instead, so help must win over it -- asking
+// for help while naming a job must never cancel that job.
+const REVIEW_OPTION_SCHEMA = {
+  valueOptions: ["base", "scope", "model", "cwd"],
+  booleanOptions: ["json", "background", "wait"],
+  aliasMap: { m: "model" },
+  freeFormPositionals: true
+};
 
 // One schema per subcommand, read by BOTH the handler and help detection. Keeping a
 // separate hand-maintained list for help detection is what broke it: an option the help
@@ -103,7 +113,8 @@ const COMMAND_OPTION_SCHEMAS = new Map([
     {
       valueOptions: ["model", "effort", "cwd", "prompt-file"],
       booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
-      aliasMap: { m: "model" }
+      aliasMap: { m: "model" },
+      freeFormPositionals: true
     }
   ],
   ["transfer", { valueOptions: ["cwd", "source"], booleanOptions: ["json"] }],
@@ -133,7 +144,13 @@ function isHelpRequest(subcommand, argv) {
     booleanOptions: [...(schema.booleanOptions ?? []), "help"],
     aliasMap: { ...(schema.aliasMap ?? {}), h: "help" }
   });
-  return options.help === true && positionals.length === 0;
+  if (options.help !== true) {
+    return false;
+  }
+  // Only free-form subcommands need to defend against a flag-looking token that the user
+  // meant as prose. Where the positional is a structured job id, a leftover positional is
+  // not a reason to dispatch -- `cancel "job-1 --help"` must print usage, not cancel job-1.
+  return schema.freeFormPositionals !== true || positionals.length === 0;
 }
 
 function printUsage(subcommand) {

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -87,29 +87,46 @@ const USAGE_LINES = new Map([
 // unrecognised token as a positional, so `adversarial-review --help` was joined into the
 // review's focus text and ran a full review -- minutes of wall clock and a model turn,
 // for someone who asked what the flags were.
-// Detecting help by scanning tokens is not safe once argv is normalized. Focus text is
-// split into tokens too, so `adversarial-review "why does --help start a review"` yields a
-// --help token and a token scan would make that review impossible to run -- a hard block,
-// not just a surprise. Parse instead, and treat it as help only when nothing else was
-// asked for: the help flag present AND no focus text left over. The bare word "help" is
-// never matched here; a `help` subcommand is handled separately before dispatch.
-const HELP_DETECTION_VALUE_OPTIONS = [
-  "base",
-  "scope",
-  "model",
-  "cwd",
-  "effort",
-  "prompt-file",
-  "source",
-  "timeout-ms",
-  "poll-interval-ms"
-];
+const REVIEW_OPTION_SCHEMA = { valueOptions: ["base", "scope", "model", "cwd"], booleanOptions: ["json", "background", "wait"], aliasMap: { m: "model" } };
 
-function isHelpRequest(argv) {
+// One schema per subcommand, read by BOTH the handler and help detection. Keeping a
+// separate hand-maintained list for help detection is what broke it: an option the help
+// parser did not know (`--wait`) became a positional, help was not detected, and the real
+// parser then consumed the option and reviewed `--help` as focus text. Any option added
+// here is automatically known to both, so the two can never disagree again.
+const COMMAND_OPTION_SCHEMAS = new Map([
+  ["setup", { valueOptions: ["cwd"], booleanOptions: ["json", "enable-review-gate", "disable-review-gate"] }],
+  ["review", REVIEW_OPTION_SCHEMA],
+  ["adversarial-review", REVIEW_OPTION_SCHEMA],
+  [
+    "task",
+    {
+      valueOptions: ["model", "effort", "cwd", "prompt-file"],
+      booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
+      aliasMap: { m: "model" }
+    }
+  ],
+  ["transfer", { valueOptions: ["cwd", "source"], booleanOptions: ["json"] }],
+  ["status", { valueOptions: ["cwd", "timeout-ms", "poll-interval-ms"], booleanOptions: ["json", "all", "wait"] }],
+  ["result", { valueOptions: ["cwd"], booleanOptions: ["json"] }],
+  ["cancel", { valueOptions: ["cwd"], booleanOptions: ["json"] }]
+]);
+
+// Parse with the subcommand's real schema, then treat it as help only when the flag is
+// present AND nothing else was asked for. Scanning tokens cannot work here: argv is
+// normalized first, so focus text is split into tokens too, and a scan would match
+// `adversarial-review "why does --help start a review"` and make that review impossible
+// to run. Parsing also gets `--` right for free -- anything after it is a positional, so
+// a literal `--help` in focus text stays focus text.
+function isHelpRequest(subcommand, argv) {
+  const schema = COMMAND_OPTION_SCHEMAS.get(subcommand);
+  if (!schema) {
+    return false;
+  }
   const { options, positionals } = parseArgs(normalizeArgv(argv), {
-    valueOptions: HELP_DETECTION_VALUE_OPTIONS,
-    booleanOptions: ["help"],
-    aliasMap: { h: "help" }
+    valueOptions: schema.valueOptions ?? [],
+    booleanOptions: [...(schema.booleanOptions ?? []), "help"],
+    aliasMap: { ...(schema.aliasMap ?? {}), h: "help" }
   });
   return options.help === true && positionals.length === 0;
 }
@@ -245,8 +262,7 @@ async function buildSetupReport(cwd, actionsTaken = []) {
 
 async function handleSetup(argv) {
   const { options } = parseCommandInput(argv, {
-    valueOptions: ["cwd"],
-    booleanOptions: ["json", "enable-review-gate", "disable-review-gate"]
+    ...COMMAND_OPTION_SCHEMAS.get("setup")
   });
 
   if (options["enable-review-gate"] && options["disable-review-gate"]) {
@@ -742,11 +758,7 @@ function enqueueBackgroundTask(cwd, job, request) {
 
 async function handleReviewCommand(argv, config) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["base", "scope", "model", "cwd"],
-    booleanOptions: ["json", "background", "wait"],
-    aliasMap: {
-      m: "model"
-    }
+    ...REVIEW_OPTION_SCHEMA
   });
 
   const cwd = resolveCommandCwd(options);
@@ -792,11 +804,7 @@ async function handleReview(argv) {
 
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["model", "effort", "cwd", "prompt-file"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
-    aliasMap: {
-      m: "model"
-    }
+    ...COMMAND_OPTION_SCHEMAS.get("task")
   });
 
   const cwd = resolveCommandCwd(options);
@@ -855,8 +863,7 @@ async function handleTask(argv) {
 
 async function handleTransfer(argv) {
   const { options } = parseCommandInput(argv, {
-    valueOptions: ["cwd", "source"],
-    booleanOptions: ["json"]
+    ...COMMAND_OPTION_SCHEMAS.get("transfer")
   });
 
   const cwd = resolveCommandCwd(options);
@@ -913,8 +920,7 @@ async function handleTaskWorker(argv) {
 
 async function handleStatus(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["cwd", "timeout-ms", "poll-interval-ms"],
-    booleanOptions: ["json", "all", "wait"]
+    ...COMMAND_OPTION_SCHEMAS.get("status")
   });
 
   const cwd = resolveCommandCwd(options);
@@ -1064,7 +1070,7 @@ async function main() {
   // raw token comparison misses the flag -- the handler would then split it itself and
   // start a full review with --help as focus text, which is exactly what this prevents.
   // Checked before the switch, so help can never reach a handler that would dispatch.
-  if (USAGE_LINES.has(subcommand) && isHelpRequest(argv)) {
+  if (USAGE_LINES.has(subcommand) && isHelpRequest(subcommand, argv)) {
     printUsage(subcommand);
     return;
   }

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -87,12 +87,31 @@ const USAGE_LINES = new Map([
 // unrecognised token as a positional, so `adversarial-review --help` was joined into the
 // review's focus text and ran a full review -- minutes of wall clock and a model turn,
 // for someone who asked what the flags were.
-// Only the flags, never the bare word "help": argv is normalized before this runs, so a
-// focus string like "review the help system" tokenizes to include "help", and matching it
-// would print usage instead of running the review the user asked for. A bare `help`
-// subcommand is still handled separately, before dispatch.
+// Detecting help by scanning tokens is not safe once argv is normalized. Focus text is
+// split into tokens too, so `adversarial-review "why does --help start a review"` yields a
+// --help token and a token scan would make that review impossible to run -- a hard block,
+// not just a surprise. Parse instead, and treat it as help only when nothing else was
+// asked for: the help flag present AND no focus text left over. The bare word "help" is
+// never matched here; a `help` subcommand is handled separately before dispatch.
+const HELP_DETECTION_VALUE_OPTIONS = [
+  "base",
+  "scope",
+  "model",
+  "cwd",
+  "effort",
+  "prompt-file",
+  "source",
+  "timeout-ms",
+  "poll-interval-ms"
+];
+
 function isHelpRequest(argv) {
-  return argv.some((token) => token === "--help" || token === "-h");
+  const { options, positionals } = parseArgs(normalizeArgv(argv), {
+    valueOptions: HELP_DETECTION_VALUE_OPTIONS,
+    booleanOptions: ["help"],
+    aliasMap: { h: "help" }
+  });
+  return options.help === true && positionals.length === 0;
 }
 
 function printUsage(subcommand) {
@@ -1045,7 +1064,7 @@ async function main() {
   // raw token comparison misses the flag -- the handler would then split it itself and
   // start a full review with --help as focus text, which is exactly what this prevents.
   // Checked before the switch, so help can never reach a handler that would dispatch.
-  if (USAGE_LINES.has(subcommand) && isHelpRequest(normalizeArgv(argv))) {
+  if (USAGE_LINES.has(subcommand) && isHelpRequest(argv)) {
     printUsage(subcommand);
     return;
   }

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -946,8 +946,7 @@ async function handleStatus(argv) {
 
 function handleResult(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["cwd"],
-    booleanOptions: ["json"]
+    ...COMMAND_OPTION_SCHEMAS.get("result")
   });
 
   const cwd = resolveCommandCwd(options);
@@ -999,8 +998,7 @@ function handleTaskResumeCandidate(argv) {
 
 async function handleCancel(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["cwd"],
-    booleanOptions: ["json"]
+    ...COMMAND_OPTION_SCHEMAS.get("cancel")
   });
 
   const cwd = resolveCommandCwd(options);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1021,6 +1021,32 @@ test("help is detected when the plugin passes all arguments as one string", () =
   assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
 });
 
+test("focus text containing --help is reviewed, not swallowed as a help request", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.mkdirSync(path.join(repo, "src"));
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0];\n");
+  run("git", ["add", "src/app.js"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0].id;\n");
+
+  // Normalization splits focus text into tokens, so a token scan would see --help here and
+  // make this review impossible to run. Help means the flag AND nothing else asked for.
+  const result = run("node", [SCRIPT, "adversarial-review", "why does --help start a review"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(/^Usage:/.test(result.stdout), false, "focus text containing --help printed usage");
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.ok(state.lastTurnStart, "the review never started");
+  assert.match(state.lastTurnStart.prompt, /start a review/);
+});
+
 test("focus text mentioning help still runs the review", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -995,6 +995,58 @@ test("adversarial-review --help prints usage without dispatching a review", () =
   assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
 });
 
+test("help is detected when the plugin passes all arguments as one string", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "README.md"), "hello again\n");
+
+  // The plugin commands invoke the companion with "$ARGUMENTS" as a SINGLE quoted
+  // argument, so this is the shape real usage takes. Comparing raw tokens misses the
+  // flag here, and the handler then splits the string itself and reviews with --help as
+  // focus text.
+  const result = run("node", [SCRIPT, "adversarial-review", "--base main --help"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^Usage:/);
+  const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath, "utf8")) : {};
+  assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
+});
+
+test("focus text mentioning help still runs the review", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.mkdirSync(path.join(repo, "src"));
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0];\n");
+  run("git", ["add", "src/app.js"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0].id;\n");
+
+  // Because argv is normalized before the check, a bare "help" token appears in ordinary
+  // focus text. Matching it would silently swap the user's review for a usage dump.
+  const result = run("node", [SCRIPT, "adversarial-review", "review the help system"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(/^Usage:/.test(result.stdout), false, "focus text containing 'help' printed usage");
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.ok(state.lastTurnStart, "the review never started");
+  assert.match(state.lastTurnStart.prompt, /help system/);
+});
+
 test("subcommand help accepts -h and prints only that subcommand", () => {
   const binDir = makeTempDir();
   installFakeCodex(binDir);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1021,6 +1021,55 @@ test("help is detected when the plugin passes all arguments as one string", () =
   assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
 });
 
+test("help is detected when it follows another recognized flag", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "README.md"), "hello again\n");
+
+  // Help detection must parse with the subcommand's real schema. A separate list would
+  // not know --wait, which would land in positionals, defeat the no-focus-text rule, and
+  // let the real parser consume --wait and review "--help" as focus text.
+  const result = run("node", [SCRIPT, "adversarial-review", "--wait --help"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^Usage:/);
+  const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath, "utf8")) : {};
+  assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
+});
+
+test("a quoted focus argument keeps its help-looking words as focus text", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.mkdirSync(path.join(repo, "src"));
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0];\n");
+  run("git", ["add", "src/app.js"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = items[0].id;\n");
+
+  const result = run("node", [SCRIPT, "adversarial-review", "review --help handling"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(/^Usage:/.test(result.stdout), false, "a focused review printed usage instead");
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.ok(state.lastTurnStart, "the review never started");
+  assert.match(state.lastTurnStart.prompt, /handling/);
+});
+
 test("focus text containing --help is reviewed, not swallowed as a help request", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1021,6 +1021,31 @@ test("help is detected when the plugin passes all arguments as one string", () =
   assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
 });
 
+test("help is detected when combined with the shared -C alias", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "README.md"), "hello again\n");
+
+  // -C is injected by parseCommandInput, not by any subcommand schema. Detecting help
+  // with a bare parseArgs call misses it, so -C and its value become positionals, the
+  // no-focus-text rule fails, and the handler dispatches with --help still in the input.
+  const result = run("node", [SCRIPT, "adversarial-review", `-C ${repo} --help`], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^Usage:/);
+  const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath, "utf8")) : {};
+  assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
+});
+
 test("help is detected when it follows another recognized flag", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -969,6 +969,44 @@ test("task --background enqueues a detached worker and exposes per-job status", 
   assert.match(resultPayload.storedJob.rendered, /Handled the requested task/);
 });
 
+test("adversarial-review --help prints usage without dispatching a review", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "README.md"), "hello again\n");
+
+  const result = run("node", [SCRIPT, "adversarial-review", "--help"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^Usage:/);
+  assert.match(result.stdout, /adversarial-review \[--wait\|--background\]/);
+
+  // The point of the change: an unrecognised flag used to become focus text, so asking
+  // for help started a real review. Nothing may reach the model.
+  const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath, "utf8")) : {};
+  assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
+});
+
+test("subcommand help accepts -h and prints only that subcommand", () => {
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+
+  const result = run("node", [SCRIPT, "task", "-h"], { cwd: makeTempDir(), env: buildEnv(binDir) });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /codex-companion\.mjs task \[--background\]/);
+  // Scoped, not the whole usage block.
+  assert.equal(/adversarial-review/.test(result.stdout), false, "task -h printed other subcommands");
+});
+
 test("review rejects focus text because it is native-review only", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1021,6 +1021,54 @@ test("help is detected when the plugin passes all arguments as one string", () =
   assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
 });
 
+test("task honours help when --prompt-file makes the positional irrelevant", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "prompt.txt"), "the real prompt\n");
+
+  // readTaskPrompt returns the file unconditionally when --prompt-file is set, so the
+  // positional is discarded. Treating it as protected prompt text suppressed help and
+  // started a real turn using prompt.txt.
+  const result = run("node", [SCRIPT, "task", "--prompt-file prompt.txt ignored --help"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^Usage:/);
+  const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath, "utf8")) : {};
+  assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
+});
+
+test("task still protects a literal prompt that mentions --help", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  // Without --prompt-file the positional IS the prompt, so it must still block help.
+  const result = run("node", [SCRIPT, "task", "explain what --help prints"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(/^Usage:/.test(result.stdout), false, "a literal prompt printed usage");
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.ok(state.lastTurnStart, "the task never started");
+  assert.match(state.lastTurnStart.prompt, /what --help prints/);
+});
+
 test("native review honours help even when a positional is present", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1021,6 +1021,32 @@ test("help is detected when the plugin passes all arguments as one string", () =
   assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
 });
 
+test("native review honours help even when a positional is present", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "README.md"), "hello again\n");
+
+  // Native review rejects all focus text in validateNativeReviewRequest, so unlike
+  // adversarial-review it has no free-form positional use. Sharing the free-form
+  // classification made a help request answered with a complaint about focus text.
+  const result = run("node", [SCRIPT, "review", "--scope working-tree focus --help"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^Usage:/);
+  assert.equal(/custom focus text/.test(result.stderr), false, "help was answered with the focus-text error");
+  const state = fs.existsSync(statePath) ? JSON.parse(fs.readFileSync(statePath, "utf8")) : {};
+  assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
+});
+
 test("cancel with a job id and --help prints usage without cancelling the job", () => {
   const workspace = makeTempDir();
   const stateDir = resolveStateDir(workspace);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1021,6 +1021,48 @@ test("help is detected when the plugin passes all arguments as one string", () =
   assert.equal(state.lastTurnStart ?? null, null, "a help request started a Codex turn");
 });
 
+test("cancel with a job id and --help prints usage without cancelling the job", () => {
+  const workspace = makeTempDir();
+  const stateDir = resolveStateDir(workspace);
+  fs.mkdirSync(path.join(stateDir, "jobs"), { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir, "state.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        config: { stopReviewGate: false },
+        jobs: [
+          {
+            id: "task-live",
+            kind: "task",
+            kindLabel: "task",
+            status: "running",
+            title: "Codex Task",
+            jobClass: "task",
+            summary: "A job that must survive a help request",
+            createdAt: "2026-03-18T15:30:00.000Z",
+            updatedAt: "2026-03-18T15:30:03.000Z"
+          }
+        ]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+
+  // cancel takes a structured job id, not free-form text, so a leftover positional is no
+  // reason to dispatch. Applying the free-form rule here made `cancel "task-live --help"`
+  // cancel task-live instead of explaining the command.
+  const result = run("node", [SCRIPT, "cancel", "task-live --help"], { cwd: workspace });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /^Usage:/);
+
+  const after = JSON.parse(fs.readFileSync(path.join(stateDir, "state.json"), "utf8"));
+  assert.equal(after.jobs[0].status, "running", "a help request cancelled the job");
+});
+
 test("help is detected when combined with the shared -C alias", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
## Problem

`--help` is only recognised as the *first* argument (`subcommand === "--help"`). Anywhere else it lands in `argv`, and because `parseArgs` treats any unrecognised `--token` as a positional, it is carried into the subcommand as data rather than handled as a request for usage.

For `adversarial-review` the positionals become the review's focus text, so:

```
node scripts/codex-companion.mjs adversarial-review --help
```

runs a **full review** against the default base — minutes of wall clock and a real model turn — for someone who asked what the flags were. I burned ~10 minutes to this twice in one afternoon before realising the flag was being eaten.

The same shape applies to any subcommand whose parser accepts positionals; `adversarial-review` is simply the one where the cost is highest.

## Fix

`main()` checks for `--help`, `-h` or `help` in `argv` before the dispatch `switch`, and prints usage for that subcommand alone.

Checking before the switch is the substance of the change, not an implementation detail: it means a help request can never reach a handler capable of dispatching. Putting the check inside each handler would leave the same bug one refactor away.

Bare `--help`, `-h`, and `help` as the subcommand still print the full usage block, unchanged.

The usage lines move into a `Map` keyed by subcommand so one line can be printed without duplicating the text. The full block prints in the same order as before.

```
$ node scripts/codex-companion.mjs adversarial-review --help
Usage:
  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]
```

## Tests

Two tests in `tests/runtime.test.mjs`:

- `adversarial-review --help` prints usage **and starts no Codex turn** — asserted against the fake app server's recorded `lastTurnStart`, since "printed usage" alone would not prove the review was skipped
- `task -h` prints only the task line, not the whole block

Both verified non-vacuous against `db52e28`, where they fail.

Full suite: **93 passing / 0 failing of 93.**

_Correction: an earlier revision of this description reported 3 pre-existing failures on `main`. That was wrong. They were caused by `CODEX_COMPANION_SESSION_ID` being set in my shell: `filterJobsForCurrentClaudeSession` then filters jobs to `job.sessionId === sessionId`, and the `status`/`result` test fixtures are handcrafted without a `sessionId`, so they were all filtered out. With that variable unset the suite is green. There are no pre-existing failures._

