### PR TITLE
fix: resolve model aliases on review and adversarial-review

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -720,6 +720,7 @@ async function handleReviewCommand(argv, config) {
 
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveCommandWorkspace(options);
+  const model = normalizeRequestedModel(options.model);
   const focusText = positionals.join(" ").trim();
   const target = resolveReviewTarget(cwd, {
     base: options.base,
@@ -743,7 +744,7 @@ async function handleReviewCommand(argv, config) {
         cwd,
         base: options.base,
         scope: options.scope,
-        model: options.model,
+        model,
         focusText,
         reviewName: config.reviewName,
         onProgress: progress

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -313,6 +313,8 @@ rl.on("line", (line) => {
           throw new Error("thread/start.persistFullHistory requires experimentalApi capability");
         }
         const thread = nextThread(state, message.params.cwd, message.params.ephemeral);
+        state.lastThreadStart = { threadId: thread.id, model: message.params.model ?? null };
+        saveState(state);
         send({ id: message.id, result: { thread: buildThread(thread), model: message.params.model || "gpt-5.4", modelProvider: "openai", serviceTier: null, cwd: thread.cwd, approvalPolicy: "never", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
         send({ method: "thread/started", params: { thread: { id: thread.id } } });
         break;

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -784,6 +784,50 @@ test("task forwards model selection and reasoning effort to app-server turn/star
   assert.equal(fakeState.lastTurnStart.effort, "low");
 });
 
+test("review resolves model aliases the same way task does", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.mkdirSync(path.join(repo, "src"));
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = 1;\n");
+  run("git", ["add", "src/app.js"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = 2;\n");
+
+  const result = run("node", [SCRIPT, "review", "--model", "spark"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastThreadStart.model, "gpt-5.3-codex-spark");
+});
+
+test("adversarial review resolves model aliases the same way task does", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.mkdirSync(path.join(repo, "src"));
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = 1;\n");
+  run("git", ["add", "src/app.js"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "src", "app.js"), "export const value = 2;\n");
+
+  const result = run("node", [SCRIPT, "adversarial-review", "--model", "spark"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastThreadStart.model, "gpt-5.3-codex-spark");
+});
+
 test("task logs reasoning summaries and assistant messages to the job log", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
Fixes #687.

`handleReviewCommand` accepts `--model`/`-m` (`valueOptions: [..., "model", ...]`, `aliasMap: { m: "model" }`) but forwards the raw string to `executeReviewRun` → `runAppServerReview` → `thread/start`. `normalizeRequestedModel()` — the only thing that resolves `MODEL_ALIASES` — is called solely in `handleTask`.

So the documented `spark` alias reaches the API as the literal string `spark`:

```
$ node scripts/codex-companion.mjs review --wait --scope working-tree --model spark
[codex] Codex error: {"type":"error","status":400,"error":{"type":"invalid_request_error",
"message":"The 'spark' model is not supported when using Codex with a ChatGPT account."}}
```

The message names the **account** as the cause, which is wrong and expensive to chase — the same account runs `--model gpt-5.3-codex-spark` successfully seconds later, and `spark` was never a model id. openai/codex#15648 is people landing on that sentence. The alias is documented for the runtime in `skills/codex-cli-runtime/SKILL.md` ("Map `spark` to `--model gpt-5.3-codex-spark`") and `agents/codex-rescue.md`, with nothing marking it task-only.

## The change

Three lines of source: normalize in `handleReviewCommand` the way `handleTask` already does, so both command families resolve aliases identically. Covers `review` and `adversarial-review`, which share the handler.

## Tests

The fake app-server recorded only `turn/start`, so **nothing could observe the model on the review path** — review sets the model at `thread/start`. Added `state.lastThreadStart`, then one regression test per command mirroring the existing `task forwards model selection and reasoning effort to app-server turn/start`.

Both new tests fail on `main` with exactly the reported bug:

```
✖ review resolves model aliases the same way task does
    actual: 'spark',
    expected: 'gpt-5.3-codex-spark',
✖ adversarial review resolves model aliases the same way task does
    actual: 'spark',
    expected: 'gpt-5.3-codex-spark',
```

and pass with it.

## Verification

`node --test tests/*.test.mjs` on macOS 15 (arm64), Node 25, `codex-cli` 0.149.1:

| | tests | pass | fail |
|---|---|---|---|
| `main`, untouched | 91 | 87 | 4 |
| this branch | 93 | 89 | 4 |

The same 4 fail before and after (`status shows phases…`, `status preserves adversarial review kind labels`, `result returns the stored output…`, `resolveStateDir uses a temp-backed per-workspace directory`) — pre-existing on a clean checkout in this environment, untouched by this change. `npm run check-version` passes; no version bump included, happy to add one if that is expected of contributor PRs.

Related: #654 (the flag is undocumented for these two commands — this PR does not change the docs, so that stays open), #651 / #476 (`--effort` has the same task-vs-review asymmetry, not addressed here).
