### PR TITLE
fix: fail closed on malformed stop hook input

### DIFF
--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -140,7 +140,16 @@ function runStopReview(cwd, input = {}) {
 }
 
 function main() {
-  const input = readHookInput();
+  let input;
+  try {
+    input = readHookInput();
+  } catch {
+    emitDecision({
+      decision: "block",
+      reason: "The stop review gate could not read or parse hook input; refusing to fail open."
+    });
+    return;
+  }
   const cwd = input.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd();
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const config = getConfig(workspaceRoot);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1979,6 +1979,19 @@ test("stop hook runs a stop-time review task and blocks on findings when the rev
   assert.match(status.stdout, /Codex Stop Gate Review/);
 });
 
+test("stop hook blocks when hook input is malformed JSON", () => {
+  const blocked = run(process.execPath, [STOP_HOOK], {
+    cwd: ROOT,
+    input: "{not-json"
+  });
+
+  assert.equal(blocked.status, 0, blocked.stderr);
+  assert.deepEqual(JSON.parse(blocked.stdout), {
+    decision: "block",
+    reason: "The stop review gate could not read or parse hook input; refusing to fail open."
+  });
+});
+
 test("stop hook logs running tasks to stderr without blocking when the review gate is disabled", () => {
   const repo = makeTempDir();
   initGitRepo(repo);


### PR DESCRIPTION
## Summary

- catch failures while reading or parsing Stop-hook input
- emit a valid `decision: "block"` response instead of exiting without a decision
- add regression coverage for malformed non-empty JSON input

## Testing

- `npm test` (92 tests passed)
- `npm run build`
- `npm run check-version`

Fixes #676
