### PR TITLE
fix(task): stop free-form prompt text from hijacking --model (defect 1 of #699)

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
-import { parseArgs, splitRawArgumentString } from "./lib/args.mjs";
+import { parseCommandInput, parseReviewArgv, parseTaskArgv } from "./lib/args.mjs";
 import {
     buildPersistentTaskThreadName,
     DEFAULT_CONTINUE_PROMPT,
@@ -125,27 +125,6 @@ function normalizeReasoningEffort(effort) {
     );
   }
   return normalized;
-}
-
-function normalizeArgv(argv) {
-  if (argv.length === 1) {
-    const [raw] = argv;
-    if (!raw || !raw.trim()) {
-      return [];
-    }
-    return splitRawArgumentString(raw);
-  }
-  return argv;
-}
-
-function parseCommandInput(argv, config = {}) {
-  return parseArgs(normalizeArgv(argv), {
-    ...config,
-    aliasMap: {
-      C: "cwd",
-      ...(config.aliasMap ?? {})
-    }
-  });
 }
 
 function resolveCommandCwd(options = {}) {
@@ -710,13 +689,7 @@ function enqueueBackgroundTask(cwd, job, request) {
 }
 
 async function handleReviewCommand(argv, config) {
-  const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["base", "scope", "model", "cwd"],
-    booleanOptions: ["json", "background", "wait"],
-    aliasMap: {
-      m: "model"
-    }
-  });
+  const { options, positionals } = parseReviewArgv(argv);
 
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveCommandWorkspace(options);
@@ -760,13 +733,7 @@ async function handleReview(argv) {
 }
 
 async function handleTask(argv) {
-  const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["model", "effort", "cwd", "prompt-file"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
-    aliasMap: {
-      m: "model"
-    }
-  });
+  const { options, positionals } = parseTaskArgv(argv);
 
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveCommandWorkspace(options);

--- a/plugins/codex/scripts/lib/args.mjs
+++ b/plugins/codex/scripts/lib/args.mjs
@@ -126,3 +126,47 @@ export function splitRawArgumentString(raw) {
 
   return tokens;
 }
+
+// A companion subcommand is often invoked with the whole request as a single
+// argument (e.g. `codex-companion.mjs task "fix the flaky test"`). Shell-split it
+// so option parsing sees individual tokens; a multi-argument argv is passed through.
+export function normalizeArgv(argv) {
+  if (argv.length === 1) {
+    const [raw] = argv;
+    if (!raw || !raw.trim()) {
+      return [];
+    }
+    return splitRawArgumentString(raw);
+  }
+  return argv;
+}
+
+export function parseCommandInput(argv, config = {}) {
+  return parseArgs(normalizeArgv(argv), {
+    ...config,
+    aliasMap: {
+      C: "cwd",
+      ...(config.aliasMap ?? {})
+    }
+  });
+}
+
+// Command argument schemas live here so the parser and its tests share one source
+// of truth. There is intentionally no short `-m` alias for `--model`: `task` and
+// `review` prompts are free-form text that routinely contains tokens like
+// `python -m pytest`, and a greedy `-m` alias swallowed the following word as the
+// model (yielding e.g. `--model pytest` -> gateway 404) while dropping it from the
+// prompt. Only the documented long `--model` form selects a model. See #699.
+export function parseTaskArgv(argv) {
+  return parseCommandInput(argv, {
+    valueOptions: ["model", "effort", "cwd", "prompt-file"],
+    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"]
+  });
+}
+
+export function parseReviewArgv(argv) {
+  return parseCommandInput(argv, {
+    valueOptions: ["base", "scope", "model", "cwd"],
+    booleanOptions: ["json", "background", "wait"]
+  });
+}

--- a/tests/task-args.test.mjs
+++ b/tests/task-args.test.mjs
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseReviewArgv, parseTaskArgv } from "../plugins/codex/scripts/lib/args.mjs";
+
+// Regression coverage for issue #699 (defect 1): free-form prompt text was parsed
+// as CLI options. A task prompt containing `python -m pytest` was tokenized and the
+// undocumented `-m` alias consumed the next word as `--model` (e.g. `--model pytest`,
+// which the gateway rejects with a 404), while also dropping those words from the
+// prompt. Only the documented long `--model` form should select a model.
+
+test("task prompt keeps `-m` tokens instead of hijacking --model", () => {
+  const { options, positionals } = parseTaskArgv([
+    "fix the failing python -m pytest tests suite"
+  ]);
+
+  assert.equal(options.model, undefined, "no model should be inferred from prompt text");
+  assert.equal(
+    positionals.join(" "),
+    "fix the failing python -m pytest tests suite",
+    "the prompt text must be preserved verbatim, including `-m pytest`"
+  );
+});
+
+test("bare `-m value` in a task prompt no longer sets the model", () => {
+  const { options, positionals } = parseTaskArgv(["-m pytest"]);
+
+  assert.equal(options.model, undefined);
+  assert.deepEqual(positionals, ["-m", "pytest"]);
+});
+
+test("task still honors the documented long --model flag", () => {
+  const { options, positionals } = parseTaskArgv(["--model spark do the thing"]);
+
+  assert.equal(options.model, "spark");
+  assert.equal(positionals.join(" "), "do the thing");
+});
+
+test("task boolean flags still parse alongside a prompt", () => {
+  const { options, positionals } = parseTaskArgv([
+    "--background --write refactor the payment module"
+  ]);
+
+  assert.equal(options.background, true);
+  assert.equal(options.write, true);
+  assert.equal(positionals.join(" "), "refactor the payment module");
+});
+
+test("review focus text keeps `-m` tokens but still honors --model", () => {
+  const swallowed = parseReviewArgv(["check the -m pytest invocation in ci"]);
+  assert.equal(swallowed.options.model, undefined);
+  assert.equal(swallowed.positionals.join(" "), "check the -m pytest invocation in ci");
+
+  const explicit = parseReviewArgv(["--model spark --scope branch"]);
+  assert.equal(explicit.options.model, "spark");
+  assert.equal(explicit.options.scope, "branch");
+});


### PR DESCRIPTION
## What

Background `task` jobs (and `review`) accept the request as a single argument string
that the companion shell-splits before option parsing. An **undocumented** short
`-m` alias for `--model` then consumed the next token of ordinary prompt text:

- A prompt containing `python -m pytest` parsed to `--model pytest`, which the
  gateway rejects with `Model "pytest" is not supported` (a 404).
- The swallowed words (`-m pytest`) also went missing from the prompt itself.

Only the documented long `--model` form is meant to select a model (the usage string
and the `codex-rescue` agent/skills only ever reference `--model`).

## Fix

Remove the `-m` alias so free-form prompt text like `python -m pytest` is preserved
verbatim and no bogus model is inferred. `--model <id>` continues to work.

The shared parsing helpers and the command argument schemas move into
`lib/args.mjs` as `parseTaskArgv` / `parseReviewArgv`, giving the parser and its
tests a single source of truth (and removing the duplicated inline configs).

## Scope

This addresses **defect 1** of #699 (the model-alias parsing). The other defects in
that report (zombie background jobs, cancel hangs, discarded stderr) are separate
concerns and are intentionally out of scope here.

## Tests

Adds `tests/task-args.test.mjs`: prompt text retains `-m` tokens, `--model` still
selects a model, boolean flags still parse, and the same holds for `review` focus
text. `npm test` and `npm run build` pass.

Addresses #699 (defect 1)
