### PR TITLE
fix(commands): replace inline !` command syntax with explicit Bash blocks

### DIFF
--- a/plugins/codex/commands/cancel.md
+++ b/plugins/codex/commands/cancel.md
@@ -5,4 +5,8 @@ disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 
-!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" cancel "$ARGUMENTS"`
+Cancel the requested background Codex job by running the Bash command below.
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" cancel "$ARGUMENTS"
+```

--- a/plugins/codex/commands/result.md
+++ b/plugins/codex/commands/result.md
@@ -5,7 +5,11 @@ disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 
-!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" result "$ARGUMENTS"`
+Show the stored final output for a finished Codex job by running the Bash command below, then present the full output.
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" result "$ARGUMENTS"
+```
 
 Present the full command output to the user. Do not summarize or condense it. Preserve all details including:
 - Job ID and status

--- a/plugins/codex/commands/status.md
+++ b/plugins/codex/commands/status.md
@@ -5,7 +5,11 @@ disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 
-!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" status "$ARGUMENTS"`
+Run the Codex status command with the Bash tool (the `allowed-tools` frontmatter above permits it), then format the output as described below:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" status "$ARGUMENTS"
+```
 
 If the user did not pass a job ID:
 - Render the command output as a single Markdown table for the current and past runs in this session.

--- a/plugins/codex/commands/transfer.md
+++ b/plugins/codex/commands/transfer.md
@@ -5,6 +5,10 @@ disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
 
-!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" transfer "$ARGUMENTS"`
+Transfer the current Claude Code session into a resumable Codex thread by running the Bash command below, then present the output to the user.
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" transfer "$ARGUMENTS"
+```
 
 Present the command output to the user exactly as returned. Preserve the Codex session ID and the `codex resume <session-id>` command.


### PR DESCRIPTION
Closes #600.

## Summary
`status.md`, `transfer.md`, `cancel.md`, and `result.md` used the inline `!`node "..." "$ARGUMENTS"` ` shorthand that is not supported by the runtime parsing. This replaces it with an explicit `Bash(node:*)` code block (already allowed by frontmatter) followed by post-processing instructions, matching the pattern already used in `review.md`.

```markdown
- !`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" status "$ARGUMENTS"`
+ ```bash
+ node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" status "$ARGUMENTS"
+ ```
```

No runtime behavior changes; the same command is executed. `node --test tests/commands.test.mjs` passes.