### PR TITLE
Keep the inferred-completion timer referenced

### DIFF
--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -390,7 +390,12 @@ function scheduleInferredCompletion(state) {
     }
     completeTurn(state, null, { inferred: true });
   }, 250);
-  state.completionTimer.unref?.();
+  // Intentionally referenced: this timer is the only thing that resolves
+  // state.completion on the inferred-completion path. If it is unref'd it stops
+  // holding the event loop open, so once the app-server socket closes the loop
+  // can drain while `await state.completion` is still pending -- node then exits
+  // 0 without writing anything. The timer is bounded at 250ms and is always
+  // cleared, so keeping it referenced cannot delay or hang shutdown.
 }
 
 function belongsToTurn(state, message) {

--- a/tests/inferred-completion.test.mjs
+++ b/tests/inferred-completion.test.mjs
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CODEX_LIB = path.join(HERE, "..", "plugins", "codex", "scripts", "lib", "codex.mjs");
+
+// The inferred-completion timer in scheduleInferredCompletion() is the only thing
+// that resolves `state.completion` when a turn arrives without an explicit final
+// turn marker. If that timer is unref'd it does not hold the event loop open, so
+// once the app-server socket closes the loop can drain with the completion promise
+// still pending. Node then exits 0 having written nothing at all -- and callers
+// that expect JSON on stdout (the stop-review gate) fail with a parse error that
+// looks like a review verdict rather than a tooling failure.
+//
+// scheduleInferredCompletion is not exported, so this asserts the observable
+// contract in a subprocess: a pending await whose sole remaining handle is that
+// timer must still produce output rather than exiting silently.
+function runCompletionHarness({ unref }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "inferred-completion-"));
+  const script = path.join(dir, "harness.mjs");
+
+  fs.writeFileSync(
+    script,
+    `
+let resolveCompletion;
+const completion = new Promise((resolve) => { resolveCompletion = resolve; });
+const timer = setTimeout(() => resolveCompletion("completed"), 250);
+${unref ? "timer.unref?.();" : ""}
+async function main() {
+  const result = await completion;
+  process.stdout.write(JSON.stringify({ rawOutput: result }) + "\\n");
+}
+main().catch((error) => {
+  process.stderr.write(String(error) + "\\n");
+  process.exitCode = 1;
+});
+`
+  );
+
+  try {
+    return spawnSync(process.execPath, [script], { encoding: "utf8", timeout: 30_000 });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("an unref'd completion timer lets the process exit 0 with no output", () => {
+  const result = runCompletionHarness({ unref: true });
+
+  // This is the failure mode being guarded against: a clean exit code with an
+  // empty stdout is indistinguishable from success to a caller parsing JSON.
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "");
+});
+
+test("a referenced completion timer resolves the turn and emits parseable output", () => {
+  const result = runCompletionHarness({ unref: false });
+
+  assert.equal(result.status, 0);
+  assert.notEqual(result.stdout.trim(), "", "expected the completion timer to produce output");
+  assert.equal(JSON.parse(result.stdout).rawOutput, "completed");
+});
+
+test("scheduleInferredCompletion does not unref the completion timer", () => {
+  const source = fs.readFileSync(CODEX_LIB, "utf8");
+  const start = source.indexOf("function scheduleInferredCompletion");
+  assert.notEqual(start, -1, "expected to find scheduleInferredCompletion in codex.mjs");
+
+  const end = source.indexOf("\nfunction ", start + 1);
+  const body = source.slice(start, end === -1 ? undefined : end);
+
+  assert.doesNotMatch(
+    body.replace(/^\s*\/\/.*$/gm, ""),
+    /completionTimer\.unref/,
+    "the inferred-completion timer must stay referenced so the turn can resolve before the event loop drains"
+  );
+});


### PR DESCRIPTION
## Problem

`codex-companion.mjs` can exit `0` having written nothing at all — no stdout, no stderr. Any caller that expects JSON on stdout cannot distinguish this from success.

The visible symptom is in the stop-review gate: `stop-review-gate-hook.mjs` runs `codex-companion.mjs task --json`, gets zero bytes, and `JSON.parse` throws. The hook reports *"the stop-time Codex review task returned invalid JSON"* and blocks the turn, so a tooling failure is presented to the user as a failed code review.

I have 27 occurrences logged locally over ~2.5 months, all with an identical signature:

```
status=0 signal=null errorCode=
stdout (0 bytes):
stderr:
```

No signal, no error code, both streams empty.

## Cause

`scheduleInferredCompletion` in `plugins/codex/scripts/lib/codex.mjs` schedules the 250ms timer that resolves `state.completion` when a turn arrives without an explicit final-turn marker. That timer was `unref`'d, so it does not hold the event loop open:

```js
  }, 250);
  state.completionTimer.unref?.();
```

Meanwhile `runAppServerTurn` is parked on `await state.completion`. Once the app-server socket closes, the unref'd timer is the only handle left — and unref'd handles do not keep Node alive. The loop drains, the promise never settles, and Node exits `0` silently. An unresolved promise is not an error, so nothing is reported.

It is a race against socket teardown, which is why it is intermittent rather than constant.

Notably this is *not* a broker failure. I tested both broker failure modes against the unmodified client, and neither produces this signature:

- broker accepts but never replies → hangs indefinitely
- broker drops the connection mid-request → exits `1` with `codex app-server connection closed` on stderr (`handleExit` correctly rejects pending requests)

Only event-loop drain yields exit `0` with both streams empty.

## Change

Drop the `.unref?.()` so the timer stays referenced. The timer is bounded at 250ms and is always cleared (`clearCompletionTimer`, plus it nulls itself in its own callback), so keeping it referenced cannot delay or hang shutdown. Its early-return branches only trigger when `state.completed` is already true or when work is still pending — in which case a later event reschedules.

## Test

`tests/inferred-completion.test.mjs` covers the observable contract in a subprocess, since `scheduleInferredCompletion` is not exported:

- an unref'd completion timer exits `0` with empty stdout (pins the failure mode)
- a referenced timer resolves and emits parseable JSON
- `scheduleInferredCompletion` does not unref its timer (guards the regression)

The third test fails against `main` before the change and passes after.

Verified end-to-end against a live broker: `task --json` now returns 151 bytes of valid JSON with `rawOutput` populated, where it previously returned zero bytes.

## Notes

`tests/state.test.mjs` → *"resolveStateDir uses a temp-backed per-workspace directory"* already fails on a clean checkout of `main` on macOS, before this change. It looks environment-specific and is untouched here. Excluding it, the surrounding suite is 20/21 with the 3 new tests passing. I did not run the full suite locally as it spawns real codex processes and exceeds my local timeout.
