### PR TITLE
feat: add `task --thread <id>` to resume a specific Codex thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ One simple first run is:
 
 ## Usage
 
+### Live task input
+
+Use the job ID from `/codex:status` to control an already running task:
+
+```text
+/codex:message <job-id> Use the latest plan from the plan center, not the stored chargeId.
+/codex:message <job-id> --interrupt Stop this approach and inspect the new requirement first.
+/codex:status <job-id> --wait
+/codex:answer <job-id> --request-id <id> --answers-file /absolute/path/answers.json
+```
+
+`message` uses native `turn/steer`: inputs stay ordered and are consumed before a later model request, not necessarily before tools already issued by the model. The acknowledgement means accepted, not executed. `--interrupt` cancels the current turn and starts a new turn in the same job and thread with the new input and the original write permission. Existing changes remain; its report includes observed file changes and the workspace's Git status, including pre-existing edits.
+
+`status <job-id>` shows pending messages, questions, and interruption state. Messages leave the pending list when their user-message event is observed; this confirms entry into thread history, not model execution. `status --wait` returns early for questions. Answer files contain an answers map such as `{"source":{"answers":["Use the latest plan."]}}`. Answers must match the pending request and question IDs. Questions time out after 10 minutes and interrupt the turn; the plugin does not fabricate an answer or auto-approve permissions. After answering, wait on the same job again and collect `/codex:result <job-id>`.
+
+Tasks require the shared broker; live commands never start a second runtime or silently create another thread. The broker enables `default_mode_request_user_input` for its Codex process without editing global configuration. Existing sessions must restart to load an updated broker. `task --thread <id> --write` applies workspace-write on `turn/start`; omitting `--write` explicitly restores read-only. Native `thread/queue/*` (follow-up turns after completion) is separate and is not exposed by these mid-turn controls.
+
+Run `npm test` and `npm run build` for local checks. The optional `CODEX_REAL_APP_SERVER_TEST=1 node --test tests/real-app-server.test.mjs` uses an installed Codex CLI with isolated temporary configuration and a local mock model, including actual file writing and syntax validation. It does not contact a real model service.
+
 ### `/codex:review`
 
 Runs a normal Codex review on your current work. It gives you the same quality of code review as running `/review` inside Codex directly.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Use it when you want Codex to:
 > [!NOTE]
 > Depending on the task and the model you choose these tasks might take a long time and it's generally recommended to force the task to be in the background or move the agent to the background.
 
-It supports `--background`, `--wait`, `--thread <id>`, `--resume`, and `--fresh`. If you omit `--thread`, `--resume`, and `--fresh`, the plugin can offer to continue the latest rescue thread for this repo.
+It supports `--background`, `--wait`, `--thread <id>`, `--allow-other-repo`, `--resume`, and `--fresh`. By default, `--thread` only resumes threads tracked for the current repo; use `--allow-other-repo` for a thread from another repo or one created outside this plugin. If you omit `--thread`, `--resume`, and `--fresh`, the plugin can offer to continue the latest rescue thread for this repo.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Use it when you want Codex to:
 > [!NOTE]
 > Depending on the task and the model you choose these tasks might take a long time and it's generally recommended to force the task to be in the background or move the agent to the background.
 
-It supports `--background`, `--wait`, `--resume`, and `--fresh`. If you omit `--resume` and `--fresh`, the plugin can offer to continue the latest rescue thread for this repo.
+It supports `--background`, `--wait`, `--thread <id>`, `--resume`, and `--fresh`. If you omit `--thread`, `--resume`, and `--fresh`, the plugin can offer to continue the latest rescue thread for this repo.
 
 Examples:
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "bump-version": "node scripts/bump-version.mjs",
     "check-version": "node scripts/bump-version.mjs --check",
-    "prebuild": "mkdir -p plugins/codex/.generated/app-server-types && codex app-server generate-ts --out plugins/codex/.generated/app-server-types",
+    "prebuild": "mkdir -p plugins/codex/.generated/app-server-types && codex app-server generate-ts --experimental --out plugins/codex/.generated/app-server-types",
     "build": "tsc -p tsconfig.app-server.json",
     "test": "node --test tests/*.test.mjs"
   },

--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -32,8 +32,9 @@ Forwarding rules:
 - If the user asks for a concrete model name such as `gpt-5.4-mini`, pass it through with `--model`.
 - Treat `--effort <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
 - Default to a write-capable Codex run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
-- Treat `--thread <id>`, `--resume`, and `--fresh` as routing controls and do not include them in the task text you pass through.
+- Treat `--thread <id>`, `--allow-other-repo`, `--resume`, and `--fresh` as routing controls and do not include them in the task text you pass through.
 - `--thread <id>` means pass it through to `task` and do not add `--resume-last`.
+- `--allow-other-repo` means pass it through with `--thread <id>` only when the user explicitly supplied it.
 - `--resume` means add `--resume-last`.
 - `--fresh` means do not add `--resume-last`.
 - If the user is clearly asking to continue prior Codex work in this repository, such as "continue", "keep going", "resume", "apply the top fix", or "dig deeper", add `--resume-last` unless `--thread` or `--fresh` is present.

--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -32,10 +32,11 @@ Forwarding rules:
 - If the user asks for a concrete model name such as `gpt-5.4-mini`, pass it through with `--model`.
 - Treat `--effort <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
 - Default to a write-capable Codex run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
-- Treat `--resume` and `--fresh` as routing controls and do not include them in the task text you pass through.
+- Treat `--thread <id>`, `--resume`, and `--fresh` as routing controls and do not include them in the task text you pass through.
+- `--thread <id>` means pass it through to `task` and do not add `--resume-last`.
 - `--resume` means add `--resume-last`.
 - `--fresh` means do not add `--resume-last`.
-- If the user is clearly asking to continue prior Codex work in this repository, such as "continue", "keep going", "resume", "apply the top fix", or "dig deeper", add `--resume-last` unless `--fresh` is present.
+- If the user is clearly asking to continue prior Codex work in this repository, such as "continue", "keep going", "resume", "apply the top fix", or "dig deeper", add `--resume-last` unless `--thread` or `--fresh` is present.
 - Otherwise forward the task as a fresh `task` run.
 - Preserve the user's task text as-is apart from stripping routing flags.
 - Return the stdout of the `codex-companion` command exactly as-is.

--- a/plugins/codex/commands/answer.md
+++ b/plugins/codex/commands/answer.md
@@ -1,0 +1,10 @@
+---
+description: Answer a pending Codex question without restarting its task or thread
+argument-hint: '<job-id> --request-id <id> --answers-file <path>'
+disable-model-invocation: true
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" answer "$ARGUMENTS"`
+
+Return the command output unchanged. Use the request ID and question IDs shown by `/codex:status <job-id>`. The JSON file contains the answers map, for example `{"source":{"answers":["Use the latest plan from the plan center."]}}`. Preserve the user's answer; do not invent consent or answer permission requests on the user's behalf. Stale or already answered requests are rejected.

--- a/plugins/codex/commands/message.md
+++ b/plugins/codex/commands/message.md
@@ -1,0 +1,10 @@
+---
+description: Send a correction to a running Codex task, optionally interrupting its current turn
+argument-hint: '<job-id> [--interrupt] [--prompt-file <path>] [message]'
+disable-model-invocation: true
+allowed-tools: Bash(node:*)
+---
+
+!`node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" message "$ARGUMENTS"`
+
+Return the command output unchanged. Accepted means queued for the next model request, not proof that Codex has followed the instruction. `--interrupt` cancels the current turn and continues the same job and thread with the new message, retaining existing file changes and the task's original write permissions. It does not roll back files. For a pending structured question, use `/codex:answer` instead.

--- a/plugins/codex/commands/rescue.md
+++ b/plugins/codex/commands/rescue.md
@@ -1,6 +1,6 @@
 ---
 description: Delegate investigation, an explicit fix request, or follow-up rescue work to the Codex rescue subagent
-argument-hint: "[--background|--wait] [--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [what Codex should investigate, solve, or continue]"
+argument-hint: "[--background|--wait] [--thread <id>|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [what Codex should investigate, solve, or continue]"
 allowed-tools: Bash(node:*), AskUserQuestion, Agent
 ---
 
@@ -18,6 +18,8 @@ Execution mode:
 - If neither flag is present, default to foreground.
 - `--background` and `--wait` are execution flags for Claude Code. Do not forward them to `task`, and do not treat them as part of the natural-language task text.
 - `--model` and `--effort` are runtime-selection flags. Preserve them for the forwarded `task` call, but do not treat them as part of the natural-language task text.
+- `--thread <id>` is a routing flag. Preserve it for the forwarded `task` call, but do not treat it or its value as part of the natural-language task text.
+- If the request includes `--thread`, do not ask whether to continue. The user already chose a thread.
 - If the request includes `--resume`, do not ask whether to continue. The user already chose.
 - If the request includes `--fresh`, do not ask whether to continue. The user already chose.
 - Otherwise, before starting Codex, check for a resumable rescue thread from this Claude session by running:
@@ -44,6 +46,6 @@ Operating rules:
 - Do not ask the subagent to inspect files, monitor progress, poll `/codex:status`, fetch `/codex:result`, call `/codex:cancel`, summarize output, or do follow-up work of its own.
 - Leave `--effort` unset unless the user explicitly asks for a specific reasoning effort.
 - Leave the model unset unless the user explicitly asks for one. If they ask for `spark`, map it to `gpt-5.3-codex-spark`.
-- Leave `--resume` and `--fresh` in the forwarded request. The subagent handles that routing when it builds the `task` command.
+- Leave `--thread <id>`, `--resume`, and `--fresh` in the forwarded request. The subagent handles that routing when it builds the `task` command.
 - If the helper reports that Codex is missing or unauthenticated, stop and tell the user to run `/codex:setup`.
 - If the user did not supply a request, ask what Codex should investigate or fix.

--- a/plugins/codex/commands/rescue.md
+++ b/plugins/codex/commands/rescue.md
@@ -1,6 +1,6 @@
 ---
 description: Delegate investigation, an explicit fix request, or follow-up rescue work to the Codex rescue subagent
-argument-hint: "[--background|--wait] [--thread <id>|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [what Codex should investigate, solve, or continue]"
+argument-hint: "[--background|--wait] [--thread <id>|--resume|--fresh] [--allow-other-repo] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [what Codex should investigate, solve, or continue]"
 allowed-tools: Bash(node:*), AskUserQuestion, Agent
 ---
 
@@ -19,6 +19,8 @@ Execution mode:
 - `--background` and `--wait` are execution flags for Claude Code. Do not forward them to `task`, and do not treat them as part of the natural-language task text.
 - `--model` and `--effort` are runtime-selection flags. Preserve them for the forwarded `task` call, but do not treat them as part of the natural-language task text.
 - `--thread <id>` is a routing flag. Preserve it for the forwarded `task` call, but do not treat it or its value as part of the natural-language task text.
+- `--allow-other-repo` is a routing flag for `--thread <id>`. Preserve it for the forwarded `task` call, but do not treat it as part of the natural-language task text.
+- Without `--allow-other-repo`, `--thread <id>` only accepts threads tracked for the current repo. Threads from another repo or created outside this plugin require the override.
 - If the request includes `--thread`, do not ask whether to continue. The user already chose a thread.
 - If the request includes `--resume`, do not ask whether to continue. The user already chose.
 - If the request includes `--fresh`, do not ask whether to continue. The user already chose.
@@ -46,6 +48,6 @@ Operating rules:
 - Do not ask the subagent to inspect files, monitor progress, poll `/codex:status`, fetch `/codex:result`, call `/codex:cancel`, summarize output, or do follow-up work of its own.
 - Leave `--effort` unset unless the user explicitly asks for a specific reasoning effort.
 - Leave the model unset unless the user explicitly asks for one. If they ask for `spark`, map it to `gpt-5.3-codex-spark`.
-- Leave `--thread <id>`, `--resume`, and `--fresh` in the forwarded request. The subagent handles that routing when it builds the `task` command.
+- Leave `--thread <id>`, `--allow-other-repo`, `--resume`, and `--fresh` in the forwarded request. The subagent handles that routing when it builds the `task` command.
 - If the helper reports that Codex is missing or unauthenticated, stop and tell the user to run `/codex:setup`.
 - If the user did not supply a request, ask what Codex should investigate or fix.

--- a/plugins/codex/commands/status.md
+++ b/plugins/codex/commands/status.md
@@ -15,3 +15,5 @@ If the user did not pass a job ID:
 If the user did pass a job ID:
 - Present the full command output to the user.
 - Do not summarize or condense it.
+
+`--wait` returns early when the job has a pending question. This is not task completion: show the questions and answer with `/codex:answer`, then wait for the same job again. Live details distinguish accepted-but-unconsumed messages, pending questions, interruption, and observed file changes. Unavailable live state must not be presented as an empty queue.

--- a/plugins/codex/commands/status.md
+++ b/plugins/codex/commands/status.md
@@ -1,6 +1,6 @@
 ---
 description: Show active and recent Codex jobs for this repository, including review-gate status
-argument-hint: '[job-id] [--wait] [--timeout-ms <ms>] [--all]'
+argument-hint: '[job-id] [--wait] [--timeout-ms <ms>] [--stall-ms <ms>] [--all]'
 disable-model-invocation: true
 allowed-tools: Bash(node:*)
 ---
@@ -17,3 +17,23 @@ If the user did pass a job ID:
 - Do not summarize or condense it.
 
 `--wait` returns early when the job has a pending question. This is not task completion: show the questions and answer with `/codex:answer`, then wait for the same job again. Live details distinguish accepted-but-unconsumed messages, pending questions, interruption, and observed file changes. Unavailable live state must not be presented as an empty queue.
+
+`--wait` also returns early when Codex sends a notification; this is not task completion, so wait for the same job again. Returned notifications are acknowledged and will not trigger the next wait; plain status leaves them pending.
+
+For a Claude Code Monitor, run `node "${CLAUDE_PLUGIN_ROOT}/scripts/codex-companion.mjs" events --cwd <repo> [--poll-ms <ms>] [--stall-ms <ms>]` (poll default: 2000 ms). It watches this workspace's current-session jobs until SIGINT or SIGTERM, printing each transition once:
+
+```text
+DONE job=<job-id> thread=<thread-id>
+FAILED job=<job-id> thread=<thread-id> <first error line, or unknown>
+QUESTION job=<job-id> request=<request-id> <first question, one line, at most 200 characters>
+NOTIFIED job=<job-id> thread=<thread-id> <message with newlines replaced by spaces>
+STALLED job=<job-id> thread=<thread-id> <minutes>m without progress
+```
+
+Jobs already finished when monitoring starts are omitted. Printed notifications are acknowledged, so `status --wait` will not return them again. A missing thread ID is printed as `unknown`. Both commands fail active jobs when their recorded owner has exited, or their broker is unreachable for three consecutive polls.
+
+`--stall-ms` defaults to 900000 (15 minutes) for both `events` and `status --wait`. With no new progress log entry for this interval, `events` emits `STALLED` at most once per interval, and `status --wait --json` returns early with `stalled: true`; neither marks the job failed. Running job status shows owner liveness and minutes since last progress.
+
+Task status and stored results show the sandbox mode and effective network access. `task --sandbox <read-only|workspace-write|danger-full-access>` overrides `--write`; `danger-full-access` permits writes and network access. `--network` enables network access for `workspace-write`. Defaults remain read-only, or workspace-write without network when `--write` is given.
+
+The shared broker supports concurrent task threads. It shuts down after 10 minutes with no connected clients or owned streams (`app-server-broker.mjs serve --idle-timeout-ms <ms>` overrides this); the next task starts a fresh broker automatically.

--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -8,6 +8,7 @@ import process from "node:process";
 import { parseArgs } from "./lib/args.mjs";
 import { BROKER_BUSY_RPC_CODE, CodexAppServerClient } from "./lib/app-server.mjs";
 import { parseBrokerEndpoint } from "./lib/broker-endpoint.mjs";
+import { LiveTurnControl } from "./lib/live-turn-control.mjs";
 
 const STREAMING_METHODS = new Set(["turn/start", "review/start", "thread/compact/start"]);
 
@@ -33,10 +34,6 @@ function send(socket, message) {
   socket.write(`${JSON.stringify(message)}\n`);
 }
 
-function isInterruptRequest(message) {
-  return message?.method === "turn/interrupt";
-}
-
 function writePidFile(pidFile) {
   if (!pidFile) {
     return;
@@ -52,7 +49,7 @@ async function main() {
   }
 
   const { options } = parseArgs(argv, {
-    valueOptions: ["cwd", "pid-file", "endpoint"]
+    valueOptions: ["cwd", "pid-file", "endpoint", "input-timeout-ms"]
   });
 
   if (!options.endpoint) {
@@ -63,9 +60,13 @@ async function main() {
   const endpoint = String(options.endpoint);
   const listenTarget = parseBrokerEndpoint(endpoint);
   const pidFile = options["pid-file"] ? path.resolve(options["pid-file"]) : null;
+  const inputTimeoutMs = Number(options["input-timeout-ms"] ?? 600000);
+  if (!Number.isSafeInteger(inputTimeoutMs) || inputTimeoutMs <= 0 || inputTimeoutMs > 2147483647) {
+    throw new Error("input-timeout-ms must be a positive timer duration.");
+  }
   writePidFile(pidFile);
-
-  const appClient = await CodexAppServerClient.connect(cwd, { disableBroker: true });
+  const appClient = await CodexAppServerClient.connect(cwd, { disableBroker: true, requestUserInput: true });
+  const controls = new LiveTurnControl(appClient, routeNotification, inputTimeoutMs);
   let activeRequestSocket = null;
   let activeStreamSocket = null;
   let activeStreamThreadIds = null;
@@ -82,6 +83,7 @@ async function main() {
   }
 
   function routeNotification(message) {
+    controls.observe(message);
     const target = activeRequestSocket ?? activeStreamSocket;
     if (!target) {
       return;
@@ -100,6 +102,7 @@ async function main() {
   }
 
   async function shutdown(server) {
+    controls.close();
     for (const socket of sockets) {
       socket.end();
     }
@@ -114,6 +117,7 @@ async function main() {
   }
 
   appClient.setNotificationHandler(routeNotification);
+  appClient.setServerRequestHandler((message) => controls.handleServerRequest(message));
 
   const server = net.createServer((socket) => {
     sockets.add(socket);
@@ -167,12 +171,21 @@ async function main() {
           continue;
         }
 
-        const allowInterruptDuringActiveStream =
-          isInterruptRequest(message) && activeStreamSocket && activeStreamSocket !== socket && !activeRequestSocket;
+        if (controls.handles(message.method)) {
+          try {
+            if (message.method === "broker/redirect" && !activeStreamSocket) {
+              throw new Error("No task owner is connected to continue after interruption.");
+            }
+            const result = await controls.request(message.method, message.params ?? {});
+            send(socket, { id: message.id, result });
+          } catch (error) {
+            send(socket, { id: message.id, error: buildJsonRpcError(error.rpcCode ?? -32600, error.message) });
+          }
+          continue;
+        }
 
         if (
-          ((activeRequestSocket && activeRequestSocket !== socket) || (activeStreamSocket && activeStreamSocket !== socket)) &&
-          !allowInterruptDuringActiveStream
+          (activeRequestSocket && activeRequestSocket !== socket) || (activeStreamSocket && activeStreamSocket !== socket)
         ) {
           send(socket, {
             id: message.id,
@@ -181,21 +194,9 @@ async function main() {
           continue;
         }
 
-        if (allowInterruptDuringActiveStream) {
-          try {
-            const result = await appClient.request(message.method, message.params ?? {});
-            send(socket, { id: message.id, result });
-          } catch (error) {
-            send(socket, {
-              id: message.id,
-              error: buildJsonRpcError(error.rpcCode ?? -32000, error.message)
-            });
-          }
-          continue;
-        }
-
         const isStreaming = STREAMING_METHODS.has(message.method);
         activeRequestSocket = socket;
+        if (message.method === "turn/start") controls.starting(message.params ?? {});
 
         try {
           const result = await appClient.request(message.method, message.params ?? {});

--- a/plugins/codex/scripts/app-server-broker.mjs
+++ b/plugins/codex/scripts/app-server-broker.mjs
@@ -49,7 +49,7 @@ async function main() {
   }
 
   const { options } = parseArgs(argv, {
-    valueOptions: ["cwd", "pid-file", "endpoint", "input-timeout-ms"]
+    valueOptions: ["cwd", "pid-file", "endpoint", "input-timeout-ms", "idle-timeout-ms"]
   });
 
   if (!options.endpoint) {
@@ -64,44 +64,86 @@ async function main() {
   if (!Number.isSafeInteger(inputTimeoutMs) || inputTimeoutMs <= 0 || inputTimeoutMs > 2147483647) {
     throw new Error("input-timeout-ms must be a positive timer duration.");
   }
+  const idleTimeoutMs = Number(options["idle-timeout-ms"] ?? 600000);
+  if (!Number.isSafeInteger(idleTimeoutMs) || idleTimeoutMs <= 0 || idleTimeoutMs > 2147483647) {
+    throw new Error("idle-timeout-ms must be a positive timer duration.");
+  }
   writePidFile(pidFile);
   const appClient = await CodexAppServerClient.connect(cwd, { disableBroker: true, requestUserInput: true });
   const controls = new LiveTurnControl(appClient, routeNotification, inputTimeoutMs);
   let activeRequestSocket = null;
-  let activeStreamSocket = null;
-  let activeStreamThreadIds = null;
+  const streamOwners = new Map();
+  const pendingThreadStarts = new Map();
+  let requestTail = Promise.resolve();
+  let pendingStreamNotifications = null;
+  let idleTimer = null;
+  let shutdownPromise = null;
   const sockets = new Set();
+
+  function resetIdleTimer() {
+    clearTimeout(idleTimer);
+    if (!shutdownPromise && sockets.size === 0 && streamOwners.size === 0) {
+      idleTimer = setTimeout(async () => {
+        await shutdown(server);
+        process.exit(0);
+      }, idleTimeoutMs);
+      idleTimer.unref();
+    }
+  }
 
   function clearSocketOwnership(socket) {
     if (activeRequestSocket === socket) {
       activeRequestSocket = null;
     }
-    if (activeStreamSocket === socket) {
-      activeStreamSocket = null;
-      activeStreamThreadIds = null;
+    for (const [threadId, owner] of streamOwners) {
+      if (owner === socket) streamOwners.delete(threadId);
     }
+    resetIdleTimer();
   }
 
   function routeNotification(message) {
     controls.observe(message);
-    const target = activeRequestSocket ?? activeStreamSocket;
+    deliverNotification(message);
+  }
+
+  function deliverNotification(message) {
+    const threadId = message.params?.threadId ?? message.params?.thread?.id;
+    const parentId = message.params?.thread?.source?.subagent?.thread_spawn?.parent_thread_id;
+    if (threadId && parentId && !streamOwners.has(threadId) && streamOwners.has(parentId)) {
+      streamOwners.set(threadId, streamOwners.get(parentId));
+    }
+    // Threadless notifications belong only to the current non-streaming request; otherwise drop them.
+    const target = threadId ? streamOwners.get(threadId) : activeRequestSocket;
     if (!target) {
+      if (message.method === "thread/started") pendingThreadStarts.set(threadId, message);
+      else if (threadId && pendingStreamNotifications) pendingStreamNotifications.push(message);
       return;
     }
-    send(target, message);
-    if (message.method === "turn/completed" && activeStreamSocket === target) {
-      const threadId = message.params?.threadId ?? null;
-      if (!threadId || !activeStreamThreadIds || activeStreamThreadIds.has(threadId)) {
-        activeStreamSocket = null;
-        activeStreamThreadIds = null;
-        if (activeRequestSocket === target) {
-          activeRequestSocket = null;
+    // Spawned agents share their parent's owner, never another root task's stream.
+    if (message.params?.item?.type === "collabAgentToolCall") {
+      for (const childId of message.params.item.receiverThreadIds ?? []) {
+        if (!streamOwners.has(childId)) streamOwners.set(childId, target);
+        if (streamOwners.get(childId) === target && pendingThreadStarts.has(childId)) {
+          send(target, pendingThreadStarts.get(childId));
+          pendingThreadStarts.delete(childId);
         }
       }
     }
+    send(target, message);
+    if (message.method === "turn/completed") {
+      streamOwners.delete(threadId);
+    }
+    resetIdleTimer();
   }
 
-  async function shutdown(server) {
+  function shutdown(server) {
+    if (shutdownPromise) return shutdownPromise;
+    clearTimeout(idleTimer);
+    shutdownPromise = closeServer(server);
+    return shutdownPromise;
+  }
+
+  async function closeServer(server) {
     controls.close();
     for (const socket of sockets) {
       socket.end();
@@ -121,6 +163,7 @@ async function main() {
 
   const server = net.createServer((socket) => {
     sockets.add(socket);
+    resetIdleTimer();
     socket.setEncoding("utf8");
     let buffer = "";
 
@@ -173,7 +216,7 @@ async function main() {
 
         if (controls.handles(message.method)) {
           try {
-            if (message.method === "broker/redirect" && !activeStreamSocket) {
+            if (message.method === "broker/redirect" && !streamOwners.has(message.params?.threadId)) {
               throw new Error("No task owner is connected to continue after interruption.");
             }
             const result = await controls.request(message.method, message.params ?? {});
@@ -184,42 +227,56 @@ async function main() {
           continue;
         }
 
-        if (
-          (activeRequestSocket && activeRequestSocket !== socket) || (activeStreamSocket && activeStreamSocket !== socket)
-        ) {
-          send(socket, {
-            id: message.id,
-            error: buildJsonRpcError(BROKER_BUSY_RPC_CODE, "Shared Codex broker is busy.")
-          });
-          continue;
-        }
-
-        const isStreaming = STREAMING_METHODS.has(message.method);
-        activeRequestSocket = socket;
-        if (message.method === "turn/start") controls.starting(message.params ?? {});
-
-        try {
-          const result = await appClient.request(message.method, message.params ?? {});
-          send(socket, { id: message.id, result });
+        // Serialize request/response exchanges, not the lifetime of their turns.
+        const request = requestTail.then(async () => {
+          if (socket.destroyed) return;
+          const isStreaming = STREAMING_METHODS.has(message.method);
+          const threadIds = buildStreamThreadIds(message.method, message.params, null);
+          if (isStreaming && [...threadIds].some((id) => streamOwners.has(id) && streamOwners.get(id) !== socket)) {
+            send(socket, { id: message.id, error: buildJsonRpcError(BROKER_BUSY_RPC_CODE, "Shared Codex broker is busy.") });
+            return;
+          }
+          const added = new Set();
           if (isStreaming) {
-            activeStreamSocket = socket;
-            activeStreamThreadIds = buildStreamThreadIds(message.method, message.params ?? {}, result);
-          }
-          if (activeRequestSocket === socket) {
+            // Reserve known threads before sending: turn events can precede the RPC response.
+            for (const id of threadIds) {
+              if (!streamOwners.has(id)) added.add(id);
+              streamOwners.set(id, socket);
+            }
+            pendingStreamNotifications = [];
+            resetIdleTimer();
+          } else activeRequestSocket = socket;
+          if (message.method === "turn/start") controls.starting(message.params ?? {});
+          try {
+            const result = await appClient.request(message.method, message.params ?? {});
+            if (message.method === "thread/start") pendingThreadStarts.delete(result.thread?.id);
+            if (isStreaming && !socket.destroyed) {
+              for (const id of buildStreamThreadIds(message.method, message.params, result)) {
+                if (!threadIds.has(id)) {
+                  streamOwners.set(id, socket);
+                  if (pendingThreadStarts.has(id)) {
+                    send(socket, pendingThreadStarts.get(id));
+                    pendingThreadStarts.delete(id);
+                  }
+                }
+              }
+              const buffered = pendingStreamNotifications;
+              pendingStreamNotifications = null;
+              for (const notification of buffered) deliverNotification(notification);
+            }
+            send(socket, { id: message.id, result });
+          } catch (error) {
+            for (const id of added) {
+              if (streamOwners.get(id) === socket) streamOwners.delete(id);
+            }
+            send(socket, { id: message.id, error: buildJsonRpcError(error.rpcCode ?? -32000, error.message) });
+          } finally {
             activeRequestSocket = null;
+            pendingStreamNotifications = null;
+            resetIdleTimer();
           }
-        } catch (error) {
-          send(socket, {
-            id: message.id,
-            error: buildJsonRpcError(error.rpcCode ?? -32000, error.message)
-          });
-          if (activeRequestSocket === socket) {
-            activeRequestSocket = null;
-          }
-          if (activeStreamSocket === socket && !isStreaming) {
-            activeStreamSocket = null;
-          }
-        }
+        });
+        requestTail = request.catch(() => {});
       }
     });
 
@@ -245,6 +302,7 @@ async function main() {
   });
 
   server.listen(listenTarget.path);
+  resetIdleTimer();
 }
 
 main().catch((error) => {

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -79,7 +79,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--thread <id>|--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
@@ -464,10 +464,10 @@ async function executeTaskRun(request) {
 
   const taskMetadata = buildTaskRunMetadata({
     prompt: request.prompt,
-    resumeLast: request.resumeLast
+    resumeLast: Boolean(request.resumeLast || request.resumeThreadId)
   });
 
-  let resumeThreadId = null;
+  let resumeThreadId = request.resumeThreadId ?? null;
   if (request.resumeLast) {
     const latestThread = await resolveLatestTrackedTaskThread(workspaceRoot, {
       excludeJobId: request.jobId
@@ -601,7 +601,7 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, resumeThreadId, jobId }) {
   return {
     cwd,
     model,
@@ -609,6 +609,7 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId
     prompt,
     write,
     resumeLast,
+    resumeThreadId,
     jobId
   };
 }
@@ -761,7 +762,7 @@ async function handleReview(argv) {
 
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["model", "effort", "cwd", "prompt-file"],
+    valueOptions: ["model", "effort", "cwd", "prompt-file", "thread"],
     booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
     aliasMap: {
       m: "model"
@@ -775,19 +776,26 @@ async function handleTask(argv) {
   const prompt = readTaskPrompt(cwd, options, positionals);
 
   const resumeLast = Boolean(options["resume-last"] || options.resume);
+  const resumeThreadId = options.thread == null ? null : String(options.thread).trim();
+  if (options.thread != null && (!resumeThreadId || resumeThreadId.startsWith("-"))) {
+    throw new Error("Provide a thread id with --thread.");
+  }
   const fresh = Boolean(options.fresh);
   if (resumeLast && fresh) {
     throw new Error("Choose either --resume/--resume-last or --fresh.");
   }
+  if (resumeThreadId && (resumeLast || fresh)) {
+    throw new Error("Choose only one of --thread, --resume/--resume-last, or --fresh.");
+  }
   const write = Boolean(options.write);
   const taskMetadata = buildTaskRunMetadata({
     prompt,
-    resumeLast
+    resumeLast: Boolean(resumeLast || resumeThreadId)
   });
 
   if (options.background) {
     ensureCodexAvailable(cwd);
-    requireTaskRequest(prompt, resumeLast);
+    requireTaskRequest(prompt, Boolean(resumeLast || resumeThreadId));
 
     const job = buildTaskJob(workspaceRoot, taskMetadata, write);
     const request = buildTaskRequest({
@@ -797,6 +805,7 @@ async function handleTask(argv) {
       prompt,
       write,
       resumeLast,
+      resumeThreadId,
       jobId: job.id
     });
     const { payload } = enqueueBackgroundTask(cwd, job, request);
@@ -815,6 +824,7 @@ async function handleTask(argv) {
         prompt,
         write,
         resumeLast,
+        resumeThreadId,
         jobId: job.id,
         onProgress: progress
       }),

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -22,7 +22,8 @@ import {
     runAppServerTurn
   } from "./lib/codex.mjs";
 import { resolveClaudeSessionPath } from "./lib/claude-session-transfer.mjs";
-import { liveStatus, sendLiveCommand } from "./lib/live-commands.mjs";
+import { acknowledgeNotifications, liveStatus, sendLiveCommand } from "./lib/live-commands.mjs";
+import { streamJobEvents } from "./lib/job-events.mjs";
 import { readStdinIfPiped } from "./lib/fs.mjs";
 import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./lib/git.mjs";
 import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
@@ -38,6 +39,9 @@ import {
 import {
   buildSingleJobSnapshot,
   buildStatusSnapshot,
+  checkJobLiveness,
+  DEFAULT_STALL_MS,
+  lastJobProgressAt,
   readStoredJob,
   resolveCancelableJob,
   resolveResultJob,
@@ -80,9 +84,10 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--thread <id>|--resume-last|--resume|--fresh] [--allow-other-repo] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--sandbox <read-only|workspace-write|danger-full-access>] [--network] [--thread <id>|--resume-last|--resume|--fresh] [--allow-other-repo] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
+      "  node scripts/codex-companion.mjs events [--cwd <repo>] [--poll-ms <ms>] [--stall-ms <ms>]",
       "  node scripts/codex-companion.mjs message <job-id> [--interrupt] [--prompt-file <path>] [text] [--json]",
       "  node scripts/codex-companion.mjs answer <job-id> --request-id <id> --answers-file <path> [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
@@ -322,12 +327,28 @@ async function waitForSingleJobSnapshot(cwd, reference, options = {}) {
   const timeoutMs = Math.max(0, Number(options.timeoutMs) || DEFAULT_STATUS_WAIT_TIMEOUT_MS);
   const pollIntervalMs = Math.max(100, Number(options.pollIntervalMs) || DEFAULT_STATUS_POLL_INTERVAL_MS);
   const deadline = Date.now() + timeoutMs;
+  const stallMs = options.stallMs ?? DEFAULT_STALL_MS;
+  const brokerFailures = new Map();
   let snapshot = buildSingleJobSnapshot(cwd, reference);
 
   while (isActiveJobStatus(snapshot.job.status) && Date.now() < deadline) {
+    snapshot.job.live = await liveStatus(snapshot.workspaceRoot, snapshot.job);
+    snapshot.job = checkJobLiveness(snapshot.workspaceRoot, snapshot.job, snapshot.job.live, brokerFailures);
+    if (!isActiveJobStatus(snapshot.job.status)) break;
     if (snapshot.job.threadId) {
-      snapshot.job.live = await liveStatus(snapshot.workspaceRoot, snapshot.job);
       if (snapshot.job.live?.questions?.length) return { ...snapshot, waitingForAnswer: true, waitTimedOut: false, timeoutMs };
+      if (snapshot.job.live?.notifications?.length) {
+        await acknowledgeNotifications(snapshot.workspaceRoot, snapshot.job, snapshot.job.live.notifications.map((notification) => notification.id));
+        return { ...snapshot, hasNotifications: true, waitTimedOut: false, timeoutMs };
+      }
+    }
+    const lastStall = Date.parse(snapshot.job.lastStalledAt ?? "") || 0;
+    if (snapshot.job.status === "running" && Date.now() - Math.max(lastJobProgressAt(snapshot.job), lastStall) >= stallMs) {
+      snapshot.job.lastStalledAt = nowIso();
+      const stored = readStoredJob(snapshot.workspaceRoot, snapshot.job.id);
+      writeJobFile(snapshot.workspaceRoot, snapshot.job.id, { ...(stored ?? snapshot.job), lastStalledAt: snapshot.job.lastStalledAt });
+      upsertJob(snapshot.workspaceRoot, { id: snapshot.job.id, lastStalledAt: snapshot.job.lastStalledAt });
+      return { ...snapshot, stalled: true, waitTimedOut: false, timeoutMs, stallMs };
     }
     await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())));
     snapshot = buildSingleJobSnapshot(cwd, reference);
@@ -508,7 +529,8 @@ async function executeTaskRun(request) {
     defaultPrompt: resumeThreadId ? DEFAULT_CONTINUE_PROMPT : "",
     model: request.model,
     effort: request.effort,
-    sandbox: request.write ? "workspace-write" : "read-only",
+    sandbox: request.sandbox ?? (request.write ? "workspace-write" : "read-only"),
+    network: Boolean(request.network),
     onProgress: request.onProgress,
     persistThread: true,
     threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
@@ -611,8 +633,8 @@ function createTrackedProgress(job, options = {}) {
   };
 }
 
-function buildTaskJob(workspaceRoot, taskMetadata, write) {
-  return createCompanionJob({
+function buildTaskJob(workspaceRoot, taskMetadata, write, sandbox, network) {
+  return { ...createCompanionJob({
     prefix: "task",
     kind: "task",
     title: taskMetadata.title,
@@ -620,16 +642,18 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
     jobClass: "task",
     summary: taskMetadata.summary,
     write
-  });
+  }), sandbox, network };
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, resumeThreadId, allowOtherRepo, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, sandbox, network, resumeLast, resumeThreadId, allowOtherRepo, jobId }) {
   return {
     cwd,
     model,
     effort,
     prompt,
     write,
+    sandbox,
+    network,
     resumeLast,
     resumeThreadId,
     allowOtherRepo,
@@ -785,8 +809,8 @@ async function handleReview(argv) {
 
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["model", "effort", "cwd", "prompt-file", "thread"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background", "allow-other-repo"],
+    valueOptions: ["model", "effort", "cwd", "prompt-file", "thread", "sandbox"],
+    booleanOptions: ["json", "write", "network", "resume-last", "resume", "fresh", "background", "allow-other-repo"],
     aliasMap: {
       m: "model"
     }
@@ -811,47 +835,47 @@ async function handleTask(argv) {
   if (resumeThreadId && (resumeLast || fresh)) {
     throw new Error("Choose only one of --thread, --resume/--resume-last, or --fresh.");
   }
-  const write = Boolean(options.write);
+  const sandbox = options.sandbox ?? (options.write ? "workspace-write" : "read-only");
+  if (!["read-only", "workspace-write", "danger-full-access"].includes(sandbox)) {
+    throw new Error("--sandbox must be read-only, workspace-write, or danger-full-access.");
+  }
+  const write = sandbox !== "read-only";
+  const network = Boolean(options.network);
   const taskMetadata = buildTaskRunMetadata({
     prompt,
     resumeLast: Boolean(resumeLast || resumeThreadId)
   });
 
+  const job = buildTaskJob(workspaceRoot, taskMetadata, write, sandbox, network);
+  const request = buildTaskRequest({
+    cwd,
+    model,
+    effort,
+    prompt,
+    write,
+    sandbox,
+    network,
+    resumeLast,
+    resumeThreadId,
+    allowOtherRepo,
+    jobId: job.id
+  });
+  job.request = request;
+
   if (options.background) {
     ensureCodexAvailable(cwd);
     requireTaskRequest(prompt, Boolean(resumeLast || resumeThreadId));
 
-    const job = buildTaskJob(workspaceRoot, taskMetadata, write);
-    const request = buildTaskRequest({
-      cwd,
-      model,
-      effort,
-      prompt,
-      write,
-      resumeLast,
-      resumeThreadId,
-      allowOtherRepo,
-      jobId: job.id
-    });
     const { payload } = enqueueBackgroundTask(cwd, job, request);
     outputCommandResult(payload, renderQueuedTaskLaunch(payload), options.json);
     return;
   }
 
-  const job = buildTaskJob(workspaceRoot, taskMetadata, write);
   await runForegroundCommand(
     job,
     (progress) =>
       executeTaskRun({
-        cwd,
-        model,
-        effort,
-        prompt,
-        write,
-        resumeLast,
-        resumeThreadId,
-        allowOtherRepo,
-        jobId: job.id,
+        ...request,
         onProgress: progress
       }),
     { json: options.json }
@@ -916,9 +940,36 @@ async function handleTaskWorker(argv) {
   );
 }
 
+async function handleEvents(argv) {
+  const { options } = parseCommandInput(argv, { valueOptions: ["cwd", "poll-ms", "stall-ms"] });
+  const pollMs = Number(options["poll-ms"] ?? 2000);
+  if (!Number.isSafeInteger(pollMs) || pollMs <= 0 || pollMs > 2147483647) {
+    throw new Error("--poll-ms must be a positive integer no greater than 2147483647.");
+  }
+  const controller = new AbortController();
+  const stop = () => {
+    controller.abort();
+    process.stdout.write("", () => process.exit(0));
+  };
+  process.on("SIGINT", stop);
+  process.on("SIGTERM", stop);
+  try {
+    await streamJobEvents(resolveCommandCwd(options), { pollMs, stallMs: parseStallMs(options), signal: controller.signal });
+  } finally {
+    process.off("SIGINT", stop);
+    process.off("SIGTERM", stop);
+  }
+}
+
+function parseStallMs(options) {
+  const stallMs = Number(options["stall-ms"] ?? DEFAULT_STALL_MS);
+  if (!Number.isSafeInteger(stallMs) || stallMs <= 0) throw new Error("--stall-ms must be a positive integer.");
+  return stallMs;
+}
+
 async function handleStatus(argv) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["cwd", "timeout-ms", "poll-interval-ms"],
+    valueOptions: ["cwd", "timeout-ms", "poll-interval-ms", "stall-ms"],
     booleanOptions: ["json", "all", "wait"]
   });
 
@@ -928,12 +979,16 @@ async function handleStatus(argv) {
     const snapshot = options.wait
       ? await waitForSingleJobSnapshot(cwd, reference, {
           timeoutMs: options["timeout-ms"],
-          pollIntervalMs: options["poll-interval-ms"]
+          pollIntervalMs: options["poll-interval-ms"],
+          stallMs: parseStallMs(options)
         })
       : buildSingleJobSnapshot(cwd, reference);
     snapshot.job.live ??= await liveStatus(snapshot.workspaceRoot, snapshot.job);
-    if (snapshot.job.live?.questions?.length) snapshot.job.phase = "waiting-for-answer";
-    outputCommandResult(snapshot, renderJobStatusReport(snapshot.job), options.json);
+    if (isActiveJobStatus(snapshot.job.status) && snapshot.job.live?.questions?.length) snapshot.job.phase = "waiting-for-answer";
+    const stalledLine = snapshot.stalled
+      ? `STALLED job=${snapshot.job.id} thread=${snapshot.job.threadId ?? "unknown"} ${snapshot.job.progressAgeMinutes}m without progress\n`
+      : "";
+    outputCommandResult(snapshot, `${stalledLine}${renderJobStatusReport(snapshot.job)}`, options.json);
     return;
   }
 
@@ -1108,6 +1163,9 @@ async function main() {
       break;
     case "status":
       await handleStatus(argv);
+      break;
+    case "events":
+      await handleEvents(argv);
       break;
     case "message":
     case "answer":

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -79,7 +79,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--thread <id>|--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--thread <id>|--resume-last|--resume|--fresh] [--allow-other-repo] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
@@ -355,6 +355,16 @@ async function resolveLatestTrackedTaskThread(cwd, options = {}) {
   return findLatestTaskThread(workspaceRoot);
 }
 
+function requireTrackedThreadForWorkspace(workspaceRoot, threadId) {
+  if (listJobs(workspaceRoot).some((job) => job.threadId === threadId)) {
+    return;
+  }
+
+  throw new Error(
+    `Thread ${threadId} is not tracked for this repository. Pass --allow-other-repo to resume a thread from another repository or one created outside this plugin.`
+  );
+}
+
 async function executeReviewRun(request) {
   ensureCodexAvailable(request.cwd);
   ensureGitRepository(request.cwd);
@@ -461,6 +471,9 @@ async function executeReviewRun(request) {
 async function executeTaskRun(request) {
   const workspaceRoot = resolveWorkspaceRoot(request.cwd);
   ensureCodexAvailable(request.cwd);
+  if (request.resumeThreadId && !request.allowOtherRepo) {
+    requireTrackedThreadForWorkspace(workspaceRoot, request.resumeThreadId);
+  }
 
   const taskMetadata = buildTaskRunMetadata({
     prompt: request.prompt,
@@ -601,7 +614,7 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, resumeThreadId, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, resumeThreadId, allowOtherRepo, jobId }) {
   return {
     cwd,
     model,
@@ -610,6 +623,7 @@ function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, resum
     write,
     resumeLast,
     resumeThreadId,
+    allowOtherRepo,
     jobId
   };
 }
@@ -763,7 +777,7 @@ async function handleReview(argv) {
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["model", "effort", "cwd", "prompt-file", "thread"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
+    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background", "allow-other-repo"],
     aliasMap: {
       m: "model"
     }
@@ -777,6 +791,7 @@ async function handleTask(argv) {
 
   const resumeLast = Boolean(options["resume-last"] || options.resume);
   const resumeThreadId = options.thread == null ? null : String(options.thread).trim();
+  const allowOtherRepo = Boolean(options["allow-other-repo"]);
   if (options.thread != null && (!resumeThreadId || resumeThreadId.startsWith("-"))) {
     throw new Error("Provide a thread id with --thread.");
   }
@@ -806,6 +821,7 @@ async function handleTask(argv) {
       write,
       resumeLast,
       resumeThreadId,
+      allowOtherRepo,
       jobId: job.id
     });
     const { payload } = enqueueBackgroundTask(cwd, job, request);
@@ -825,6 +841,7 @@ async function handleTask(argv) {
         write,
         resumeLast,
         resumeThreadId,
+        allowOtherRepo,
         jobId: job.id,
         onProgress: progress
       }),

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -22,6 +22,7 @@ import {
     runAppServerTurn
   } from "./lib/codex.mjs";
 import { resolveClaudeSessionPath } from "./lib/claude-session-transfer.mjs";
+import { liveStatus, sendLiveCommand } from "./lib/live-commands.mjs";
 import { readStdinIfPiped } from "./lib/fs.mjs";
 import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./lib/git.mjs";
 import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
@@ -82,6 +83,8 @@ function printUsage() {
       "  node scripts/codex-companion.mjs task [--background] [--write] [--thread <id>|--resume-last|--resume|--fresh] [--allow-other-repo] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
+      "  node scripts/codex-companion.mjs message <job-id> [--interrupt] [--prompt-file <path>] [text] [--json]",
+      "  node scripts/codex-companion.mjs answer <job-id> --request-id <id> --answers-file <path> [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
       "  node scripts/codex-companion.mjs cancel [job-id] [--json]"
     ].join("\n")
@@ -322,6 +325,10 @@ async function waitForSingleJobSnapshot(cwd, reference, options = {}) {
   let snapshot = buildSingleJobSnapshot(cwd, reference);
 
   while (isActiveJobStatus(snapshot.job.status) && Date.now() < deadline) {
+    if (snapshot.job.threadId) {
+      snapshot.job.live = await liveStatus(snapshot.workspaceRoot, snapshot.job);
+      if (snapshot.job.live?.questions?.length) return { ...snapshot, waitingForAnswer: true, waitTimedOut: false, timeoutMs };
+    }
     await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())));
     snapshot = buildSingleJobSnapshot(cwd, reference);
   }
@@ -526,6 +533,8 @@ async function executeTaskRun(request) {
     threadId: result.threadId,
     rawOutput,
     touchedFiles: result.touchedFiles,
+    interruptedTurns: result.interruptedTurns,
+    error: result.error ?? null,
     reasoningSummary: result.reasoningSummary
   };
 
@@ -922,6 +931,8 @@ async function handleStatus(argv) {
           pollIntervalMs: options["poll-interval-ms"]
         })
       : buildSingleJobSnapshot(cwd, reference);
+    snapshot.job.live ??= await liveStatus(snapshot.workspaceRoot, snapshot.job);
+    if (snapshot.job.live?.questions?.length) snapshot.job.phase = "waiting-for-answer";
     outputCommandResult(snapshot, renderJobStatusReport(snapshot.job), options.json);
     return;
   }
@@ -931,7 +942,26 @@ async function handleStatus(argv) {
   }
 
   const report = buildStatusSnapshot(cwd, { all: options.all });
+  for (const job of report.running) {
+    job.live = await liveStatus(report.workspaceRoot, job);
+    if (job.live?.questions?.length) job.phase = "waiting-for-answer";
+    else if (job.live?.interrupting) job.phase = "interrupting";
+  }
   outputResult(renderStatusPayload(report, options.json), options.json);
+}
+
+async function handleLiveCommand(command, argv) {
+  const { options, positionals } = parseCommandInput(argv, {
+    valueOptions: ["cwd", "prompt-file", "request-id", "answers-file"],
+    booleanOptions: ["json", "interrupt"]
+  });
+  const cwd = resolveCommandWorkspace(options);
+  if (options["answers-file"]) options["answers-file"] = path.resolve(resolveCommandCwd(options), options["answers-file"]);
+  const text = options["prompt-file"]
+    ? fs.readFileSync(path.resolve(resolveCommandCwd(options), options["prompt-file"]), "utf8")
+    : positionals.slice(1).join(" ");
+  const result = await sendLiveCommand(cwd, positionals[0], command, options, text);
+  outputCommandResult(result, `${JSON.stringify(result, null, 2)}\n`, options.json);
 }
 
 function handleResult(argv) {
@@ -1078,6 +1108,10 @@ async function main() {
       break;
     case "status":
       await handleStatus(argv);
+      break;
+    case "message":
+    case "answer":
+      await handleLiveCommand(subcommand, argv);
       break;
     case "result":
       handleResult(argv);

--- a/plugins/codex/scripts/lib/app-server-protocol.d.ts
+++ b/plugins/codex/scripts/lib/app-server-protocol.d.ts
@@ -26,6 +26,10 @@ import type {
   TurnInterruptResponse,
   TurnStartParams,
   TurnStartResponse,
+  TurnSteerParams,
+  TurnSteerResponse,
+  TurnCompletedNotification,
+  ToolRequestUserInputParams,
   UserInput
 } from "../../.generated/app-server-types/v2/index.js";
 
@@ -54,6 +58,26 @@ export interface CodexAppServerClientOptions {
   brokerEndpoint?: string;
   disableBroker?: boolean;
   reuseExistingBroker?: boolean;
+  requestUserInput?: boolean;
+  requireBroker?: boolean;
+}
+
+export interface PendingMessage {
+  id: string;
+  input: UserInput[];
+  status: "sending" | "accepted";
+}
+
+export interface LiveTurnStatus {
+  threadId: string;
+  turnId: string | null;
+  pendingMessages: PendingMessage[];
+  undeliveredMessages: PendingMessage[];
+  questions: Array<ToolRequestUserInputParams & { requestId: string | number; expiresAt: number }>;
+  interrupting: boolean;
+  partialChanges: Array<{ path: string; status: string }>;
+  error: string | null;
+  workspaceStatus?: string;
 }
 
 export interface AppServerMethodMap {
@@ -66,10 +90,16 @@ export interface AppServerMethodMap {
   "review/start": { params: ReviewStartParams; result: ReviewStartResponse };
   "turn/start": { params: TurnStartParams; result: TurnStartResponse };
   "turn/interrupt": { params: TurnInterruptParams; result: TurnInterruptResponse };
+  "turn/steer": { params: TurnSteerParams; result: TurnSteerResponse & { messageId?: string } };
+  "broker/status": { params: { threadId: string }; result: LiveTurnStatus };
+  "broker/answer": { params: { threadId: string; turnId: string; requestId: string | number; answers: unknown }; result: { answered: boolean; requestId: string | number } };
+  "broker/redirect": { params: { threadId: string; turnId: string; input: UserInput[] }; result: { interrupted: boolean; threadId: string; turnId: string; partialChanges: LiveTurnStatus["partialChanges"] } };
 }
 
 export type AppServerMethod = keyof AppServerMethodMap;
 export type AppServerRequestParams<M extends AppServerMethod> = AppServerMethodMap[M]["params"];
 export type AppServerResponse<M extends AppServerMethod> = AppServerMethodMap[M]["result"];
-export type AppServerNotification = ServerNotification;
+export type AppServerNotification = Exclude<ServerNotification, { method: "turn/completed" }> |
+  { method: "turn/completed"; params: TurnCompletedNotification & { redirectInput?: UserInput[]; controlError?: string; interruptedWorkspaceStatus?: string } } |
+  { method: "companion/question"; params: { threadId: string; turnId: string; requestId: string | number } };
 export type AppServerNotificationHandler = (message: AppServerNotification) => void;

--- a/plugins/codex/scripts/lib/app-server-protocol.d.ts
+++ b/plugins/codex/scripts/lib/app-server-protocol.d.ts
@@ -6,6 +6,7 @@ import type {
   ServerNotification
 } from "../../.generated/app-server-types/index.js";
 import type {
+  DynamicToolSpec,
   ExternalAgentConfigImportParams,
   ExternalAgentConfigImportResponse,
   ReviewStartParams,
@@ -34,6 +35,7 @@ import type {
 } from "../../.generated/app-server-types/v2/index.js";
 
 export type {
+  DynamicToolSpec,
   ClientInfo,
   InitializeCapabilities,
   InitializeParams,
@@ -56,6 +58,7 @@ export interface CodexAppServerClientOptions {
   clientInfo?: ClientInfo;
   capabilities?: InitializeCapabilities;
   brokerEndpoint?: string;
+  brokerTimeoutMs?: number;
   disableBroker?: boolean;
   reuseExistingBroker?: boolean;
   requestUserInput?: boolean;
@@ -74,10 +77,18 @@ export interface LiveTurnStatus {
   pendingMessages: PendingMessage[];
   undeliveredMessages: PendingMessage[];
   questions: Array<ToolRequestUserInputParams & { requestId: string | number; expiresAt: number }>;
+  notifications: DirectorNotification[];
   interrupting: boolean;
   partialChanges: Array<{ path: string; status: string }>;
   error: string | null;
   workspaceStatus?: string;
+}
+
+export interface DirectorNotification {
+  id: string;
+  message: string;
+  turnId: string;
+  receivedAt: string;
 }
 
 export interface AppServerMethodMap {
@@ -92,6 +103,7 @@ export interface AppServerMethodMap {
   "turn/interrupt": { params: TurnInterruptParams; result: TurnInterruptResponse };
   "turn/steer": { params: TurnSteerParams; result: TurnSteerResponse & { messageId?: string } };
   "broker/status": { params: { threadId: string }; result: LiveTurnStatus };
+  "broker/ack-notifications": { params: { threadId: string; ids: string[] }; result: { remaining: number } };
   "broker/answer": { params: { threadId: string; turnId: string; requestId: string | number; answers: unknown }; result: { answered: boolean; requestId: string | number } };
   "broker/redirect": { params: { threadId: string; turnId: string; input: UserInput[] }; result: { interrupted: boolean; threadId: string; turnId: string; partialChanges: LiveTurnStatus["partialChanges"] } };
 }
@@ -101,5 +113,6 @@ export type AppServerRequestParams<M extends AppServerMethod> = AppServerMethodM
 export type AppServerResponse<M extends AppServerMethod> = AppServerMethodMap[M]["result"];
 export type AppServerNotification = Exclude<ServerNotification, { method: "turn/completed" }> |
   { method: "turn/completed"; params: TurnCompletedNotification & { redirectInput?: UserInput[]; controlError?: string; interruptedWorkspaceStatus?: string } } |
-  { method: "companion/question"; params: { threadId: string; turnId: string; requestId: string | number } };
+  { method: "companion/question"; params: { threadId: string; turnId: string; requestId: string | number } } |
+  { method: "companion/notification"; params: DirectorNotification & { threadId: string } };
 export type AppServerNotificationHandler = (message: AppServerNotification) => void;

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -65,6 +65,7 @@ class AppServerClientBase {
     this.exitError = null;
     /** @type {AppServerNotificationHandler | null} */
     this.notificationHandler = null;
+    this.serverRequestHandler = null;
     this.lineBuffer = "";
     this.transport = "unknown";
 
@@ -75,6 +76,14 @@ class AppServerClientBase {
 
   setNotificationHandler(handler) {
     this.notificationHandler = handler;
+  }
+
+  setServerRequestHandler(handler) {
+    this.serverRequestHandler = handler;
+  }
+
+  respond(id, result) {
+    this.sendMessage({ id, result });
   }
 
   /**
@@ -154,6 +163,9 @@ class AppServerClientBase {
   }
 
   handleServerRequest(message) {
+    if (this.serverRequestHandler?.(message)) {
+      return;
+    }
     this.sendMessage({
       id: message.id,
       error: buildJsonRpcError(-32601, `Unsupported server request: ${message.method}`)
@@ -187,7 +199,9 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
   }
 
   async initialize() {
-    this.proc = spawn("codex", ["app-server"], {
+    const args = ["app-server"];
+    if (this.options.requestUserInput) args.push("-c", "features.default_mode_request_user_input=true");
+    this.proc = spawn("codex", args, {
       cwd: this.cwd,
       env: this.options.env ?? process.env,
       stdio: ["pipe", "pipe", "pipe"],
@@ -344,6 +358,9 @@ export class CodexAppServerClient {
         const brokerSession = await ensureBrokerSession(cwd, { env: options.env });
         brokerEndpoint = brokerSession?.endpoint ?? null;
       }
+    }
+    if (!brokerEndpoint && options.requireBroker) {
+      throw new Error("A shared broker is required for interactive tasks. Check /codex:setup before retrying.");
     }
     const client = brokerEndpoint
       ? new BrokerCodexAppServerClient(cwd, { ...options, brokerEndpoint })

--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -31,7 +31,7 @@ const DEFAULT_CLIENT_INFO = {
 
 /** @type {InitializeCapabilities} */
 const DEFAULT_CAPABILITIES = {
-  experimentalApi: false,
+  experimentalApi: true,
   requestAttestation: false,
   optOutNotificationMethods: [
     "item/agentMessage/delta",
@@ -300,6 +300,9 @@ class BrokerCodexAppServerClient extends AppServerClientBase {
     await new Promise((resolve, reject) => {
       const target = parseBrokerEndpoint(this.endpoint);
       this.socket = net.createConnection({ path: target.path });
+      const timeout = this.options.brokerTimeoutMs
+        ? setTimeout(() => this.socket.destroy(new Error("Live broker request timed out.")), this.options.brokerTimeoutMs)
+        : null;
       this.socket.setEncoding("utf8");
       this.socket.on("connect", resolve);
       this.socket.on("data", (chunk) => {
@@ -312,6 +315,7 @@ class BrokerCodexAppServerClient extends AppServerClientBase {
         this.handleExit(error);
       });
       this.socket.on("close", () => {
+        if (timeout) clearTimeout(timeout);
         this.handleExit(this.exitError);
       });
     });

--- a/plugins/codex/scripts/lib/broker-lifecycle.mjs
+++ b/plugins/codex/scripts/lib/broker-lifecycle.mjs
@@ -146,7 +146,7 @@ export async function ensureBrokerSession(cwd, options = {}) {
     env: options.env ?? process.env
   });
 
-  const ready = await waitForBrokerEndpoint(endpoint, options.timeoutMs ?? 2000);
+  const ready = await waitForBrokerEndpoint(endpoint, options.timeoutMs ?? 10000);
   if (!ready) {
     teardownBrokerSession({
       endpoint,

--- a/plugins/codex/scripts/lib/broker-lifecycle.mjs
+++ b/plugins/codex/scripts/lib/broker-lifecycle.mjs
@@ -111,6 +111,44 @@ async function isBrokerEndpointReady(endpoint) {
 }
 
 export async function ensureBrokerSession(cwd, options = {}) {
+  const lockFile = path.join(resolveStateDir(cwd), "broker.lock");
+  fs.mkdirSync(path.dirname(lockFile), { recursive: true });
+  const deadline = Date.now() + 30000;
+  while (true) {
+    try {
+      const fd = fs.openSync(lockFile, "wx");
+      try {
+        fs.writeFileSync(fd, `${process.pid}\n`);
+      } finally {
+        fs.closeSync(fd);
+      }
+      break;
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      try {
+        const pid = Number(fs.readFileSync(lockFile, "utf8"));
+        if (Number.isSafeInteger(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+          } catch (error) {
+            if (error.code === "ESRCH" && Number(fs.readFileSync(lockFile, "utf8")) === pid) fs.unlinkSync(lockFile);
+          }
+        }
+      } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+      }
+      if (Date.now() >= deadline) throw new Error("Timed out waiting for the shared Codex broker startup lock.");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  try {
+    return await ensureLockedBrokerSession(cwd, options);
+  } finally {
+    fs.unlinkSync(lockFile);
+  }
+}
+
+async function ensureLockedBrokerSession(cwd, options) {
   const existing = loadBrokerSession(cwd);
   if (existing && (await isBrokerEndpointReady(existing.endpoint))) {
     return existing;

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -32,6 +32,8 @@
  *   fileChanges: ThreadItem[],
  *   commandExecutions: ThreadItem[],
  *   onProgress: ProgressReporter | null
+ *   redirectInput?: UserInput[]
+ *   interruptedWorkspaceStatus?: string
  * }} TurnCaptureState
  */
 import crypto from "node:crypto";
@@ -371,7 +373,9 @@ function completeTurn(state, turn = null, options = {}) {
 }
 
 function scheduleInferredCompletion(state) {
-  if (state.completed || state.finalTurn || !state.finalAnswerSeen) {
+  // Only the legacy subagent flow can omit the parent completion notification.
+  // A normal turn's final text may still be followed by failure or interruption.
+  if (state.completed || state.finalTurn || !state.finalAnswerSeen || state.threadIds.size <= 1) {
     return;
   }
 
@@ -489,6 +493,11 @@ function recordItem(state, item, lifecycle, threadId = null) {
 
 function applyTurnNotification(state, message) {
   switch (message.method) {
+    case "companion/question":
+      clearCompletionTimer(state);
+      state.finalAnswerSeen = false;
+      emitProgress(state.onProgress, `Waiting for answer to request ${message.params.requestId}. Use /codex:status to read the questions.`, "waiting-for-answer");
+      break;
     case "thread/started":
       registerThread(state, message.params.thread.id, {
         threadName: message.params.thread.name,
@@ -549,6 +558,9 @@ function applyTurnNotification(state, message) {
         `Turn ${message.params.turn.status === "completed" ? "completed" : message.params.turn.status}.`,
         "finalizing"
       );
+      state.redirectInput = message.params.redirectInput;
+      state.interruptedWorkspaceStatus = message.params.interruptedWorkspaceStatus;
+      if (message.params.controlError) state.error = { message: message.params.controlError };
       completeTurn(state, message.params.turn);
       break;
     default:
@@ -603,17 +615,22 @@ async function captureTurn(client, threadId, startRequest, options = {}) {
       completeTurn(state, response.turn);
     }
 
-    return await state.completion;
+    return await Promise.race([
+      state.completion,
+      client.exitPromise.then(() => {
+        throw client.exitError ?? new Error("Codex connection closed before the turn completed.");
+      })
+    ]);
   } finally {
     clearCompletionTimer(state);
     client.setNotificationHandler(previousHandler ?? null);
   }
 }
 
-async function withAppServer(cwd, fn) {
+async function withAppServer(cwd, fn, options = {}) {
   let client = null;
   try {
-    client = await CodexAppServerClient.connect(cwd);
+    client = await CodexAppServerClient.connect(cwd, { requireBroker: options.requireBroker });
     const result = await fn(client);
     await client.close();
     return result;
@@ -628,7 +645,7 @@ async function withAppServer(cwd, fn) {
       client = null;
     }
 
-    if (!shouldRetryDirect) {
+    if (!shouldRetryDirect || options.requireBroker) {
       throw error;
     }
 
@@ -1129,19 +1146,36 @@ export async function runAppServerTurn(cwd, options = {}) {
       throw new Error("A prompt is required for this Codex run.");
     }
 
-    const turnState = await captureTurn(
-      client,
-      threadId,
-      () =>
-        client.request("turn/start", {
+    let turnState;
+    let input = buildTurnInput(prompt);
+    const fileChanges = [];
+    const interruptedTurns = [];
+    do {
+      turnState = await captureTurn(
+        client,
+        threadId,
+        () => client.request("turn/start", {
           threadId,
-          input: buildTurnInput(prompt),
+          input,
+          cwd,
+          approvalPolicy: "never",
+          sandboxPolicy: options.sandbox === "workspace-write"
+            ? { type: "workspaceWrite", writableRoots: [cwd], networkAccess: false, excludeTmpdirEnvVar: false, excludeSlashTmp: false }
+            : { type: "readOnly" },
           model: options.model ?? null,
           effort: options.effort ?? null,
           outputSchema: options.outputSchema ?? null
         }),
-      { onProgress: options.onProgress }
-    );
+        { onProgress: options.onProgress }
+      );
+      fileChanges.push(...turnState.fileChanges);
+      input = turnState.redirectInput;
+      if (input) {
+        interruptedTurns.push({ turnId: turnState.turnId, touchedFiles: collectTouchedFiles(turnState.fileChanges),
+          workspaceStatus: turnState.interruptedWorkspaceStatus });
+        emitProgress(options.onProgress, "Turn interrupted; continuing in the same thread with the new instruction. Existing file changes are retained.", "redirecting");
+      }
+    } while (input);
 
     return {
       status: buildResultStatus(turnState),
@@ -1152,11 +1186,12 @@ export async function runAppServerTurn(cwd, options = {}) {
       turn: turnState.finalTurn,
       error: turnState.error,
       stderr: cleanCodexStderr(client.stderr),
-      fileChanges: turnState.fileChanges,
-      touchedFiles: collectTouchedFiles(turnState.fileChanges),
+      fileChanges,
+      touchedFiles: collectTouchedFiles(fileChanges),
+      interruptedTurns,
       commandExecutions: turnState.commandExecutions
     };
-  });
+  }, { requireBroker: options.persistThread });
 }
 
 export async function findLatestTaskThread(cwd) {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -48,6 +48,19 @@ import { binaryAvailable } from "./process.mjs";
 
 const SERVICE_NAME = "claude_code_codex_plugin";
 const TASK_THREAD_PREFIX = "Codex Companion Task";
+/** @type {import("./app-server-protocol").DynamicToolSpec} */
+const NOTIFY_DIRECTOR_TOOL = {
+  type: "function",
+  name: "notify_director",
+  description: "Send a short note to the director agent that started you, without stopping your work. Use it only for conclusions that change the plan, blockers you are working around, or a finished phase the director could act on now. Do not report routine progress. Returns immediately; the director does not reply through this tool. Notes longer than 400 characters are rejected.",
+  inputSchema: {
+    type: "object",
+    properties: { message: { type: "string", maxLength: 400 } },
+    required: ["message"],
+    additionalProperties: false
+  },
+  deferLoading: false
+};
 const DEFAULT_CONTINUE_PROMPT =
   "Continue from the current thread state. Pick the next highest-value step and follow through until the task is resolved.";
 const EXTERNAL_AGENT_IMPORT_COMPLETED = "externalAgentConfig/import/completed";
@@ -69,7 +82,8 @@ function buildThreadParams(cwd, options = {}) {
     approvalPolicy: options.approvalPolicy ?? "never",
     sandbox: options.sandbox ?? "read-only",
     serviceName: SERVICE_NAME,
-    ephemeral: options.ephemeral ?? true
+    ephemeral: options.ephemeral ?? true,
+    ...(options.persistThread ? { dynamicTools: [NOTIFY_DIRECTOR_TOOL] } : {})
   };
 }
 
@@ -493,6 +507,9 @@ function recordItem(state, item, lifecycle, threadId = null) {
 
 function applyTurnNotification(state, message) {
   switch (message.method) {
+    case "companion/notification":
+      emitProgress(state.onProgress, `Notification: ${message.params.message}`, "notified");
+      break;
     case "companion/question":
       clearCompletionTimer(state);
       state.finalAnswerSeen = false;
@@ -1132,6 +1149,7 @@ export async function runAppServerTurn(cwd, options = {}) {
         model: options.model,
         sandbox: options.sandbox,
         ephemeral: options.persistThread ? false : true,
+        persistThread: options.persistThread,
         threadName: options.persistThread ? options.threadName : options.threadName ?? null
       });
       threadId = response.thread.id;
@@ -1159,9 +1177,11 @@ export async function runAppServerTurn(cwd, options = {}) {
           input,
           cwd,
           approvalPolicy: "never",
-          sandboxPolicy: options.sandbox === "workspace-write"
-            ? { type: "workspaceWrite", writableRoots: [cwd], networkAccess: false, excludeTmpdirEnvVar: false, excludeSlashTmp: false }
-            : { type: "readOnly" },
+          sandboxPolicy: options.sandbox === "danger-full-access"
+            ? { type: "dangerFullAccess" }
+            : options.sandbox === "workspace-write"
+              ? { type: "workspaceWrite", writableRoots: [cwd], networkAccess: Boolean(options.network), excludeTmpdirEnvVar: false, excludeSlashTmp: false }
+              : { type: "readOnly", networkAccess: false },
           model: options.model ?? null,
           effort: options.effort ?? null,
           outputSchema: options.outputSchema ?? null

--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -1,12 +1,54 @@
 import fs from "node:fs";
 
 import { getSessionRuntimeStatus } from "./codex.mjs";
-import { getConfig, listJobs, readJobFile, resolveJobFile } from "./state.mjs";
+import { getConfig, listJobs, readJobFile, resolveJobFile, upsertJob, writeJobFile } from "./state.mjs";
 import { SESSION_ID_ENV } from "./tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./workspace.mjs";
 
 export const DEFAULT_MAX_STATUS_JOBS = 8;
 export const DEFAULT_MAX_PROGRESS_LINES = 4;
+export const DEFAULT_STALL_MS = 15 * 60 * 1000;
+
+export function ownerProcessAlive(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return null;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code !== "ESRCH";
+  }
+}
+
+export function lastJobProgressAt(job) {
+  if (job.logFile) {
+    try {
+      return fs.statSync(job.logFile).mtimeMs;
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+  return Date.parse(job.startedAt ?? job.createdAt ?? "") || Date.now();
+}
+
+export function checkJobLiveness(cwd, job, live, brokerFailures, options = {}) {
+  if (job.status !== "queued" && job.status !== "running") return job;
+  const failures = job.threadId && live?.unavailable ? (brokerFailures.get(job.id) ?? 0) + 1 : 0;
+  brokerFailures.set(job.id, failures);
+  const reason = (options.ownerAlive ?? ownerProcessAlive)(job.pid) === false
+    ? "owner process exited"
+    : failures > 2 ? "broker unreachable" : null;
+  if (!reason) return job;
+  const fail = options.fail ?? ((workspaceRoot, current, errorMessage) => {
+    const latest = listJobs(workspaceRoot).find((item) => item.id === current.id);
+    if (!latest || (latest.status !== "queued" && latest.status !== "running")) return latest ?? current;
+    const patch = { id: current.id, status: "failed", phase: "failed", errorMessage, completedAt: new Date().toISOString() };
+    const stored = readStoredJob(workspaceRoot, current.id);
+    writeJobFile(workspaceRoot, current.id, { ...(stored ?? latest), ...patch });
+    upsertJob(workspaceRoot, patch);
+    return { ...current, ...patch };
+  });
+  return fail(cwd, job, reason);
+}
 
 export function sortJobsNewestFirst(jobs) {
   return [...jobs].sort((left, right) => String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? "")));
@@ -160,8 +202,15 @@ function inferLegacyJobPhase(job, progressPreview = []) {
 
 export function enrichJob(job, options = {}) {
   const maxProgressLines = options.maxProgressLines ?? DEFAULT_MAX_PROGRESS_LINES;
+  const active = job.status === "queued" || job.status === "running";
+  const progressAt = active ? lastJobProgressAt(job) : null;
   const enriched = {
     ...job,
+    ...(active ? {
+      ownerAlive: ownerProcessAlive(job.pid),
+      lastProgressAt: new Date(progressAt).toISOString(),
+      progressAgeMinutes: Math.max(0, Math.floor((Date.now() - progressAt) / 60000))
+    } : {}),
     kindLabel: getJobTypeLabel(job),
     progressPreview:
       job.status === "queued" || job.status === "running" || job.status === "failed"

--- a/plugins/codex/scripts/lib/job-events.mjs
+++ b/plugins/codex/scripts/lib/job-events.mjs
@@ -1,0 +1,80 @@
+import { setTimeout } from "node:timers/promises";
+import { buildStatusSnapshot, checkJobLiveness, DEFAULT_STALL_MS, lastJobProgressAt, readStoredJob } from "./job-control.mjs";
+import { acknowledgeNotifications, liveStatus } from "./live-commands.mjs";
+
+function oneLine(text) {
+  return String(text ?? "").replace(/[\r\n]+/g, " ");
+}
+
+export async function streamJobEvents(cwd, { pollMs = 2000, stallMs = DEFAULT_STALL_MS, signal } = {}, dependencies = {}) {
+  const snapshot = dependencies.snapshot ?? buildStatusSnapshot;
+  const status = dependencies.status ?? liveStatus;
+  const acknowledge = dependencies.acknowledge ?? acknowledgeNotifications;
+  const readJob = dependencies.readJob ?? readStoredJob;
+  const writeLine = dependencies.writeLine ?? ((line) => process.stdout.write(`${line}\n`));
+  const now = dependencies.now ?? Date.now;
+  const progressAt = dependencies.progressAt ?? lastJobProgressAt;
+  const active = new Set();
+  const questions = new Set();
+  const notifications = new Set();
+  const brokerFailures = new Map();
+  const stalls = new Map();
+  while (!signal?.aborted) {
+    const report = snapshot(cwd, { all: true });
+    for (let job of [...report.running, report.latestFinished, ...report.recent].filter(Boolean)) {
+      if (signal?.aborted) break;
+      let running = job.status === "queued" || job.status === "running";
+      if (running) active.add(job.id);
+      if (!active.has(job.id)) continue;
+      let live = await status(cwd, job);
+      if (signal?.aborted) continue;
+      job = checkJobLiveness(report.workspaceRoot ?? cwd, job, live, brokerFailures, dependencies);
+      // A dead owner must be reported even when its pending notes cannot be acknowledged.
+      if (job.status === "failed" && (job.errorMessage === "owner process exited" || job.errorMessage === "broker unreachable")) live = null;
+      running = job.status === "queued" || job.status === "running";
+      if (job.status === "running") {
+        const progress = progressAt(job);
+        const previous = stalls.get(job.id);
+        const lastReported = previous?.progress === progress ? previous.reportedAt : progress;
+        if (now() - lastReported >= stallMs) {
+          writeLine(`STALLED job=${job.id} thread=${job.threadId ?? "unknown"} ${Math.max(0, Math.floor((now() - progress) / 60000))}m without progress`);
+          stalls.set(job.id, { progress, reportedAt: now() });
+        }
+      }
+      if (running && live?.unavailable) continue;
+      for (const question of live?.questions ?? []) {
+        const key = `${job.id}:${question.requestId}`;
+        if (questions.has(key)) continue;
+        writeLine(`QUESTION job=${job.id} request=${question.requestId} ${oneLine(question.questions?.[0]?.question).slice(0, 200)}`);
+        questions.add(key);
+      }
+      const pending = (live?.notifications ?? []).filter((note) => !notifications.has(`${job.id}:${note.id}`));
+      if (pending.length) {
+        try {
+          await acknowledge(cwd, job, pending.map((note) => note.id));
+        } catch {
+          continue;
+        }
+        for (const note of pending) {
+          writeLine(`NOTIFIED job=${job.id} thread=${job.threadId ?? "unknown"} ${oneLine(note.message)}`);
+          notifications.add(`${job.id}:${note.id}`);
+        }
+      }
+      if (!running) {
+        const prefix = `job=${job.id} thread=${job.threadId ?? "unknown"}`;
+        if (job.status === "completed") {
+          writeLine(`DONE ${prefix}`);
+        } else {
+          const error = job.errorMessage ?? readJob(report.workspaceRoot, job.id)?.result?.error?.message;
+          writeLine(`FAILED ${prefix} ${String(error ?? "").split(/[\r\n]/)[0] || "unknown"}`);
+        }
+        active.delete(job.id);
+      }
+    }
+    try {
+      await setTimeout(pollMs, undefined, { signal });
+    } catch (error) {
+      if (error.name !== "AbortError") throw error;
+    }
+  }
+}

--- a/plugins/codex/scripts/lib/live-commands.mjs
+++ b/plugins/codex/scripts/lib/live-commands.mjs
@@ -4,10 +4,10 @@ import { BROKER_ENDPOINT_ENV, CodexAppServerClient } from "./app-server.mjs";
 import { loadBrokerSession } from "./broker-lifecycle.mjs";
 import { buildSingleJobSnapshot } from "./job-control.mjs";
 
-async function withLiveClient(cwd, action) {
+async function withLiveClient(cwd, action, options = {}) {
   const endpoint = process.env[BROKER_ENDPOINT_ENV] ?? loadBrokerSession(cwd)?.endpoint;
   if (!endpoint) throw new Error("No live broker found. This task cannot receive messages; do not start another runtime for its thread.");
-  const client = await CodexAppServerClient.connect(cwd, { brokerEndpoint: endpoint });
+  const client = await CodexAppServerClient.connect(cwd, { ...options, brokerEndpoint: endpoint });
   try {
     return await action(client);
   } finally {
@@ -18,10 +18,14 @@ async function withLiveClient(cwd, action) {
 export async function liveStatus(cwd, job) {
   if (!job.threadId) return null;
   try {
-    return await withLiveClient(cwd, (client) => client.request("broker/status", { threadId: job.threadId }));
+    return await withLiveClient(cwd, (client) => client.request("broker/status", { threadId: job.threadId }), { brokerTimeoutMs: 5000 });
   } catch (error) {
     return { unavailable: error.message };
   }
+}
+
+export async function acknowledgeNotifications(cwd, job, ids) {
+  return withLiveClient(cwd, (client) => client.request("broker/ack-notifications", { threadId: job.threadId, ids }), { brokerTimeoutMs: 5000 });
 }
 
 export async function sendLiveCommand(cwd, reference, command, options, text) {

--- a/plugins/codex/scripts/lib/live-commands.mjs
+++ b/plugins/codex/scripts/lib/live-commands.mjs
@@ -1,0 +1,51 @@
+import fs from "node:fs";
+import path from "node:path";
+import { BROKER_ENDPOINT_ENV, CodexAppServerClient } from "./app-server.mjs";
+import { loadBrokerSession } from "./broker-lifecycle.mjs";
+import { buildSingleJobSnapshot } from "./job-control.mjs";
+
+async function withLiveClient(cwd, action) {
+  const endpoint = process.env[BROKER_ENDPOINT_ENV] ?? loadBrokerSession(cwd)?.endpoint;
+  if (!endpoint) throw new Error("No live broker found. This task cannot receive messages; do not start another runtime for its thread.");
+  const client = await CodexAppServerClient.connect(cwd, { brokerEndpoint: endpoint });
+  try {
+    return await action(client);
+  } finally {
+    await client.close();
+  }
+}
+
+export async function liveStatus(cwd, job) {
+  if (!job.threadId) return null;
+  try {
+    return await withLiveClient(cwd, (client) => client.request("broker/status", { threadId: job.threadId }));
+  } catch (error) {
+    return { unavailable: error.message };
+  }
+}
+
+export async function sendLiveCommand(cwd, reference, command, options, text) {
+  if (!reference) throw new Error("Pass an explicit job ID from /codex:status.");
+  const { job } = buildSingleJobSnapshot(cwd, reference);
+  if (job.jobClass !== "task" || job.status !== "running" || !job.threadId) {
+    throw new Error("This command requires a running task with a known thread and turn.");
+  }
+  return withLiveClient(cwd, async (client) => {
+    const params = { threadId: job.threadId, turnId: job.turnId };
+    if (command === "answer") {
+      if (!options["request-id"] || !options["answers-file"]) throw new Error("answer requires --request-id and --answers-file.");
+      const snapshot = await client.request("broker/status", { threadId: job.threadId });
+      const question = snapshot.questions.find((item) => String(item.requestId) === options["request-id"]);
+      if (!question) throw new Error("No matching pending question. Refresh /codex:status.");
+      const answers = JSON.parse(fs.readFileSync(path.resolve(cwd, options["answers-file"]), "utf8"));
+      return client.request("broker/answer", { ...params, turnId: question.turnId, requestId: question.requestId, answers });
+    }
+    if (!text?.trim()) throw new Error("message requires text or --prompt-file.");
+    if (!job.turnId) throw new Error("The task is still starting. Refresh /codex:status before sending a message.");
+    const input = [{ type: "text", text: text.trim(), text_elements: [] }];
+    const result = options.interrupt
+      ? await client.request("broker/redirect", { ...params, input })
+      : await client.request("turn/steer", { threadId: job.threadId, expectedTurnId: job.turnId, input });
+    return { jobId: job.id, ...result };
+  });
+}

--- a/plugins/codex/scripts/lib/live-turn-control.mjs
+++ b/plugins/codex/scripts/lib/live-turn-control.mjs
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import { runCommand } from "./process.mjs";
 
-const CONTROL_METHODS = new Set(["turn/steer", "turn/interrupt", "broker/status", "broker/answer", "broker/redirect"]);
+const CONTROL_METHODS = new Set(["turn/steer", "turn/interrupt", "broker/status", "broker/answer", "broker/redirect", "broker/ack-notifications"]);
 
 // The broker owns this state so short-lived control clients cannot steal the event stream.
 export class LiveTurnControl {
@@ -16,7 +16,7 @@ export class LiveTurnControl {
 
   state(threadId) {
     if (!this.threads.has(threadId)) {
-      this.threads.set(threadId, { threadId, turnId: null, pendingMessages: [], questions: [],
+      this.threads.set(threadId, { threadId, turnId: null, pendingMessages: [], questions: [], notifications: [],
         interrupting: false, partialChanges: [], undeliveredMessages: [], error: null });
     }
     return this.threads.get(threadId);
@@ -94,6 +94,25 @@ export class LiveTurnControl {
   }
 
   handleServerRequest(message) {
+    if (message.method === "item/tool/call") {
+      const p = message.params;
+      const state = this.threads.get(p.threadId);
+      if (p.tool !== "notify_director" || !state) return false;
+      if (typeof p.arguments?.message !== "string") {
+        this.client.respond(message.id, { contentItems: [{ type: "inputText", text: 'Expected arguments: { "message": "..." } with a string message.' }], success: false });
+        return true;
+      }
+      if ([...p.arguments.message].length > 400) {
+        this.client.respond(message.id, { contentItems: [{ type: "inputText", text: "Message must be at most 400 characters." }], success: false });
+        return true;
+      }
+      this.client.respond(message.id, { contentItems: [{ type: "inputText", text: "Delivered to the director." }], success: true });
+      const notification = { id: crypto.randomBytes(6).toString("hex"), message: p.arguments.message,
+        turnId: p.turnId, receivedAt: new Date().toISOString() };
+      state.notifications.push(notification);
+      this.notify({ method: "companion/notification", params: { threadId: p.threadId, ...notification } });
+      return true;
+    }
     if (message.method !== "item/tool/requestUserInput") return false;
     const p = message.params;
     const state = this.state(p.threadId);
@@ -119,6 +138,11 @@ export class LiveTurnControl {
 
   async execute(method, p) {
     const state = this.threads.get(p.threadId);
+    if (method === "broker/ack-notifications") {
+      if (!state) throw new Error("Thread is not loaded in this broker.");
+      state.notifications = state.notifications.filter((notification) => !p.ids.includes(notification.id));
+      return { remaining: state.notifications.length };
+    }
     if (!state?.turnId) throw new Error("No active turn or pending question in this broker.");
     const expectedTurnId = p.expectedTurnId ?? p.turnId;
     if (state.turnId !== expectedTurnId) throw new Error("Active turn mismatch; refresh status before retrying.");

--- a/plugins/codex/scripts/lib/live-turn-control.mjs
+++ b/plugins/codex/scripts/lib/live-turn-control.mjs
@@ -1,0 +1,188 @@
+import crypto from "node:crypto";
+import { runCommand } from "./process.mjs";
+
+const CONTROL_METHODS = new Set(["turn/steer", "turn/interrupt", "broker/status", "broker/answer", "broker/redirect"]);
+
+// The broker owns this state so short-lived control clients cannot steal the event stream.
+export class LiveTurnControl {
+  constructor(client, notify, inputTimeoutMs = 600000) {
+    this.client = client;
+    this.notify = notify;
+    this.inputTimeoutMs = inputTimeoutMs;
+    this.threads = new Map();
+    this.requests = new Map();
+    this.tail = Promise.resolve();
+  }
+
+  state(threadId) {
+    if (!this.threads.has(threadId)) {
+      this.threads.set(threadId, { threadId, turnId: null, pendingMessages: [], questions: [],
+        interrupting: false, partialChanges: [], undeliveredMessages: [], error: null });
+    }
+    return this.threads.get(threadId);
+  }
+
+  handles(method) {
+    return CONTROL_METHODS.has(method);
+  }
+
+  starting(params) {
+    this.state(params.threadId).cwd = params.cwd ?? this.client.cwd;
+  }
+
+  request(method, params) {
+    if (method === "broker/status") return Promise.resolve(this.snapshot(params.threadId));
+    const result = this.tail.then(() => this.execute(method, params));
+    this.tail = result.catch(() => {});
+    return result;
+  }
+
+  snapshot(threadId) {
+    const state = this.threads.get(threadId);
+    if (!state) throw new Error("Thread is not loaded in this broker.");
+    const { redirectInput, interruptedReport, finishInterrupt, ...snapshot } = state;
+    return snapshot;
+  }
+
+  clearQuestions(state) {
+    for (const question of state.questions) {
+      clearTimeout(this.requests.get(question.requestId)?.timer);
+      this.requests.delete(question.requestId);
+    }
+    state.questions = [];
+  }
+
+  observe(message) {
+    const p = message.params ?? {};
+    const threadId = p.threadId ?? p.thread?.id;
+    if (!threadId) return;
+    const state = this.state(threadId);
+    if (message.method === "turn/started") {
+      this.clearQuestions(state);
+      Object.assign(state, { turnId: p.turn.id, pendingMessages: [], partialChanges: [], error: null, interrupting: false });
+    } else if (message.method === "item/started" && p.item?.type === "userMessage") {
+      state.pendingMessages = state.pendingMessages.filter((item) => item.id !== p.item.clientId);
+    } else if (message.method === "item/completed" && p.item?.type === "fileChange") {
+      for (const change of p.item.changes ?? []) {
+        const previous = state.partialChanges.findIndex((entry) => entry.path === change.path);
+        const entry = { path: change.path, status: p.item.status };
+        if (previous === -1) state.partialChanges.push(entry);
+        else state.partialChanges[previous] = entry;
+      }
+    } else if (message.method === "serverRequest/resolved") {
+      clearTimeout(this.requests.get(p.requestId)?.timer);
+      this.requests.delete(p.requestId);
+      state.questions = state.questions.filter((question) => question.requestId !== p.requestId);
+    } else if (message.method === "turn/completed" && p.turn.id === state.turnId) {
+      if (p.turn.status === "interrupted") {
+        const status = runCommand("git", ["status", "--short"], { cwd: state.cwd ?? this.client.cwd, maxBuffer: 1024 * 1024 });
+        state.workspaceStatus = status.error || status.status !== 0
+          ? `Unavailable: ${status.error?.message ?? status.stderr}` : status.stdout;
+        state.interruptedReport = { partialChanges: [...state.partialChanges], workspaceStatus: state.workspaceStatus };
+        p.interruptedWorkspaceStatus = state.workspaceStatus;
+        if (state.redirectInput) p.redirectInput = state.redirectInput;
+      }
+      if (state.error) p.controlError = state.error;
+      delete state.redirectInput;
+      state.undeliveredMessages = state.pendingMessages;
+      state.pendingMessages = [];
+      state.interrupting = false;
+      state.turnId = null;
+      this.clearQuestions(state);
+      state.finishInterrupt?.({ status: p.turn.status, ...state.interruptedReport });
+    }
+  }
+
+  handleServerRequest(message) {
+    if (message.method !== "item/tool/requestUserInput") return false;
+    const p = message.params;
+    const state = this.state(p.threadId);
+    if (state.turnId !== p.turnId) return false;
+    const question = { requestId: message.id, ...p, expiresAt: Date.now() + this.inputTimeoutMs };
+    state.questions.push(question);
+    const timer = setTimeout(() => {
+      // Recheck after earlier control requests, including an answer, have completed.
+      const expired = this.tail.then(async () => {
+        if (!this.requests.has(message.id) || state.turnId !== p.turnId) return;
+        state.error = "Waiting for user answer timed out.";
+        await this.execute("turn/interrupt", { threadId: p.threadId, turnId: p.turnId });
+      });
+      this.tail = expired.catch((error) => {
+        state.error += ` Interrupt failed: ${error.message}`;
+      });
+    }, this.inputTimeoutMs);
+    timer.unref();
+    this.requests.set(message.id, { question, timer });
+    this.notify({ method: "companion/question", params: question });
+    return true;
+  }
+
+  async execute(method, p) {
+    const state = this.threads.get(p.threadId);
+    if (!state?.turnId) throw new Error("No active turn or pending question in this broker.");
+    const expectedTurnId = p.expectedTurnId ?? p.turnId;
+    if (state.turnId !== expectedTurnId) throw new Error("Active turn mismatch; refresh status before retrying.");
+    if (method === "broker/answer") {
+      const entry = this.requests.get(p.requestId);
+      if (!entry || entry.question.threadId !== p.threadId || entry.question.turnId !== p.turnId) {
+        throw new Error("No matching pending question.");
+      }
+      const ids = entry.question.questions.map((question) => question.id);
+      if (!p.answers || Object.keys(p.answers).length !== ids.length || !ids.every((id) =>
+        Array.isArray(p.answers[id]?.answers) && p.answers[id].answers.length > 0 &&
+        p.answers[id].answers.every((answer) => typeof answer === "string" && answer.trim()))) {
+        throw new Error("Answer every question using its exact question ID and an array of nonempty strings.");
+      }
+      this.client.respond(p.requestId, { answers: p.answers });
+      clearTimeout(entry.timer);
+      this.requests.delete(p.requestId);
+      state.questions = state.questions.filter((question) => question.requestId !== p.requestId);
+      return { answered: true, requestId: p.requestId };
+    }
+    if (method === "turn/steer" || method === "broker/redirect") {
+      if (!Array.isArray(p.input) || !p.input.length || p.input.some((item) => item.type !== "text" || !item.text?.trim())) {
+        throw new Error("A nonempty text message is required.");
+      }
+    }
+    if (method === "turn/steer") {
+      if (state.questions.length) throw new Error("Answer the pending question with answer, or use message --interrupt.");
+      if (state.pendingMessages.length >= 100) throw new Error("Pending message queue is full (100 messages).");
+      const id = p.clientUserMessageId ?? crypto.randomUUID();
+      if (state.pendingMessages.some((message) => message.id === id)) throw new Error("Message ID is already pending.");
+      const entry = { id, input: p.input, status: "sending" };
+      state.pendingMessages.push(entry);
+      try {
+        const result = await this.client.request("turn/steer", { threadId: p.threadId, expectedTurnId,
+          clientUserMessageId: id, input: p.input });
+        entry.status = "accepted";
+        return { ...result, messageId: id };
+      } catch (error) {
+        state.pendingMessages = state.pendingMessages.filter((message) => message !== entry);
+        throw error;
+      }
+    }
+    state.interrupting = true;
+    if (method === "broker/redirect") state.redirectInput = p.input;
+    const terminal = new Promise((resolve) => { state.finishInterrupt = resolve; });
+    try {
+      await this.client.request("turn/interrupt", { threadId: p.threadId, turnId: expectedTurnId });
+      // Core can acknowledge interrupt before it emits turn/completed.
+      const report = await Promise.race([terminal, this.client.exitPromise.then(() => {
+        throw new Error("Codex disconnected before interruption completed.");
+      })]);
+      if (report.status !== "interrupted") throw new Error("Turn ended before it could be interrupted.");
+      return { interrupted: true, threadId: p.threadId, turnId: expectedTurnId, ...report,
+        note: "Changes are retained. Workspace status includes pre-existing changes and shell edits." };
+    } catch (error) {
+      delete state.redirectInput;
+      throw error;
+    } finally {
+      delete state.finishInterrupt;
+      state.interrupting = false;
+    }
+  }
+
+  close() {
+    for (const state of this.threads.values()) this.clearQuestions(state);
+  }
+}

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -121,6 +121,14 @@ function appendActiveJobsTable(lines, jobs) {
   }
 }
 
+function formatSandboxDetails(job) {
+  const sandbox = job?.sandbox ?? job?.request?.sandbox;
+  if (!sandbox) return "";
+  const network = sandbox === "danger-full-access" ||
+    (sandbox === "workspace-write" && (job.network ?? job.request?.network));
+  return `Sandbox: ${sandbox} (network: ${network ? "enabled" : "disabled"})`;
+}
+
 function pushJobDetails(lines, job, options = {}) {
   lines.push(`- ${formatJobLine(job)}`);
   if (job.summary) {
@@ -128,6 +136,13 @@ function pushJobDetails(lines, job, options = {}) {
   }
   if (job.phase) {
     lines.push(`  Phase: ${job.phase}`);
+  }
+  if (job.errorMessage) lines.push(`  Error: ${job.errorMessage}`);
+  const sandboxDetails = formatSandboxDetails(job);
+  if (sandboxDetails) lines.push(`  ${sandboxDetails}`);
+  if (job.status === "running") {
+    lines.push(`  Owner: ${job.ownerAlive === true ? "alive" : job.ownerAlive === false ? "exited" : "unknown"}`);
+    if (job.progressAgeMinutes != null) lines.push(`  Last progress: ${job.progressAgeMinutes}m ago`);
   }
   if (options.showElapsed && job.elapsed) {
     lines.push(`  Elapsed: ${job.elapsed}`);
@@ -395,6 +410,9 @@ export function renderJobStatusReport(job) {
         JSON.stringify(question.questions, null, 2),
         `Answer: /codex:answer ${job.id} --request-id ${question.requestId} --answers-file <path>`);
     }
+    for (const notification of job.live.notifications ?? []) {
+      lines.push(`Notification ${notification.id} (received ${notification.receivedAt}): ${notification.message}`);
+    }
     for (const change of job.live.partialChanges ?? []) lines.push(`File change (${change.status}): ${change.path}`);
     for (const message of job.live.undeliveredMessages ?? []) lines.push(`Not observed in thread history before turn ended: ${message.id}`);
     if (job.live.workspaceStatus) lines.push("Workspace status at interruption (includes pre-existing changes):", job.live.workspaceStatus);
@@ -406,12 +424,14 @@ export function renderJobStatusReport(job) {
 export function renderStoredJobResult(job, storedJob) {
   const threadId = storedJob?.threadId ?? job.threadId ?? null;
   const resumeCommand = threadId ? `codex resume ${threadId}` : null;
+  const sandboxDetails = formatSandboxDetails(storedJob) || formatSandboxDetails(job);
+  const sandboxSuffix = sandboxDetails ? `\n${sandboxDetails}\n` : "";
   if (isStructuredReviewStoredResult(storedJob) && storedJob?.rendered) {
     const output = storedJob.rendered.endsWith("\n") ? storedJob.rendered : `${storedJob.rendered}\n`;
     if (!threadId) {
-      return output;
+      return `${output}${sandboxSuffix}`;
     }
-    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
+    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n${sandboxSuffix}`;
   }
 
   const rawOutput =
@@ -421,17 +441,17 @@ export function renderStoredJobResult(job, storedJob) {
   if (rawOutput) {
     const output = rawOutput.endsWith("\n") ? rawOutput : `${rawOutput}\n`;
     if (!threadId) {
-      return output;
+      return `${output}${sandboxSuffix}`;
     }
-    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
+    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n${sandboxSuffix}`;
   }
 
   if (storedJob?.rendered) {
     const output = storedJob.rendered.endsWith("\n") ? storedJob.rendered : `${storedJob.rendered}\n`;
     if (!threadId) {
-      return output;
+      return `${output}${sandboxSuffix}`;
     }
-    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n`;
+    return `${output}\nCodex session ID: ${threadId}\nResume in Codex: ${resumeCommand}\n${sandboxSuffix}`;
   }
 
   const lines = [
@@ -440,6 +460,7 @@ export function renderStoredJobResult(job, storedJob) {
     `Job: ${job.id}`,
     `Status: ${job.status}`
   ];
+  if (sandboxDetails) lines.push(sandboxDetails);
 
   if (threadId) {
     lines.push(`Codex session ID: ${threadId}`);

--- a/plugins/codex/scripts/lib/render.mjs
+++ b/plugins/codex/scripts/lib/render.mjs
@@ -384,6 +384,22 @@ export function renderJobStatusReport(job) {
     showResultHint: true,
     showReviewHint: true
   });
+  if (job.live?.unavailable) lines.push(`Live controls unavailable: ${job.live.unavailable}`);
+  else if (job.live) {
+    lines.push("", `Interrupting: ${job.live.interrupting ? "yes" : "no"}`);
+    for (const message of job.live.pendingMessages ?? []) {
+      lines.push(`Pending message ${message.id} (${message.status}): ${message.input.map((item) => item.text).join("\n")}`);
+    }
+    for (const question of job.live.questions ?? []) {
+      lines.push(`Waiting for answer: ${question.requestId} (expires ${new Date(question.expiresAt).toISOString()})`,
+        JSON.stringify(question.questions, null, 2),
+        `Answer: /codex:answer ${job.id} --request-id ${question.requestId} --answers-file <path>`);
+    }
+    for (const change of job.live.partialChanges ?? []) lines.push(`File change (${change.status}): ${change.path}`);
+    for (const message of job.live.undeliveredMessages ?? []) lines.push(`Not observed in thread history before turn ended: ${message.id}`);
+    if (job.live.workspaceStatus) lines.push("Workspace status at interruption (includes pre-existing changes):", job.live.workspaceStatus);
+    if (job.live.error) lines.push(job.live.error);
+  }
   return `${lines.join("\n").trimEnd()}\n`;
 }
 

--- a/plugins/codex/scripts/lib/state.mjs
+++ b/plugins/codex/scripts/lib/state.mjs
@@ -11,6 +11,7 @@ const FALLBACK_STATE_ROOT_DIR = path.join(os.tmpdir(), "codex-companion");
 const STATE_FILE_NAME = "state.json";
 const JOBS_DIR_NAME = "jobs";
 const MAX_JOBS = 50;
+const LOCK_WAIT = new Int32Array(new SharedArrayBuffer(4));
 
 function nowIso() {
   return new Date().toISOString();
@@ -89,7 +90,44 @@ function removeFileIfExists(filePath) {
   }
 }
 
-export function saveState(cwd, state) {
+function withStateLock(cwd, action) {
+  ensureStateDir(cwd);
+  const lockFile = path.join(resolveStateDir(cwd), "state.lock");
+  const deadline = Date.now() + 30000;
+  let fd;
+  while (fd === undefined) {
+    try {
+      fd = fs.openSync(lockFile, "wx");
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      try {
+        const owner = Number(fs.readFileSync(lockFile, "utf8"));
+        if (Number.isSafeInteger(owner) && owner > 0) {
+          try {
+            process.kill(owner, 0);
+          } catch (ownerError) {
+            if (ownerError.code === "ESRCH" && Number(fs.readFileSync(lockFile, "utf8")) === owner) {
+              fs.unlinkSync(lockFile);
+            }
+          }
+        }
+      } catch (readError) {
+        if (readError.code !== "ENOENT") throw readError;
+      }
+      if (Date.now() >= deadline) throw new Error(`Timed out waiting for job state lock: ${lockFile}`);
+      Atomics.wait(LOCK_WAIT, 0, 0, 10);
+    }
+  }
+  try {
+    fs.writeFileSync(fd, `${process.pid}\n`);
+    return action();
+  } finally {
+    fs.closeSync(fd);
+    fs.unlinkSync(lockFile);
+  }
+}
+
+function writeState(cwd, state) {
   const previousJobs = loadState(cwd).jobs;
   ensureStateDir(cwd);
   const nextJobs = pruneJobs(state.jobs ?? []);
@@ -111,14 +149,23 @@ export function saveState(cwd, state) {
     removeFileIfExists(job.logFile);
   }
 
-  fs.writeFileSync(resolveStateFile(cwd), `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
+  const stateFile = resolveStateFile(cwd);
+  const temporaryFile = `${stateFile}.${process.pid}.tmp`;
+  fs.writeFileSync(temporaryFile, `${JSON.stringify(nextState, null, 2)}\n`, "utf8");
+  fs.renameSync(temporaryFile, stateFile);
   return nextState;
 }
 
+export function saveState(cwd, state) {
+  return withStateLock(cwd, () => writeState(cwd, state));
+}
+
 export function updateState(cwd, mutate) {
-  const state = loadState(cwd);
-  mutate(state);
-  return saveState(cwd, state);
+  return withStateLock(cwd, () => {
+    const state = loadState(cwd);
+    mutate(state);
+    return writeState(cwd, state);
+  });
 }
 
 export function generateJobId(prefix = "job") {

--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -13,7 +13,7 @@ import {
   sendBrokerShutdown,
   teardownBrokerSession
 } from "./lib/broker-lifecycle.mjs";
-import { loadState, resolveStateFile, saveState } from "./lib/state.mjs";
+import { loadState, resolveStateFile, updateState } from "./lib/state.mjs";
 import { TRANSCRIPT_PATH_ENV } from "./lib/claude-session-transfer.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
 
@@ -68,9 +68,8 @@ function cleanupSessionJobs(cwd, sessionId) {
     }
   }
 
-  saveState(workspaceRoot, {
-    ...state,
-    jobs: state.jobs.filter((job) => job.sessionId !== sessionId)
+  updateState(workspaceRoot, (current) => {
+    current.jobs = current.jobs.filter((job) => job.sessionId !== sessionId);
   });
 }
 

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -29,12 +29,14 @@ Command selection:
 - If the forwarded request includes `--model`, normalize `spark` to `gpt-5.3-codex-spark` and pass it through to `task`.
 - If the forwarded request includes `--effort`, pass it through to `task`.
 - If the forwarded request includes `--thread <id>`, strip the option and value from the task text and pass them through to `task`.
+- If the forwarded request includes `--allow-other-repo`, strip it from the task text and pass it through to `task`.
 - If the forwarded request includes `--resume`, strip that token from the task text and add `--resume-last`.
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.
 - `--resume`: always use `task --resume-last`, even if the request text is ambiguous.
 - `--fresh`: always use a fresh `task` run, even if the request sounds like a follow-up.
 - `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`.
-- `task --thread <id>`: resume that specific Codex thread without consulting tracked rescue jobs.
+- `task --thread <id>`: resume that specific Codex thread only when it is tracked for the current repo.
+- `task --thread <id> --allow-other-repo`: explicitly allow a thread from another repo or one created outside this plugin.
 - `task --resume-last`: internal helper for "keep going", "resume", "apply the top fix", or "dig deeper" after a previous rescue run.
 
 Safety rules:

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -28,11 +28,13 @@ Command selection:
 - If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only. Strip it before calling `task`, and do not treat it as part of the natural-language task text.
 - If the forwarded request includes `--model`, normalize `spark` to `gpt-5.3-codex-spark` and pass it through to `task`.
 - If the forwarded request includes `--effort`, pass it through to `task`.
+- If the forwarded request includes `--thread <id>`, strip the option and value from the task text and pass them through to `task`.
 - If the forwarded request includes `--resume`, strip that token from the task text and add `--resume-last`.
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.
 - `--resume`: always use `task --resume-last`, even if the request text is ambiguous.
 - `--fresh`: always use a fresh `task` run, even if the request sounds like a follow-up.
 - `--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`.
+- `task --thread <id>`: resume that specific Codex thread without consulting tracked rescue jobs.
 - `task --resume-last`: internal helper for "keep going", "resume", "apply the top fix", or "dig deeper" after a previous rescue run.
 
 Safety rules:

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -104,6 +104,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /--background\|--wait/);
   assert.match(rescue, /--resume\|--fresh/);
   assert.match(rescue, /--thread <id>/);
+  assert.match(rescue, /--allow-other-repo/);
   assert.match(rescue, /--model <model\|spark>/);
   assert.match(rescue, /--effort <none\|minimal\|low\|medium\|high\|xhigh>/);
   assert.match(rescue, /task-resume-candidate --json/);
@@ -115,6 +116,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /Do not forward them to `task`/i);
   assert.match(rescue, /`--model` and `--effort` are runtime-selection flags/i);
   assert.match(rescue, /`--thread <id>` is a routing flag/i);
+  assert.match(rescue, /`--allow-other-repo` is a routing flag/i);
   assert.match(rescue, /Leave `--effort` unset unless the user explicitly asks for a specific reasoning effort/i);
   assert.match(rescue, /If they ask for `spark`, map it to `gpt-5\.3-codex-spark`/i);
   assert.match(rescue, /If the request includes `--resume`, do not ask whether to continue/i);
@@ -125,10 +127,11 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /Return the Codex companion stdout verbatim to the user/i);
   assert.match(rescue, /Do not paraphrase, summarize, rewrite, or add commentary before or after it/i);
   assert.match(rescue, /return that command's stdout as-is/i);
-  assert.match(rescue, /Leave `--thread <id>`, `--resume`, and `--fresh` in the forwarded request/i);
+  assert.match(rescue, /Leave `--thread <id>`, `--allow-other-repo`, `--resume`, and `--fresh` in the forwarded request/i);
   assert.match(agent, /--resume/);
   assert.match(agent, /--fresh/);
   assert.match(agent, /--thread <id>/);
+  assert.match(agent, /--allow-other-repo/);
   assert.match(agent, /thin forwarding wrapper/i);
   assert.match(agent, /prefer foreground for a small, clearly bounded rescue request/i);
   assert.match(agent, /If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution/i);
@@ -199,6 +202,7 @@ test("internal docs use task terminology for rescue runs", () => {
   assert.match(runtimeSkill, /Use `task` for every rescue request/i);
   assert.match(runtimeSkill, /task --resume-last/i);
   assert.match(runtimeSkill, /task --thread <id>/i);
+  assert.match(runtimeSkill, /task --thread <id> --allow-other-repo/i);
   assert.match(promptingSkill, /Use `task` when the task is diagnosis/i);
   assert.match(promptRecipes, /Codex task prompts/i);
   assert.match(promptRecipes, /Use these as starting templates for Codex task prompts/i);

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -103,6 +103,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.doesNotMatch(rescue, /^context:\s*fork\b/m);
   assert.match(rescue, /--background\|--wait/);
   assert.match(rescue, /--resume\|--fresh/);
+  assert.match(rescue, /--thread <id>/);
   assert.match(rescue, /--model <model\|spark>/);
   assert.match(rescue, /--effort <none\|minimal\|low\|medium\|high\|xhigh>/);
   assert.match(rescue, /task-resume-candidate --json/);
@@ -113,6 +114,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /default to foreground/i);
   assert.match(rescue, /Do not forward them to `task`/i);
   assert.match(rescue, /`--model` and `--effort` are runtime-selection flags/i);
+  assert.match(rescue, /`--thread <id>` is a routing flag/i);
   assert.match(rescue, /Leave `--effort` unset unless the user explicitly asks for a specific reasoning effort/i);
   assert.match(rescue, /If they ask for `spark`, map it to `gpt-5\.3-codex-spark`/i);
   assert.match(rescue, /If the request includes `--resume`, do not ask whether to continue/i);
@@ -123,9 +125,10 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /Return the Codex companion stdout verbatim to the user/i);
   assert.match(rescue, /Do not paraphrase, summarize, rewrite, or add commentary before or after it/i);
   assert.match(rescue, /return that command's stdout as-is/i);
-  assert.match(rescue, /Leave `--resume` and `--fresh` in the forwarded request/i);
+  assert.match(rescue, /Leave `--thread <id>`, `--resume`, and `--fresh` in the forwarded request/i);
   assert.match(agent, /--resume/);
   assert.match(agent, /--fresh/);
+  assert.match(agent, /--thread <id>/);
   assert.match(agent, /thin forwarding wrapper/i);
   assert.match(agent, /prefer foreground for a small, clearly bounded rescue request/i);
   assert.match(agent, /If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution/i);
@@ -195,6 +198,7 @@ test("internal docs use task terminology for rescue runs", () => {
   assert.match(runtimeSkill, /codex-companion\.mjs" task "<raw arguments>"/);
   assert.match(runtimeSkill, /Use `task` for every rescue request/i);
   assert.match(runtimeSkill, /task --resume-last/i);
+  assert.match(runtimeSkill, /task --thread <id>/i);
   assert.match(promptingSkill, /Use `task` when the task is diagnosis/i);
   assert.match(promptRecipes, /Codex task prompts/i);
   assert.match(promptRecipes, /Use these as starting templates for Codex task prompts/i);

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -74,7 +74,9 @@ test("continue is not exposed as a user-facing command", () => {
   const commandFiles = fs.readdirSync(path.join(PLUGIN_ROOT, "commands")).sort();
   assert.deepEqual(commandFiles, [
     "adversarial-review.md",
+    "answer.md",
     "cancel.md",
+    "message.md",
     "rescue.md",
     "result.md",
     "review.md",

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -3,9 +3,71 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { spawnSync } from "node:child_process";
+import { sendBrokerShutdown } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { createBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-endpoint.mjs";
+
+const tempDirs = new Set();
+let testPluginDataDirs = null;
 
 export function makeTempDir(prefix = "codex-plugin-test-") {
-  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.add(dir);
+  return dir;
+}
+
+export async function shutdownTestBrokers(pluginDataDir) {
+  if (![...tempDirs].some((dir) => pluginDataDir === dir || pluginDataDir.startsWith(`${dir}${path.sep}`))) {
+    throw new Error(`Refusing broker cleanup outside test temp directories: ${pluginDataDir}`);
+  }
+  const stateRoot = path.join(pluginDataDir, "state");
+  if (!fs.existsSync(stateRoot)) return;
+  for (const entry of fs.readdirSync(stateRoot, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const sessionFile = path.join(stateRoot, entry.name, "broker.json");
+    if (!fs.existsSync(sessionFile)) continue;
+    const session = JSON.parse(fs.readFileSync(sessionFile, "utf8"));
+    // Seeded status-only records have no pid file and do not own a broker.
+    if (!session.pidFile || !fs.existsSync(session.pidFile)) continue;
+    if (!session.sessionDir?.startsWith(`${os.tmpdir()}${path.sep}`) ||
+        session.pidFile !== path.join(session.sessionDir, "broker.pid") ||
+        session.endpoint !== createBrokerEndpoint(session.sessionDir)) {
+      throw new Error(`Refusing broker cleanup for an unowned endpoint: ${sessionFile}`);
+    }
+    await sendBrokerShutdown(session.endpoint);
+    let running = true;
+    for (let attempt = 0; attempt < 100 && running; attempt += 1) {
+      try {
+        process.kill(session.pid, 0);
+      } catch (error) {
+        if (error.code !== "ESRCH") throw error;
+        running = false;
+      }
+      if (running) await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    if (running || fs.existsSync(session.pidFile)) throw new Error(`Test broker did not shut down: ${sessionFile}`);
+  }
+}
+
+export function isolateTestEnvironment(t) {
+  const previous = { ...process.env };
+  const previousPluginDataDirs = testPluginDataDirs;
+  for (const key of Object.keys(process.env)) {
+    if (key.startsWith("CODEX_COMPANION_") || ["CLAUDE_PLUGIN_DATA", "CLAUDE_ENV_FILE", "CLAUDE_SESSION_ID", "CLAUDE_TRANSCRIPT_PATH"].includes(key)) {
+      delete process.env[key];
+    }
+  }
+  process.env.CLAUDE_PLUGIN_DATA = makeTempDir();
+  testPluginDataDirs = new Set([process.env.CLAUDE_PLUGIN_DATA]);
+  const pluginDataDirs = testPluginDataDirs;
+  t.after(async () => {
+    try {
+      for (const dir of pluginDataDirs) await shutdownTestBrokers(dir);
+    } finally {
+      for (const key of Object.keys(process.env)) if (!(key in previous)) delete process.env[key];
+      Object.assign(process.env, previous);
+      testPluginDataDirs = previousPluginDataDirs;
+    }
+  });
 }
 
 export function writeExecutable(filePath, source) {
@@ -13,6 +75,8 @@ export function writeExecutable(filePath, source) {
 }
 
 export function run(command, args, options = {}) {
+  const pluginDataDir = (options.env ?? process.env).CLAUDE_PLUGIN_DATA;
+  if (pluginDataDir) testPluginDataDirs?.add(pluginDataDir);
   return spawnSync(command, args, {
     cwd: options.cwd,
     env: options.env,

--- a/tests/job-events.test.mjs
+++ b/tests/job-events.test.mjs
@@ -1,0 +1,178 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import fs from "node:fs";
+import path from "node:path";
+import { streamJobEvents } from "../plugins/codex/scripts/lib/job-events.mjs";
+import { checkJobLiveness, ownerProcessAlive } from "../plugins/codex/scripts/lib/job-control.mjs";
+import { CodexAppServerClient } from "../plugins/codex/scripts/lib/app-server.mjs";
+import { makeTempDir } from "./helpers.mjs";
+
+const job = { id: "job-1", threadId: "thread-1", status: "running" };
+
+async function monitor(reports, handlers = {}) {
+  const controller = new AbortController();
+  const lines = [];
+  let poll = 0;
+  await streamJobEvents("/repo", { pollMs: 1, signal: controller.signal }, {
+    snapshot(cwd, options) {
+      assert.equal(cwd, "/repo");
+      assert.equal(options.all, true);
+      if (poll === reports.length) controller.abort();
+      return { running: [], latestFinished: null, recent: [], ...reports[poll++] };
+    },
+    status: async () => ({}),
+    readJob: () => null,
+    acknowledge: async () => assert.fail("Unexpected acknowledgement"),
+    ...handlers,
+    writeLine: (line) => lines.push(line)
+  });
+  return lines;
+}
+
+test("events acknowledges a note once and reports only jobs observed active", async () => {
+  const acknowledged = [];
+  const note = { id: "note-1", message: "Phase done\r\nNext step" };
+  const finished = { ...job, status: "completed" };
+  const old = { id: "old-job", status: "completed" };
+  const lines = await monitor([
+    { running: [job], latestFinished: old },
+    { running: [job], latestFinished: old },
+    { latestFinished: finished, recent: [old] },
+    { latestFinished: finished, recent: [old] }
+  ], {
+    status: async () => ({ notifications: [note] }),
+    acknowledge: async (cwd, current, ids) => acknowledged.push({ cwd, jobId: current.id, ids })
+  });
+  assert.deepEqual(lines, [
+    "NOTIFIED job=job-1 thread=thread-1 Phase done Next step",
+    "DONE job=job-1 thread=thread-1"
+  ]);
+  assert.deepEqual(acknowledged, [{ cwd: "/repo", jobId: job.id, ids: [note.id] }]);
+});
+
+test("events reports each request once and limits the first question to one line of 200 characters", async () => {
+  const lines = await monitor([{ running: [job] }, { running: [job] }], {
+    status: async () => ({ questions: [{ requestId: "request-1", questions: [
+      { question: `Choose\n${"x".repeat(300)}` }, { question: "Do not show this" }
+    ] }] })
+  });
+  assert.deepEqual(lines, [`QUESTION job=job-1 request=request-1 Choose ${"x".repeat(193)}`]);
+});
+
+test("events silently retries unavailable broker state before reporting a failure", async () => {
+  const failed = { ...job, status: "failed", errorMessage: "First error\nMore details" };
+  let calls = 0;
+  const lines = await monitor([
+    { running: [job] }, { latestFinished: failed }, { latestFinished: failed }, { latestFinished: failed }
+  ], { status: async () => ++calls < 3 ? { unavailable: "Broker offline" } : {} });
+  assert.deepEqual(lines, ["FAILED job=job-1 thread=thread-1 First error"]);
+});
+
+test("events reads a turn failure from the stored result and falls back to unknown", async () => {
+  const second = { ...job, id: "job-2", threadId: null };
+  const lines = await monitor([
+    { running: [job, second] },
+    { latestFinished: { ...job, status: "failed" }, recent: [{ ...second, status: "failed" }] }
+  ], { readJob: (cwd, id) => id === job.id ? { result: { error: { message: "Turn failed\nDetails" } } } : null });
+  assert.deepEqual(lines, ["FAILED job=job-1 thread=thread-1 Turn failed", "FAILED job=job-2 thread=unknown unknown"]);
+});
+
+test("events retries acknowledgement and drains terminal notifications before DONE", async () => {
+  let calls = 0;
+  let attempts = 0;
+  const finished = { ...job, status: "completed" };
+  const lines = await monitor([
+    { running: [job] }, { latestFinished: finished }, { latestFinished: finished }
+  ], {
+    status: async () => ++calls === 1 ? {} : { notifications: [{ id: "note-1", message: "Ready" }] },
+    acknowledge: async () => { if (++attempts === 1) throw new Error("Broker offline"); }
+  });
+  assert.equal(attempts, 2);
+  assert.deepEqual(lines, ["NOTIFIED job=job-1 thread=thread-1 Ready", "DONE job=job-1 thread=thread-1"]);
+});
+
+test("events fails a dead owner once even when its broker is unavailable", async () => {
+  const current = { ...job, pid: 123 };
+  const failures = [];
+  const lines = await monitor([{ running: [current] }, { latestFinished: current }], {
+    ownerAlive: () => false,
+    status: async () => ({ unavailable: "Broker offline" }),
+    fail(cwd, record, reason) {
+      failures.push(reason);
+      Object.assign(current, { status: "failed", errorMessage: reason });
+      return current;
+    }
+  });
+  assert.deepEqual(lines, ["FAILED job=job-1 thread=thread-1 owner process exited"]);
+  assert.deepEqual(failures, ["owner process exited"]);
+});
+
+test("an owner failure already marked by status is reported without acknowledging stale notes", async () => {
+  let poll = 0;
+  const lines = await monitor([
+    { running: [job] }, { latestFinished: { ...job, status: "failed", errorMessage: "owner process exited" } }
+  ], {
+    status: async () => ++poll === 1 ? {} : { notifications: [{ id: "stale", message: "Pending" }] }
+  });
+  assert.deepEqual(lines, ["FAILED job=job-1 thread=thread-1 owner process exited"]);
+});
+
+test("broker liveness fails on the third consecutive miss and resets after success", () => {
+  const failures = new Map();
+  const options = { ownerAlive: () => true, fail: (cwd, current, reason) => ({ ...current, status: "failed", errorMessage: reason }) };
+  const check = (live) => checkJobLiveness("/repo", job, live, failures, options);
+  assert.equal(check({ unavailable: "offline" }).status, "running");
+  assert.equal(check({ unavailable: "offline" }).status, "running");
+  assert.equal(check({}).status, "running");
+  assert.equal(check({ unavailable: "offline" }).status, "running");
+  assert.equal(check({ unavailable: "offline" }).status, "running");
+  assert.equal(check({ unavailable: "offline" }).errorMessage, "broker unreachable");
+  assert.equal(ownerProcessAlive(process.pid), true);
+  assert.equal(ownerProcessAlive(null), null);
+});
+
+test("events reports a stall once per interval and new progress resets the interval", async () => {
+  let clock = 20 * 60000;
+  let progress = 0;
+  let poll = 0;
+  const lines = await monitor(Array.from({ length: 5 }, () => ({ running: [job] })), {
+    now: () => clock,
+    progressAt: () => progress,
+    status: async () => {
+      poll += 1;
+      if (poll === 2) clock += 60000;
+      if (poll === 3) clock += 15 * 60000;
+      if (poll === 4) progress = clock;
+      if (poll === 5) clock += 60000;
+      return {};
+    }
+  });
+  assert.deepEqual(lines, [
+    "STALLED job=job-1 thread=thread-1 20m without progress",
+    "STALLED job=job-1 thread=thread-1 36m without progress"
+  ]);
+});
+
+test("live broker deadline closes a socket even when initialize never replies", async (t) => {
+  const root = makeTempDir("codex-live-deadline-");
+  const socketPath = path.join(root, "broker.sock");
+  const sockets = new Set();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on("data", () => {});
+    socket.on("close", () => sockets.delete(socket));
+  });
+  t.after(async () => {
+    for (const socket of sockets) socket.destroy();
+    await new Promise((resolve) => server.close(resolve));
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, resolve);
+  });
+  await assert.rejects(CodexAppServerClient.connect(root, {
+    brokerEndpoint: `unix://${socketPath}`, brokerTimeoutMs: 50
+  }), /Live broker request timed out/);
+});

--- a/tests/live-codex-fixture.cjs
+++ b/tests/live-codex-fixture.cjs
@@ -12,7 +12,15 @@ const send = (message) => process.stdout.write(`${JSON.stringify(message)}\n`);
 const threads = new Map();
 let nextTurn = 0;
 let pendingQuestion = null;
+const pendingTools = new Map();
 const emit = (method, params) => send({ method, params });
+function ask(thread) {
+  pendingQuestion = { id: "question-1", thread };
+  send({ id: "question-1", method: "item/tool/requestUserInput", params: {
+    threadId: thread.id, turnId: thread.turnId, itemId: "ask-1", autoResolutionMs: null,
+    questions: [{ id: "source", header: "Source", question: "Which source?", options: null }]
+  } });
+}
 function complete(thread, text, status = "completed") {
   const turn = { id: thread.turnId, status, items: [], error: null };
   if (text) emit("item/completed", { threadId: thread.id, turnId: turn.id, item: {
@@ -23,10 +31,17 @@ function complete(thread, text, status = "completed") {
 }
 readline.createInterface({ input: process.stdin }).on("line", (line) => {
   const message = JSON.parse(line);
+  if (process.env.LIVE_CODEX_RECORDING) fs.appendFileSync(process.env.LIVE_CODEX_RECORDING, `${line}\n`);
   const p = message.params ?? {};
   const reply = (result) => send({ id: message.id, result });
   const thread = threads.get(p.threadId);
   if (!message.method) {
+    if (pendingTools.has(message.id)) {
+      const { thread: toolThread, text } = pendingTools.get(message.id);
+      pendingTools.delete(message.id);
+      if (text.startsWith("ask notify:")) ask(toolThread);
+      else if (!text.startsWith("hold notify:")) complete(toolThread, JSON.stringify(message.result ?? message.error));
+    }
     if (pendingQuestion && message.id === pendingQuestion.id) {
       const question = pendingQuestion;
       pendingQuestion = null;
@@ -53,12 +68,17 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
       reply({ turn: { id: thread.turnId, status: "inProgress", items: [], error: null } });
       emit("turn/started", { threadId: thread.id, turn: { id: thread.turnId } });
       const text = p.input.map((item) => item.text).join("\n");
-      if (text === "ask") {
-        pendingQuestion = { id: "question-1", thread };
-        send({ id: "question-1", method: "item/tool/requestUserInput", params: {
-          threadId: thread.id, turnId: thread.turnId, itemId: "ask-1", autoResolutionMs: null,
-          questions: [{ id: "source", header: "Source", question: "Which source?", options: null }]
+      const notification = text.match(/(?:^|\s)notify:(.*)/);
+      if (notification || ["notify-invalid", "notify-missing", "unknown-tool"].includes(text)) {
+        const id = `tool-${thread.turnId}`;
+        pendingTools.set(id, { thread, text });
+        send({ id, method: "item/tool/call", params: {
+          threadId: thread.id, turnId: thread.turnId, callId: id,
+          tool: text === "unknown-tool" ? "other_tool" : "notify_director",
+          arguments: text === "notify-missing" ? {} : { message: notification ? notification[1] : 42 }
         } });
+      } else if (text === "ask") {
+        ask(thread);
       } else if (text === "approve") {
         pendingQuestion = { id: "approval-1", thread };
         send({ id: "approval-1", method: "item/fileChange/requestApproval", params: {
@@ -70,7 +90,7 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
         } });
         setTimeout(() => complete(thread, "", "failed"), 600);
       } else if (text.startsWith("write")) {
-        if (p.sandboxPolicy?.type === "workspaceWrite") {
+        if (["workspaceWrite", "dangerFullAccess"].includes(p.sandboxPolicy?.type)) {
           fs.writeFileSync(path.join(thread.cwd, "written.txt"), text);
           complete(thread, "written");
         } else complete(thread, "read-only", "failed");

--- a/tests/live-codex-fixture.cjs
+++ b/tests/live-codex-fixture.cjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const readline = require("node:readline");
+
+if (process.argv[2] !== "app-server" || process.argv.includes("--help")) {
+  console.log("codex-cli test; app-server");
+  process.exit(0);
+}
+
+const send = (message) => process.stdout.write(`${JSON.stringify(message)}\n`);
+const threads = new Map();
+let nextTurn = 0;
+let pendingQuestion = null;
+const emit = (method, params) => send({ method, params });
+function complete(thread, text, status = "completed") {
+  const turn = { id: thread.turnId, status, items: [], error: null };
+  if (text) emit("item/completed", { threadId: thread.id, turnId: turn.id, item: {
+    type: "agentMessage", id: `msg-${turn.id}`, text, phase: "final_answer"
+  } });
+  thread.turnId = null;
+  emit("turn/completed", { threadId: thread.id, turn });
+}
+readline.createInterface({ input: process.stdin }).on("line", (line) => {
+  const message = JSON.parse(line);
+  const p = message.params ?? {};
+  const reply = (result) => send({ id: message.id, result });
+  const thread = threads.get(p.threadId);
+  if (!message.method) {
+    if (pendingQuestion && message.id === pendingQuestion.id) {
+      const question = pendingQuestion;
+      pendingQuestion = null;
+      emit("serverRequest/resolved", { threadId: question.thread.id, requestId: message.id });
+      complete(question.thread, JSON.stringify(message.result ?? message.error));
+    }
+    return;
+  }
+  switch (message.method) {
+    case "initialize": reply({ userAgent: "live-test" }); break;
+    case "initialized": break;
+    case "thread/start": {
+      const value = { id: `thr-${threads.size + 1}`, cwd: p.cwd, turns: [], sandbox: p.sandbox };
+      threads.set(value.id, value);
+      reply({ thread: value });
+      break;
+    }
+    case "thread/name/set": reply({}); break;
+    // A loaded thread deliberately ignores resume overrides, like a subscribed real thread.
+    case "thread/resume": reply({ thread }); break;
+    case "turn/start": {
+      thread.turnId = `turn-${++nextTurn}`;
+      thread.inputs = p.input;
+      reply({ turn: { id: thread.turnId, status: "inProgress", items: [], error: null } });
+      emit("turn/started", { threadId: thread.id, turn: { id: thread.turnId } });
+      const text = p.input.map((item) => item.text).join("\n");
+      if (text === "ask") {
+        pendingQuestion = { id: "question-1", thread };
+        send({ id: "question-1", method: "item/tool/requestUserInput", params: {
+          threadId: thread.id, turnId: thread.turnId, itemId: "ask-1", autoResolutionMs: null,
+          questions: [{ id: "source", header: "Source", question: "Which source?", options: null }]
+        } });
+      } else if (text === "approve") {
+        pendingQuestion = { id: "approval-1", thread };
+        send({ id: "approval-1", method: "item/fileChange/requestApproval", params: {
+          threadId: thread.id, turnId: thread.turnId, itemId: "write-approval"
+        } });
+      } else if (text === "fail-late") {
+        emit("item/completed", { threadId: thread.id, turnId: thread.turnId, item: {
+          type: "agentMessage", id: "early-final", text: "partial result", phase: "final_answer"
+        } });
+        setTimeout(() => complete(thread, "", "failed"), 600);
+      } else if (text.startsWith("write")) {
+        if (p.sandboxPolicy?.type === "workspaceWrite") {
+          fs.writeFileSync(path.join(thread.cwd, "written.txt"), text);
+          complete(thread, "written");
+        } else complete(thread, "read-only", "failed");
+      } else if (text.startsWith("hold")) {
+        thread.lateChange = text === "hold-late";
+        fs.writeFileSync(path.join(thread.cwd, "partial.txt"), "partial");
+        emit("item/completed", { threadId: thread.id, turnId: thread.turnId, item: {
+          type: "fileChange", id: "patch-1", status: "completed",
+          changes: [{ path: path.join(thread.cwd, "partial.txt"), kind: { type: "add" }, diff: "+partial" }]
+        } });
+      } else complete(thread, text);
+      break;
+    }
+    case "turn/steer": {
+      if (!thread?.turnId || p.expectedTurnId !== thread.turnId) {
+        send({ id: message.id, error: { code: -32600, message: "expected turn mismatch" } });
+        break;
+      }
+      thread.inputs.push(...p.input);
+      reply({ turnId: thread.turnId });
+      setTimeout(() => {
+        emit("item/started", { threadId: thread.id, turnId: thread.turnId, item: {
+          type: "userMessage", id: `user-${p.clientUserMessageId}`, clientId: p.clientUserMessageId, content: p.input
+        } });
+        if (p.input.some((item) => item.text === "finish")) {
+          complete(thread, thread.inputs.map((item) => item.text).join("|"));
+        }
+      }, 100);
+      break;
+    }
+    case "turn/interrupt":
+      reply({});
+      setTimeout(() => {
+      if (pendingQuestion?.thread === thread) pendingQuestion = null;
+      if (thread.lateChange) {
+        fs.writeFileSync(path.join(thread.cwd, "late.txt"), "late change");
+        emit("item/completed", { threadId: thread.id, turnId: thread.turnId, item: {
+          type: "fileChange", id: "late-patch", status: "completed",
+          changes: [{ path: path.join(thread.cwd, "late.txt"), kind: { type: "add" }, diff: "+late change" }]
+        } });
+      }
+      complete(thread, "", "interrupted");
+      }, 25);
+      break;
+    default: send({ id: message.id, error: { code: -32601, message: "unsupported method" } });
+  }
+});

--- a/tests/live-control.test.mjs
+++ b/tests/live-control.test.mjs
@@ -5,11 +5,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { CodexAppServerClient } from "../plugins/codex/scripts/lib/app-server.mjs";
+import { BROKER_BUSY_RPC_CODE, CodexAppServerClient } from "../plugins/codex/scripts/lib/app-server.mjs";
 import { createBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-endpoint.mjs";
-import { sendBrokerShutdown, waitForBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { ensureBrokerSession, saveBrokerSession, sendBrokerShutdown, waitForBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
 import { buildEnv } from "./fake-codex-fixture.mjs";
-import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
+import { initGitRepo, isolateTestEnvironment, makeTempDir, run, shutdownTestBrokers } from "./helpers.mjs";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const SCRIPT = path.join(ROOT, "plugins/codex/scripts/codex-companion.mjs");
@@ -21,7 +21,8 @@ async function waitFor(predicate) {
   }
   throw new Error("Timed out waiting for live control.");
 }
-async function setup(t, timeoutMs = 600000) {
+async function setup(t, timeoutMs = 600000, idleTimeoutMs = 600000) {
+  isolateTestEnvironment(t);
   const repo = makeTempDir();
   const bin = makeTempDir();
   const socketDir = fs.mkdtempSync(path.join(os.tmpdir(), "cxl-"));
@@ -30,10 +31,12 @@ async function setup(t, timeoutMs = 600000) {
   if (process.platform === "win32") fs.writeFileSync(path.join(bin, "codex.cmd"), '@node "%~dp0codex" %*\r\n');
   initGitRepo(repo);
   const endpoint = createBrokerEndpoint(socketDir);
+  const pidFile = path.join(socketDir, "broker.pid");
   const env = { ...buildEnv(bin), CLAUDE_PLUGIN_DATA: path.join(repo, ".plugin-data"),
-    CODEX_COMPANION_APP_SERVER_ENDPOINT: endpoint };
+    CODEX_COMPANION_APP_SERVER_ENDPOINT: endpoint, LIVE_CODEX_RECORDING: path.join(bin, "requests.jsonl") };
   const broker = spawn(process.execPath, [path.join(ROOT, "plugins/codex/scripts/app-server-broker.mjs"),
-    "serve", "--endpoint", endpoint, "--cwd", repo, "--input-timeout-ms", String(timeoutMs)], { env });
+    "serve", "--endpoint", endpoint, "--cwd", repo, "--input-timeout-ms", String(timeoutMs),
+    "--idle-timeout-ms", String(idleTimeoutMs), "--pid-file", pidFile], { env });
   let errors = "";
   broker.stderr.on("data", (data) => { errors += data; });
   const closed = new Promise((resolve) => broker.on("exit", resolve));
@@ -44,7 +47,7 @@ async function setup(t, timeoutMs = 600000) {
     if (broker.exitCode === null) broker.kill();
     await closed;
   });
-  assert.equal(await waitForBrokerEndpoint(endpoint, 5000), true, errors);
+  assert.equal(await waitForBrokerEndpoint(endpoint, 15000), true, errors);
   const connect = async () => {
     const client = await CodexAppServerClient.connect(repo, { brokerEndpoint: endpoint, env });
     clients.push(client);
@@ -56,7 +59,8 @@ async function setup(t, timeoutMs = 600000) {
   const { thread } = await owner.request("thread/start", { cwd: repo, sandbox: "read-only" });
   const start = (text) => owner.request("turn/start", { threadId: thread.id, input: [{ type: "text", text }] });
   const cli = (...args) => run(process.execPath, [SCRIPT, ...args, "--json"], { cwd: repo, env });
-  return { repo, env, owner, connect, thread, start, notifications, cli };
+  const requests = () => fs.readFileSync(env.LIVE_CODEX_RECORDING, "utf8").trim().split("\n").map(JSON.parse);
+  return { repo, env, owner, connect, thread, start, notifications, cli, requests, broker, closed, endpoint, pidFile, socketDir };
 }
 
 test("steering from another socket preserves FIFO and the owning event stream", async (t) => {
@@ -67,12 +71,106 @@ test("steering from another socket preserves FIFO and the owning event stream", 
     threadId: h.thread.id, expectedTurnId: turn.id, clientUserMessageId: text, input: [{ type: "text", text }]
   })));
   assert.deepEqual(accepted.map((result) => result.turnId), [turn.id, turn.id]);
-  const snapshot = await control.request("broker/status", { threadId: h.thread.id });
-  assert.deepEqual(snapshot.pendingMessages.map((item) => item.id), ["first", "finish"]);
+  assert.deepEqual(accepted.map((result) => result.messageId), ["first", "finish"]);
   await waitFor(() => h.notifications.some((item) => item.method === "turn/completed"));
+  assert.deepEqual(h.notifications.filter((item) => item.method === "item/started" && item.params.item.type === "userMessage")
+    .map((item) => item.params.item.clientId), ["first", "finish"]);
   const final = h.notifications.find((item) => item.params?.item?.type === "agentMessage");
   assert.equal(final.params.item.text, "hold|first|finish");
   assert.deepEqual((await control.request("broker/status", { threadId: h.thread.id })).pendingMessages, []);
+});
+
+test("parallel thread owners receive only their own events and reject another socket taking an active thread", async (t) => {
+  const h = await setup(t);
+  const second = await h.connect();
+  const control = await h.connect();
+  const secondEvents = [];
+  const controlEvents = [];
+  second.setNotificationHandler((message) => secondEvents.push(message));
+  control.setNotificationHandler((message) => controlEvents.push(message));
+  const [{ thread: secondThread }] = await Promise.all([
+    second.request("thread/start", { cwd: h.repo, sandbox: "read-only" }),
+    h.owner.request("thread/name/set", { threadId: h.thread.id, name: "first" })
+  ]);
+  const [{ turn: firstTurn }, { turn: secondTurn }] = await Promise.all([
+    h.start("hold first"),
+    second.request("turn/start", { threadId: secondThread.id, input: [{ type: "text", text: "hold second" }] })
+  ]);
+  await assert.rejects(control.request("turn/start", {
+    threadId: h.thread.id, input: [{ type: "text", text: "steal" }]
+  }), (error) => error.rpcCode === BROKER_BUSY_RPC_CODE && /busy/.test(error.message));
+  const states = await Promise.all([h.thread, secondThread].map((thread) =>
+    control.request("broker/status", { threadId: thread.id })));
+  assert.deepEqual(states.map((state) => state.turnId), [firstTurn.id, secondTurn.id]);
+  const accepted = await Promise.all([[h.thread, firstTurn], [secondThread, secondTurn]].map(([thread, turn]) =>
+    control.request("turn/steer", { threadId: thread.id, expectedTurnId: turn.id,
+      input: [{ type: "text", text: "finish" }] })));
+  assert.deepEqual(accepted.map((result) => result.turnId), [firstTurn.id, secondTurn.id]);
+  await waitFor(() => [h.notifications, secondEvents].every((events) =>
+    events.some((message) => message.method === "turn/completed")));
+  for (const [events, thread] of [[h.notifications, h.thread], [secondEvents, secondThread]]) {
+    assert.ok(events.every((message) => (message.params?.threadId ?? message.params?.thread?.id) === thread.id));
+    assert.ok(events.some((message) => message.method === "turn/started"));
+    assert.ok(events.some((message) => message.method === "item/started"));
+    assert.ok(events.some((message) => message.method === "item/completed"));
+    assert.equal((await control.request("broker/status", { threadId: thread.id })).turnId, null);
+  }
+  assert.deepEqual(controlEvents, []);
+  const [{ turn: nextFirst }, { turn: nextSecond }] = await Promise.all([
+    second.request("turn/start", { threadId: h.thread.id, input: [{ type: "text", text: "next first" }] }),
+    h.owner.request("turn/start", { threadId: secondThread.id, input: [{ type: "text", text: "next second" }] })
+  ]);
+  await waitFor(() => secondEvents.some((message) => message.method === "turn/completed" && message.params.turn.id === nextFirst.id)
+    && h.notifications.some((message) => message.method === "turn/completed" && message.params.turn.id === nextSecond.id));
+});
+
+test("idle broker stays alive with an owner, exits after disconnect, and is replaced on the next request", async (t) => {
+  const h = await setup(t, 600000, 250);
+  process.env.CLAUDE_PLUGIN_DATA = h.env.CLAUDE_PLUGIN_DATA;
+  saveBrokerSession(h.repo, { endpoint: h.endpoint, pidFile: h.pidFile, sessionDir: h.socketDir, pid: h.broker.pid });
+  t.after(() => shutdownTestBrokers(h.env.CLAUDE_PLUGIN_DATA));
+  await h.start("hold");
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  assert.equal(h.broker.exitCode, null);
+  await h.owner.close();
+  await waitFor(() => h.broker.exitCode !== null);
+  assert.equal(await h.closed, 0);
+  assert.equal(fs.existsSync(h.pidFile), false);
+  const replacement = await ensureBrokerSession(h.repo, { env: h.env });
+  assert.ok(replacement);
+  assert.notEqual(replacement.pid, h.broker.pid);
+  assert.notEqual(replacement.endpoint, h.endpoint);
+  assert.equal(await waitForBrokerEndpoint(replacement.endpoint), true);
+});
+
+test("concurrent processes share one cold-started broker and recover a departed startup lock owner", async (t) => {
+  const h = await setup(t);
+  process.env.CLAUDE_PLUGIN_DATA = h.env.CLAUDE_PLUGIN_DATA;
+  t.after(() => shutdownTestBrokers(h.env.CLAUDE_PLUGIN_DATA));
+  const source = `import { ensureBrokerSession } from ${JSON.stringify(new URL("../plugins/codex/scripts/lib/broker-lifecycle.mjs", import.meta.url).href)};
+console.log(JSON.stringify(await ensureBrokerSession(process.cwd())));`;
+  const children = [0, 1].map(() => {
+    const child = spawn(process.execPath, ["--input-type=module", "-e", source], { cwd: h.repo, env: h.env });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (data) => { stdout += data; });
+    child.stderr.on("data", (data) => { stderr += data; });
+    const done = new Promise((resolve) => child.on("exit", (code) => resolve({ code, stdout, stderr })));
+    t.after(async () => { if (child.exitCode === null) child.kill(); await done; });
+    return { child, done };
+  });
+  const results = await Promise.all(children.map((entry) => entry.done));
+  for (const result of results) assert.equal(result.code, 0, result.stderr);
+  const sessions = results.map((result) => JSON.parse(result.stdout));
+  assert.equal(sessions[0].endpoint, sessions[1].endpoint);
+  assert.equal(sessions[0].pid, sessions[1].pid);
+  assert.equal(h.requests().filter((request) => request.method === "initialize").length, 2);
+  const stateRoot = path.join(h.env.CLAUDE_PLUGIN_DATA, "state");
+  const lockFile = path.join(stateRoot, fs.readdirSync(stateRoot)[0], "broker.lock");
+  fs.writeFileSync(lockFile, `${children[0].child.pid}\n`);
+  const recovered = await ensureBrokerSession(h.repo, { env: h.env });
+  assert.equal(recovered.endpoint, sessions[0].endpoint);
+  assert.equal(fs.existsSync(lockFile), false);
 });
 
 test("stale steering is rejected without adding a pending message", async (t) => {
@@ -127,8 +225,8 @@ test("continue --write overrides a loaded read-only thread at turn/start", async
   assert.equal(fs.existsSync(path.join(h.repo, "written.txt")), false);
 });
 
-async function startJob(t, h, prompt) {
-  const child = spawn(process.execPath, [SCRIPT, "task", "--write", "--json", prompt], { cwd: h.repo, env: h.env });
+async function startJob(t, h, prompt, options = ["--write"]) {
+  const child = spawn(process.execPath, [SCRIPT, "task", ...options, "--json", prompt], { cwd: h.repo, env: h.env });
   let stdout = "";
   let stderr = "";
   child.stdout.on("data", (data) => { stdout += data; });
@@ -138,10 +236,34 @@ async function startJob(t, h, prompt) {
   const job = await waitFor(() => {
     const result = h.cli("status");
     assert.equal(result.status, 0, result.stderr);
-    return JSON.parse(result.stdout).running.find((item) => item.threadId && item.turnId);
+    return JSON.parse(result.stdout).running.find((item) => item.pid === child.pid && item.threadId && item.turnId);
   });
-  return { job, done };
+  return { job, done, child };
 }
+
+test("concurrent task jobs share a repository and retain both results and progress logs", async (t) => {
+  const h = await setup(t);
+  const jobs = await Promise.all([startJob(t, h, "hold first"), startJob(t, h, "hold second")]);
+  assert.notEqual(jobs[0].job.threadId, jobs[1].job.threadId);
+  const status = h.cli("status");
+  assert.equal(status.status, 0, status.stderr);
+  assert.deepEqual(JSON.parse(status.stdout).running.map((job) => job.id).sort(), jobs.map(({ job }) => job.id).sort());
+  const control = await h.connect();
+  await Promise.all(jobs.map(({ job }) => control.request("turn/steer", {
+    threadId: job.threadId, expectedTurnId: job.turnId, input: [{ type: "text", text: "finish" }]
+  })));
+  const results = await Promise.all(jobs.map(({ done }) => done));
+  for (const [index, result] of results.entries()) {
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).threadId, jobs[index].job.threadId);
+    const finished = h.cli("status", jobs[index].job.id);
+    assert.equal(finished.status, 0, finished.stderr);
+    const job = JSON.parse(finished.stdout).job;
+    assert.equal(job.status, "completed");
+    assert.ok(fs.existsSync(job.logFile));
+    assert.match(fs.readFileSync(job.logFile, "utf8"), /Turn completed/);
+  }
+});
 
 test("message --interrupt continues the original job and reports retained changes", async (t) => {
   const h = await setup(t);
@@ -212,4 +334,284 @@ test("final text does not mark an ordinary task successful before its terminal e
   const result = h.cli("task", "fail-late");
   assert.equal(result.status, 1, result.stderr);
   assert.equal(JSON.parse(result.stdout).status, 1);
+});
+
+test("director notifications reply immediately, survive turns, and acknowledge only selected IDs", async (t) => {
+  const h = await setup(t);
+  const { turn } = await h.start("notify:Use the alternate source");
+  await waitFor(() => h.notifications.some((item) => item.method === "turn/completed"));
+  const response = h.requests().find((item) => item.id === `tool-${turn.id}`);
+  assert.deepEqual(response.result, {
+    contentItems: [{ type: "inputText", text: "Delivered to the director." }], success: true
+  });
+  const first = await h.owner.request("broker/status", { threadId: h.thread.id });
+  assert.equal(first.notifications.length, 1);
+  const notification = first.notifications[0];
+  assert.deepEqual(Object.keys(notification).sort(), ["id", "message", "receivedAt", "turnId"]);
+  assert.equal(typeof notification.id, "string");
+  assert.ok(notification.id.length > 0);
+  assert.equal(notification.message, "Use the alternate source");
+  assert.equal(notification.turnId, turn.id);
+  assert.equal(new Date(notification.receivedAt).toISOString(), notification.receivedAt);
+  assert.deepEqual(h.notifications.find((item) => item.method === "companion/notification").params,
+    { threadId: h.thread.id, ...notification });
+  await h.start("hold notify:Phase two ready");
+  const second = await waitFor(async () => {
+    const state = await h.owner.request("broker/status", { threadId: h.thread.id });
+    return state.notifications.length === 2 ? state : null;
+  });
+  assert.notEqual(second.notifications[1].id, notification.id);
+  assert.deepEqual(await h.owner.request("broker/ack-notifications", {
+    threadId: h.thread.id, ids: [notification.id, "not-pending"]
+  }), { remaining: 1 });
+  assert.deepEqual((await h.owner.request("broker/status", { threadId: h.thread.id })).notifications,
+    [second.notifications[1]]);
+});
+
+test("invalid director notifications and unknown tools do not create notifications", async (t) => {
+  const h = await setup(t);
+  for (const input of ["notify-invalid", "notify-missing", "unknown-tool", `notify:${"a".repeat(401)}`]) {
+    const { turn } = await h.start(input);
+    const response = await waitFor(() => h.requests().find((item) => item.id === `tool-${turn.id}`));
+    if (input === "unknown-tool") {
+      assert.equal(response.error.code, -32601);
+      assert.match(response.error.message, /Unsupported server request/);
+    } else {
+      assert.equal(response.result.success, false);
+      assert.equal(response.result.contentItems[0].type, "inputText");
+      assert.match(response.result.contentItems[0].text, input.startsWith("notify:") ? /400/ : /message.*string/i);
+    }
+    await waitFor(() => h.notifications.some((item) => item.method === "turn/completed" && item.params.turn.id === turn.id));
+    assert.deepEqual((await h.owner.request("broker/status", { threadId: h.thread.id })).notifications, []);
+  }
+  const message = "😀".repeat(400);
+  const { turn } = await h.start(`notify:${message}`);
+  const response = await waitFor(() => h.requests().find((item) => item.id === `tool-${turn.id}`));
+  assert.equal(response.result.success, true);
+  assert.equal((await h.owner.request("broker/status", { threadId: h.thread.id })).notifications[0].message, message);
+});
+
+test("plain status retains notifications and status --wait consumes them once while work continues", async (t) => {
+  const h = await setup(t);
+  const { job, done } = await startJob(t, h, "hold notify:Build phase ready");
+  const plain = h.cli("status", job.id);
+  assert.equal(plain.status, 0, plain.stderr);
+  const notification = JSON.parse(plain.stdout).job.live.notifications[0];
+  assert.equal(notification.message, "Build phase ready");
+  assert.deepEqual((await h.owner.request("broker/status", { threadId: job.threadId })).notifications, [notification]);
+  const waiting = h.cli("status", job.id, "--wait", "--timeout-ms", "5000");
+  assert.equal(waiting.status, 0, waiting.stderr);
+  const report = JSON.parse(waiting.stdout);
+  assert.equal(report.hasNotifications, true);
+  assert.equal(report.waitTimedOut, false);
+  assert.equal(report.timeoutMs, 5000);
+  assert.equal(report.job.status, "running");
+  assert.equal(report.job.phase, "notified");
+  assert.deepEqual(report.job.live.notifications, [notification]);
+  assert.deepEqual((await h.owner.request("broker/status", { threadId: job.threadId })).notifications, []);
+  const again = h.cli("status", job.id, "--wait", "--timeout-ms", "150");
+  assert.equal(again.status, 0, again.stderr);
+  assert.equal(JSON.parse(again.stdout).hasNotifications, undefined);
+  assert.equal(JSON.parse(again.stdout).waitTimedOut, true);
+  assert.match(fs.readFileSync(report.job.logFile, "utf8"), /Build phase ready/);
+  const finished = h.cli("message", job.id, "finish");
+  assert.equal(finished.status, 0, finished.stderr);
+  assert.equal((await done).code, 0);
+});
+
+test("status --wait does not acknowledge notifications after the job completes", async (t) => {
+  const h = await setup(t);
+  const task = h.cli("task", "notify:Final phase ready");
+  assert.equal(task.status, 0, task.stderr);
+  const status = h.cli("status");
+  assert.equal(status.status, 0, status.stderr);
+  const job = JSON.parse(status.stdout).latestFinished;
+  const before = await h.owner.request("broker/status", { threadId: job.threadId });
+  assert.equal(before.notifications[0].message, "Final phase ready");
+  const waiting = h.cli("status", job.id, "--wait", "--timeout-ms", "5000");
+  assert.equal(waiting.status, 0, waiting.stderr);
+  assert.equal(JSON.parse(waiting.stdout).hasNotifications, undefined);
+  assert.equal(JSON.parse(waiting.stdout).waitTimedOut, false);
+  assert.deepEqual((await h.owner.request("broker/status", { threadId: job.threadId })).notifications,
+    before.notifications);
+  assert.match(fs.readFileSync(job.logFile, "utf8"), /\] Notification: Final phase ready\n/);
+  const empty = h.cli("task", "notify:");
+  assert.equal(empty.status, 0, empty.stderr);
+  const emptyJob = JSON.parse(h.cli("status").stdout).latestFinished;
+  assert.match(fs.readFileSync(emptyJob.logFile, "utf8"), /\] Notification:\n/);
+});
+
+test("pending questions take precedence over director notifications", async (t) => {
+  const h = await setup(t);
+  const { job } = await startJob(t, h, "ask notify:Need a source decision");
+  await waitFor(async () => (await h.owner.request("broker/status", { threadId: job.threadId })).questions.length);
+  const result = h.cli("status", job.id, "--wait", "--timeout-ms", "5000");
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.waitingForAnswer, true);
+  assert.equal(report.hasNotifications, undefined);
+  assert.equal(report.job.live.notifications[0].message, "Need a source decision");
+  assert.deepEqual((await h.owner.request("broker/status", { threadId: job.threadId })).notifications,
+    report.job.live.notifications);
+});
+
+test("task thread starts declare notify_director and initialize enables experimental API", async (t) => {
+  const h = await setup(t);
+  const task = h.cli("task", "initial");
+  assert.equal(task.status, 0, task.stderr);
+  const threadId = JSON.parse(task.stdout).threadId;
+  const requests = h.requests();
+  assert.equal(requests.find((item) => item.method === "initialize").params.capabilities.experimentalApi, true);
+  const starts = requests.filter((item) => item.method === "thread/start");
+  assert.equal(starts[0].params.dynamicTools, undefined);
+  assert.deepEqual(starts[1].params.dynamicTools, [{
+    type: "function", name: "notify_director",
+    description: "Send a short note to the director agent that started you, without stopping your work. Use it only for conclusions that change the plan, blockers you are working around, or a finished phase the director could act on now. Do not report routine progress. Returns immediately; the director does not reply through this tool. Notes longer than 400 characters are rejected.",
+    inputSchema: { type: "object", properties: { message: { type: "string", maxLength: 400 } }, required: ["message"], additionalProperties: false },
+    deferLoading: false
+  }]);
+  const resumed = h.cli("task", "--thread", threadId, "continue");
+  assert.equal(resumed.status, 0, resumed.stderr);
+  assert.equal(h.requests().find((item) => item.method === "thread/resume").params.dynamicTools, undefined);
+});
+
+function startEvents(t, h) {
+  const child = spawn(process.execPath, [SCRIPT, "events", "--cwd", h.repo, "--poll-ms", "20"], {
+    cwd: h.repo, env: h.env
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (data) => { stdout += data; });
+  child.stderr.on("data", (data) => { stderr += data; });
+  const done = new Promise((resolve) => child.on("exit", (code, signal) => resolve({ code, signal, stdout, stderr })));
+  t.after(async () => { if (child.exitCode === null) child.kill(); await done; });
+  return { child, done, lines: () => stdout.split("\n").slice(0, -1) };
+}
+
+test("events emits one notification and one completion, acknowledges the note, and exits cleanly on SIGINT", async (t) => {
+  const h = await setup(t);
+  const { job, done } = await startJob(t, h, "hold notify:Build phase ready");
+  const events = startEvents(t, h);
+  const notified = `NOTIFIED job=${job.id} thread=${job.threadId} Build phase ready`;
+  const completed = `DONE job=${job.id} thread=${job.threadId}`;
+  await waitFor(() => events.lines().includes(notified));
+  await waitFor(async () => !(await h.owner.request("broker/status", { threadId: job.threadId })).notifications.length);
+  const waiting = h.cli("status", job.id, "--wait", "--timeout-ms", "150");
+  assert.equal(waiting.status, 0, waiting.stderr);
+  assert.equal(JSON.parse(waiting.stdout).hasNotifications, undefined);
+  assert.equal(JSON.parse(waiting.stdout).waitTimedOut, true);
+  const finished = h.cli("message", job.id, "finish");
+  assert.equal(finished.status, 0, finished.stderr);
+  assert.equal((await done).code, 0);
+  await waitFor(() => events.lines().includes(completed));
+  events.child.kill("SIGINT");
+  const result = await events.done;
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.signal, null);
+  assert.deepEqual(result.stdout.trimEnd().split("\n"), [notified, completed]);
+});
+
+test("events exits cleanly on SIGTERM while the task remains active", async (t) => {
+  const h = await setup(t);
+  const { job, done } = await startJob(t, h, "hold notify:Listener ready");
+  const events = startEvents(t, h);
+  await waitFor(() => events.lines().some((line) => line.startsWith(`NOTIFIED job=${job.id} `)));
+  events.child.kill("SIGTERM");
+  const result = await events.done;
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.signal, null);
+  assert.equal(JSON.parse(h.cli("status", job.id).stdout).job.status, "running");
+  const finished = h.cli("message", job.id, "finish");
+  assert.equal(finished.status, 0, finished.stderr);
+  assert.equal((await done).code, 0);
+});
+
+test("events and status --wait report a killed task owner as failed once", async (t) => {
+  const h = await setup(t);
+  const { job, done, child } = await startJob(t, h, "hold notify:Owner ready");
+  const events = startEvents(t, h);
+  await waitFor(() => events.lines().some((line) => line.startsWith(`NOTIFIED job=${job.id} `)));
+  child.kill("SIGKILL");
+  await done;
+  const waiting = h.cli("status", job.id, "--wait", "--timeout-ms", "5000");
+  assert.equal(waiting.status, 0, waiting.stderr);
+  const snapshot = JSON.parse(waiting.stdout);
+  assert.equal(snapshot.job.status, "failed");
+  assert.equal(snapshot.waitTimedOut, false);
+  assert.match(snapshot.job.errorMessage, /owner process exited/i);
+  const failed = `FAILED job=${job.id} thread=${job.threadId} owner process exited`;
+  await waitFor(() => events.lines().includes(failed));
+  events.child.kill("SIGTERM");
+  const result = await events.done;
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(result.stderr, "");
+  assert.deepEqual(events.lines().filter((line) => line.startsWith("FAILED ")), [failed]);
+  assert.equal(JSON.parse(h.cli("status", job.id).stdout).job.status, "failed");
+});
+
+test("events and status --wait report a quiet live task as stalled without failing it", async (t) => {
+  const h = await setup(t);
+  const { job, done } = await startJob(t, h, "hold notify:Owner ready");
+  const notified = h.cli("status", job.id, "--wait", "--timeout-ms", "5000");
+  assert.equal(notified.status, 0, notified.stderr);
+  assert.equal(JSON.parse(notified.stdout).hasNotifications, true);
+  const old = new Date(Date.now() - 20 * 60 * 1000);
+  fs.utimesSync(job.logFile, old, old);
+  const events = startEvents(t, h);
+  await waitFor(() => events.lines().some((line) => line === `STALLED job=${job.id} thread=${job.threadId} 20m without progress`));
+  const waiting = h.cli("status", job.id, "--wait", "--timeout-ms", "5000");
+  assert.equal(waiting.status, 0, waiting.stderr);
+  const snapshot = JSON.parse(waiting.stdout);
+  assert.equal(snapshot.stalled, true);
+  assert.equal(snapshot.waitTimedOut, false);
+  assert.equal(snapshot.job.status, "running");
+  const again = h.cli("status", job.id, "--wait", "--timeout-ms", "150");
+  assert.equal(again.status, 0, again.stderr);
+  assert.equal(JSON.parse(again.stdout).stalled, undefined);
+  assert.equal(JSON.parse(again.stdout).waitTimedOut, true);
+  events.child.kill("SIGTERM");
+  const result = await events.done;
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(events.lines().filter((line) => line.startsWith("STALLED ")).length, 1);
+  assert.equal(h.cli("message", job.id, "finish").status, 0);
+  assert.equal((await done).code, 0);
+});
+
+test("task sandbox and network options are persisted and preserved through interrupt redirects", async (t) => {
+  const h = await setup(t);
+  for (const { options, sandbox, policy } of [
+    { options: ["--sandbox", "danger-full-access"], sandbox: "danger-full-access", policy: { type: "dangerFullAccess" } },
+    { options: ["--write", "--network"], sandbox: "workspace-write", policy: {
+      type: "workspaceWrite", writableRoots: [fs.realpathSync(h.repo)], networkAccess: true,
+      excludeTmpdirEnvVar: false, excludeSlashTmp: false
+    } }
+  ]) {
+    const { job, done } = await startJob(t, h, "hold", options);
+    const status = h.cli("status", job.id);
+    assert.equal(status.status, 0, status.stderr);
+    const current = JSON.parse(status.stdout).job;
+    assert.equal(current.sandbox, sandbox);
+    assert.equal(current.request.sandbox, sandbox);
+    assert.equal(current.write, true);
+    assert.equal(current.network, sandbox === "workspace-write");
+    assert.equal(current.request.network, sandbox === "workspace-write");
+    const started = h.requests().filter((item) => item.method === "turn/start" && item.params.threadId === job.threadId);
+    assert.equal(started.length, 1);
+    assert.deepEqual(started[0].params.sandboxPolicy, policy);
+    const redirected = h.cli("message", job.id, "--interrupt", "write redirected");
+    assert.equal(redirected.status, 0, redirected.stderr);
+    const result = await done;
+    assert.equal(result.code, 0, result.stderr);
+    const turns = h.requests().filter((item) => item.method === "turn/start" && item.params.threadId === job.threadId);
+    assert.equal(turns.length, 2);
+    assert.deepEqual(turns[1].params.sandboxPolicy, policy);
+    assert.equal(fs.readFileSync(path.join(h.repo, "written.txt"), "utf8"), "write redirected");
+  }
+  const readonly = h.cli("task", "--write", "--sandbox", "read-only", "initial");
+  assert.equal(readonly.status, 0, readonly.stderr);
+  const job = JSON.parse(h.cli("status").stdout).latestFinished;
+  assert.equal(job.sandbox, "read-only");
+  assert.equal(job.write, false);
+  const started = h.requests().find((item) => item.method === "turn/start" && item.params.threadId === job.threadId);
+  assert.deepEqual(started.params.sandboxPolicy, { type: "readOnly", networkAccess: false });
 });

--- a/tests/live-control.test.mjs
+++ b/tests/live-control.test.mjs
@@ -1,0 +1,215 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { CodexAppServerClient } from "../plugins/codex/scripts/lib/app-server.mjs";
+import { createBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-endpoint.mjs";
+import { sendBrokerShutdown, waitForBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { buildEnv } from "./fake-codex-fixture.mjs";
+import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
+
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const SCRIPT = path.join(ROOT, "plugins/codex/scripts/codex-companion.mjs");
+async function waitFor(predicate) {
+  for (let i = 0; i < 200; i += 1) {
+    const value = await predicate();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error("Timed out waiting for live control.");
+}
+async function setup(t, timeoutMs = 600000) {
+  const repo = makeTempDir();
+  const bin = makeTempDir();
+  const socketDir = fs.mkdtempSync(path.join(os.tmpdir(), "cxl-"));
+  fs.copyFileSync(new URL("live-codex-fixture.cjs", import.meta.url), path.join(bin, "codex"));
+  fs.chmodSync(path.join(bin, "codex"), 0o755);
+  if (process.platform === "win32") fs.writeFileSync(path.join(bin, "codex.cmd"), '@node "%~dp0codex" %*\r\n');
+  initGitRepo(repo);
+  const endpoint = createBrokerEndpoint(socketDir);
+  const env = { ...buildEnv(bin), CLAUDE_PLUGIN_DATA: path.join(repo, ".plugin-data"),
+    CODEX_COMPANION_APP_SERVER_ENDPOINT: endpoint };
+  const broker = spawn(process.execPath, [path.join(ROOT, "plugins/codex/scripts/app-server-broker.mjs"),
+    "serve", "--endpoint", endpoint, "--cwd", repo, "--input-timeout-ms", String(timeoutMs)], { env });
+  let errors = "";
+  broker.stderr.on("data", (data) => { errors += data; });
+  const closed = new Promise((resolve) => broker.on("exit", resolve));
+  const clients = [];
+  t.after(async () => {
+    for (const client of clients) await client.close();
+    await sendBrokerShutdown(endpoint);
+    if (broker.exitCode === null) broker.kill();
+    await closed;
+  });
+  assert.equal(await waitForBrokerEndpoint(endpoint, 5000), true, errors);
+  const connect = async () => {
+    const client = await CodexAppServerClient.connect(repo, { brokerEndpoint: endpoint, env });
+    clients.push(client);
+    return client;
+  };
+  const owner = await connect();
+  const notifications = [];
+  owner.setNotificationHandler((message) => notifications.push(message));
+  const { thread } = await owner.request("thread/start", { cwd: repo, sandbox: "read-only" });
+  const start = (text) => owner.request("turn/start", { threadId: thread.id, input: [{ type: "text", text }] });
+  const cli = (...args) => run(process.execPath, [SCRIPT, ...args, "--json"], { cwd: repo, env });
+  return { repo, env, owner, connect, thread, start, notifications, cli };
+}
+
+test("steering from another socket preserves FIFO and the owning event stream", async (t) => {
+  const h = await setup(t);
+  const { turn } = await h.start("hold");
+  const control = await h.connect();
+  const accepted = await Promise.all(["first", "finish"].map((text) => control.request("turn/steer", {
+    threadId: h.thread.id, expectedTurnId: turn.id, clientUserMessageId: text, input: [{ type: "text", text }]
+  })));
+  assert.deepEqual(accepted.map((result) => result.turnId), [turn.id, turn.id]);
+  const snapshot = await control.request("broker/status", { threadId: h.thread.id });
+  assert.deepEqual(snapshot.pendingMessages.map((item) => item.id), ["first", "finish"]);
+  await waitFor(() => h.notifications.some((item) => item.method === "turn/completed"));
+  const final = h.notifications.find((item) => item.params?.item?.type === "agentMessage");
+  assert.equal(final.params.item.text, "hold|first|finish");
+  assert.deepEqual((await control.request("broker/status", { threadId: h.thread.id })).pendingMessages, []);
+});
+
+test("stale steering is rejected without adding a pending message", async (t) => {
+  const h = await setup(t);
+  await h.start("hold");
+  const control = await h.connect();
+  await assert.rejects(control.request("turn/steer", { threadId: h.thread.id, expectedTurnId: "old",
+    input: [{ type: "text", text: "wrong" }] }), /turn mismatch/);
+  assert.deepEqual((await control.request("broker/status", { threadId: h.thread.id })).pendingMessages, []);
+});
+
+test("question responses use the original request ID and reject incorrect answers", async (t) => {
+  const h = await setup(t);
+  const { turn } = await h.start("ask");
+  const control = await h.connect();
+  const snapshot = await waitFor(async () => {
+    const state = await control.request("broker/status", { threadId: h.thread.id });
+    return state.questions.length ? state : null;
+  });
+  assert.equal(snapshot.questions[0].requestId, "question-1");
+  const params = { threadId: h.thread.id, turnId: turn.id, requestId: "question-1" };
+  await assert.rejects(control.request("broker/answer", { ...params, turnId: "old", answers: { source: { answers: ["wrong turn"] } } }), /turn mismatch/);
+  await assert.rejects(control.request("broker/answer", { ...params, answers: { wrong: { answers: ["latest"] } } }), /question/);
+  await control.request("broker/answer", { ...params, answers: { source: { answers: ["latest"] } } });
+  await waitFor(() => h.notifications.some((item) => item.method === "turn/completed"));
+  assert.match(h.notifications.find((item) => item.params?.item?.type === "agentMessage").params.item.text, /latest/);
+  await assert.rejects(control.request("broker/answer", { ...params, answers: { source: { answers: ["again"] } } }), /pending/);
+});
+
+test("unanswered questions interrupt with an explicit timeout", async (t) => {
+  const h = await setup(t, 80);
+  await h.start("ask");
+  await waitFor(() => h.notifications.some((item) => item.method === "turn/completed"));
+  const control = await h.connect();
+  const snapshot = await control.request("broker/status", { threadId: h.thread.id });
+  assert.match(snapshot.error, /answer.*timed out/i);
+  assert.deepEqual(snapshot.questions, []);
+});
+
+test("continue --write overrides a loaded read-only thread at turn/start", async (t) => {
+  const h = await setup(t);
+  const initial = h.cli("task", "initial");
+  assert.equal(initial.status, 0, initial.stderr);
+  const threadId = JSON.parse(initial.stdout).threadId;
+  const resumed = h.cli("task", "--thread", threadId, "--write", "write latest");
+  assert.equal(resumed.status, 0, resumed.stderr);
+  assert.equal(JSON.parse(resumed.stdout).threadId, threadId);
+  assert.equal(fs.readFileSync(path.join(h.repo, "written.txt"), "utf8"), "write latest");
+  fs.unlinkSync(path.join(h.repo, "written.txt"));
+  const readonly = h.cli("task", "--thread", threadId, "write forbidden");
+  assert.equal(readonly.status, 1);
+  assert.equal(fs.existsSync(path.join(h.repo, "written.txt")), false);
+});
+
+async function startJob(t, h, prompt) {
+  const child = spawn(process.execPath, [SCRIPT, "task", "--write", "--json", prompt], { cwd: h.repo, env: h.env });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (data) => { stdout += data; });
+  child.stderr.on("data", (data) => { stderr += data; });
+  const done = new Promise((resolve) => child.on("exit", (code) => resolve({ code, stdout, stderr })));
+  t.after(async () => { if (child.exitCode === null) child.kill(); await done; });
+  const job = await waitFor(() => {
+    const result = h.cli("status");
+    assert.equal(result.status, 0, result.stderr);
+    return JSON.parse(result.stdout).running.find((item) => item.threadId && item.turnId);
+  });
+  return { job, done };
+}
+
+test("message --interrupt continues the original job and reports retained changes", async (t) => {
+  const h = await setup(t);
+  const { job, done } = await startJob(t, h, "hold");
+  const redirected = h.cli("message", job.id, "--interrupt", "write redirected");
+  assert.equal(redirected.status, 0, redirected.stderr);
+  const report = JSON.parse(redirected.stdout);
+  assert.equal(report.threadId, job.threadId);
+  assert.deepEqual(report.partialChanges, [{ path: path.join(fs.realpathSync(h.repo), "partial.txt"), status: "completed" }]);
+  const result = await done;
+  assert.equal(result.code, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.threadId, job.threadId);
+  assert.equal(payload.interruptedTurns[0].turnId, job.turnId);
+  assert.match(report.workspaceStatus, /partial.txt/);
+  assert.equal(fs.readFileSync(path.join(h.repo, "partial.txt"), "utf8"), "partial");
+  assert.equal(fs.readFileSync(path.join(h.repo, "written.txt"), "utf8"), "write redirected");
+});
+
+test("CLI status exposes questions and answer resumes the original job", async (t) => {
+  const h = await setup(t);
+  const { job, done } = await startJob(t, h, "ask");
+  const status = h.cli("status", job.id);
+  assert.equal(status.status, 0, status.stderr);
+  const question = JSON.parse(status.stdout).job.live.questions[0];
+  assert.equal(question.requestId, "question-1");
+  const stateRoot = path.join(h.env.CLAUDE_PLUGIN_DATA, "state");
+  const stateFile = path.join(stateRoot, fs.readdirSync(stateRoot)[0], "state.json");
+  const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+  state.jobs.find((entry) => entry.id === job.id).phase = "running";
+  fs.writeFileSync(stateFile, JSON.stringify(state));
+  const waiting = h.cli("status", job.id, "--wait", "--timeout-ms", "5000");
+  assert.equal(waiting.status, 0, waiting.stderr);
+  assert.equal(JSON.parse(waiting.stdout).waitingForAnswer, true);
+  const forbidden = h.cli("message", job.id, "latest");
+  assert.equal(forbidden.status, 1);
+  assert.match(forbidden.stderr, /pending question/);
+  fs.writeFileSync(path.join(h.repo, "answers.json"), JSON.stringify({ source: { answers: ["latest"] } }));
+  const answered = h.cli("answer", job.id, "--request-id", "question-1", "--answers-file", "answers.json");
+  assert.equal(answered.status, 0, answered.stderr);
+  const result = await done;
+  assert.equal(result.code, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).threadId, job.threadId);
+  assert.match(JSON.parse(result.stdout).rawOutput, /latest/);
+});
+
+test("unrelated approval requests are not auto-approved", async (t) => {
+  const h = await setup(t);
+  await h.start("approve");
+  await waitFor(() => h.notifications.some((message) => message.method === "turn/completed"));
+  const final = h.notifications.find((message) => message.params?.item?.type === "agentMessage");
+  assert.match(final.params.item.text, /Unsupported server request/);
+  const control = await h.connect();
+  assert.deepEqual((await control.request("broker/status", { threadId: h.thread.id })).questions, []);
+});
+
+test("interruption reports changes that finish during cancellation", async (t) => {
+  const h = await setup(t);
+  const { turn } = await h.start("hold-late");
+  const control = await h.connect();
+  const report = await control.request("turn/interrupt", { threadId: h.thread.id, turnId: turn.id });
+  assert.deepEqual(report.partialChanges.map((entry) => path.basename(entry.path)), ["partial.txt", "late.txt"]);
+  assert.match(report.workspaceStatus, /late.txt/);
+});
+
+test("final text does not mark an ordinary task successful before its terminal event", async (t) => {
+  const h = await setup(t);
+  const result = h.cli("task", "fail-late");
+  assert.equal(result.status, 1, result.stderr);
+  assert.equal(JSON.parse(result.stdout).status, 1);
+});

--- a/tests/real-app-server.test.mjs
+++ b/tests/real-app-server.test.mjs
@@ -1,0 +1,153 @@
+import fs from "node:fs";
+import path from "node:path";
+import http from "node:http";
+import zlib from "node:zlib";
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { CodexAppServerClient } from "../plugins/codex/scripts/lib/app-server.mjs";
+import { createBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-endpoint.mjs";
+import { sendBrokerShutdown, waitForBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+import { initGitRepo, makeTempDir } from "./helpers.mjs";
+
+const SCRIPTS = fileURLToPath(new URL("../plugins/codex/scripts/", import.meta.url));
+const enabled = process.env.CODEX_REAL_APP_SERVER_TEST === "1";
+
+test("installed app-server: question, loaded-thread write, steering, and interruption", { skip: !enabled, timeout: 120000 }, async (t) => {
+  const repo = fs.realpathSync(makeTempDir());
+  const home = makeTempDir();
+  const socketDir = makeTempDir("cxr-");
+  initGitRepo(repo);
+  const requests = [];
+  const paths = [];
+  let serverError = null;
+  const call = (name, args, id) => ({ type: "function_call", call_id: id, name, arguments: JSON.stringify(args) });
+  const final = (text) => ({ type: "message", role: "assistant", id: "final", content: [{ type: "output_text", text }] });
+  const server = http.createServer(async (req, res) => {
+    paths.push(`${req.method} ${req.url}`);
+    try {
+      if (req.method !== "POST" || !req.url.endsWith("/responses")) {
+        res.writeHead(404).end();
+        return;
+      }
+      const chunks = [];
+      for await (const chunk of req) chunks.push(chunk);
+      let body = Buffer.concat(chunks);
+      if (req.headers["content-encoding"] === "zstd") body = zlib.zstdDecompressSync(body);
+      if (req.headers["content-encoding"] === "gzip") body = zlib.gunzipSync(body);
+      requests.push(JSON.parse(body));
+      const count = requests.length;
+      const item = count === 1 ? call("request_user_input", { questions: [{ id: "source", header: "Source",
+        question: "Which source?", options: [{ label: "Latest", description: "Read the latest plan." },
+          { label: "Stored", description: "Read the stored plan." }] }] }, "question")
+        : count === 3 ? call("exec_command", { cmd: "node -e \"require('fs').writeFileSync('live-proof.mjs', 'export const value = 2;\\n'); require('child_process').execFileSync(process.execPath, ['--check', 'live-proof.mjs']); setTimeout(() => {}, 2000)\"",
+          yield_time_ms: 10000 }, "write")
+        : count === 5 ? call("exec_command", { cmd: "node -e \"require('fs').writeFileSync('shell-partial.txt', 'partial'); setTimeout(() => {}, 20000)\"", yield_time_ms: 10000 }, "partial")
+        : final(count === 2 ? "answer received" : "write and steering complete");
+      const id = `response-${count}`;
+      const events = [{ type: "response.created", response: { id } },
+        { type: "response.output_item.done", item },
+        { type: "response.completed", response: { id, usage: { input_tokens: 0, output_tokens: 0, total_tokens: 0 } } }];
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.end(events.map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join(""));
+    } catch (error) {
+      serverError = error;
+      res.writeHead(500).end(String(error));
+    }
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => { server.closeAllConnections(); server.close(); });
+  fs.writeFileSync(path.join(home, "config.toml"), `model = "gpt-5.4"
+model_provider = "local_test"
+[model_providers.local_test]
+name = "Local test"
+base_url = "http://127.0.0.1:${server.address().port}/v1"
+wire_api = "responses"
+requires_openai_auth = false
+[features]
+shell_snapshot = false
+code_mode = false
+unified_exec = true
+`);
+  const endpoint = createBrokerEndpoint(socketDir);
+  const env = { ...process.env, NO_PROXY: "127.0.0.1,localhost", no_proxy: "127.0.0.1,localhost", CODEX_HOME: home, CODEX_SQLITE_HOME: home,
+    CLAUDE_PLUGIN_DATA: path.join(home, "plugin-data"), CODEX_COMPANION_APP_SERVER_ENDPOINT: endpoint };
+  const children = [];
+  const launch = (script, args) => {
+    const child = spawn(process.execPath, [path.join(SCRIPTS, script), ...args], { cwd: repo, env });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (data) => { stdout += data; });
+    child.stderr.on("data", (data) => { stderr += data; });
+    const done = new Promise((resolve) => child.on("exit", (code) => resolve({ code, stdout, stderr })));
+    children.push({ child, done, inspect: () => ({ script, args, pid: child.pid, exitCode: child.exitCode, stdout: stdout.slice(-1000), stderr: stderr.slice(-2000) }) });
+    return done;
+  };
+  launch("app-server-broker.mjs", ["serve", "--cwd", repo, "--endpoint", endpoint]);
+  let control;
+  t.after(async () => {
+    if (t.signal.aborted || serverError || requests.length !== 6) {
+      t.diagnostic(JSON.stringify({ paths, requests: requests.length, processes: children.slice(-3).map((entry) => entry.inspect()) }));
+    }
+    await control?.close();
+    await sendBrokerShutdown(endpoint);
+    for (const entry of children) {
+      if (entry.child.exitCode === null) entry.child.kill();
+      await entry.done;
+    }
+  });
+  assert.equal(await waitForBrokerEndpoint(endpoint, 15000), true);
+  control = await CodexAppServerClient.connect(repo, { brokerEndpoint: endpoint, env });
+  const waitFor = async (predicate) => {
+    for (let i = 0; i < 400; i += 1) {
+      t.signal.throwIfAborted();
+      if (serverError) throw serverError;
+      const result = await predicate();
+      if (result) return result;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error(`No progress; model requests: ${JSON.stringify(requests)}`);
+  };
+  const first = launch("codex-companion.mjs", ["task", "--json", "Ask which source to use."]);
+  const job = await waitFor(async () => {
+    const status = await launch("codex-companion.mjs", ["status", "--json"]);
+    const snapshot = JSON.parse(status.stdout);
+    if (snapshot.latestFinished) {
+      const result = await first;
+      throw new Error(`Question was not held: ${result.stdout} ${result.stderr}; tool outputs: ${JSON.stringify(requests.flatMap((r) => r.input.filter((item) => item.type.includes("output"))))}`);
+    }
+    return snapshot.running.find((entry) => entry.live?.questions?.length);
+  });
+  const question = job.live.questions[0];
+  await control.request("broker/answer", { threadId: job.threadId, turnId: question.turnId,
+    requestId: question.requestId, answers: { source: { answers: ["Latest"] } } });
+  const firstResult = await first;
+  assert.equal(firstResult.code, 0, firstResult.stderr);
+  assert.match(JSON.stringify(requests[1].input), /Latest/);
+
+  const second = launch("codex-companion.mjs", ["task", "--thread", job.threadId, "--write", "--json", "Write and validate the module."]);
+  await waitFor(() => requests.length === 3);
+  const live = await control.request("broker/status", { threadId: job.threadId });
+  await control.request("turn/steer", { threadId: job.threadId, expectedTurnId: live.turnId,
+    input: [{ type: "text", text: "Use the latest plan, never the stored chargeId." }] });
+  const secondResult = await second;
+  assert.equal(secondResult.code, 0, secondResult.stderr);
+  assert.equal(JSON.parse(secondResult.stdout).threadId, job.threadId);
+  assert.equal(fs.readFileSync(path.join(repo, "live-proof.mjs"), "utf8"), "export const value = 2;\n");
+  assert.match(JSON.stringify(requests[3].input), /Use the latest plan/);
+  assert.match(JSON.stringify(requests[3].input), /Process exited with code 0/);
+
+  const third = launch("codex-companion.mjs", ["task", "--thread", job.threadId, "--write", "--json", "Start the next change."]);
+  await waitFor(() => fs.existsSync(path.join(repo, "shell-partial.txt")));
+  const current = await control.request("broker/status", { threadId: job.threadId });
+  const interruption = await control.request("broker/redirect", { threadId: job.threadId, turnId: current.turnId,
+    input: [{ type: "text", text: "Stop this approach and report the retained file." }] });
+  assert.match(interruption.workspaceStatus, /shell-partial.txt/);
+  const thirdResult = await third;
+  assert.equal(thirdResult.code, 0, thirdResult.stderr);
+  const payload = JSON.parse(thirdResult.stdout);
+  assert.equal(payload.threadId, job.threadId);
+  assert.equal(payload.interruptedTurns[0].turnId, current.turnId);
+  assert.equal(fs.readFileSync(path.join(repo, "shell-partial.txt"), "utf8"), "partial");
+});

--- a/tests/real-app-server.test.mjs
+++ b/tests/real-app-server.test.mjs
@@ -9,12 +9,13 @@ import { fileURLToPath } from "node:url";
 import { CodexAppServerClient } from "../plugins/codex/scripts/lib/app-server.mjs";
 import { createBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-endpoint.mjs";
 import { sendBrokerShutdown, waitForBrokerEndpoint } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
-import { initGitRepo, makeTempDir } from "./helpers.mjs";
+import { initGitRepo, isolateTestEnvironment, makeTempDir } from "./helpers.mjs";
 
 const SCRIPTS = fileURLToPath(new URL("../plugins/codex/scripts/", import.meta.url));
 const enabled = process.env.CODEX_REAL_APP_SERVER_TEST === "1";
 
-test("installed app-server: question, loaded-thread write, steering, and interruption", { skip: !enabled, timeout: 120000 }, async (t) => {
+test("installed app-server: question, notifications, loaded-thread write, steering, and interruption", { skip: !enabled, timeout: 120000 }, async (t) => {
+  isolateTestEnvironment(t);
   const repo = fs.realpathSync(makeTempDir());
   const home = makeTempDir();
   const socketDir = makeTempDir("cxr-");
@@ -41,10 +42,11 @@ test("installed app-server: question, loaded-thread write, steering, and interru
       const item = count === 1 ? call("request_user_input", { questions: [{ id: "source", header: "Source",
         question: "Which source?", options: [{ label: "Latest", description: "Read the latest plan." },
           { label: "Stored", description: "Read the stored plan." }] }] }, "question")
-        : count === 3 ? call("exec_command", { cmd: "node -e \"require('fs').writeFileSync('live-proof.mjs', 'export const value = 2;\\n'); require('child_process').execFileSync(process.execPath, ['--check', 'live-proof.mjs']); setTimeout(() => {}, 2000)\"",
+        : count === 2 || count === 4 ? call("notify_director", { message: count === 2 ? "Latest source selected." : "Resumed work can notify." }, `notification-${count}`)
+        : count === 5 ? call("exec_command", { cmd: "node -e \"require('fs').writeFileSync('live-proof.mjs', 'export const value = 2;\\n'); require('child_process').execFileSync(process.execPath, ['--check', 'live-proof.mjs']); setTimeout(() => {}, 2000)\"",
           yield_time_ms: 10000 }, "write")
-        : count === 5 ? call("exec_command", { cmd: "node -e \"require('fs').writeFileSync('shell-partial.txt', 'partial'); setTimeout(() => {}, 20000)\"", yield_time_ms: 10000 }, "partial")
-        : final(count === 2 ? "answer received" : "write and steering complete");
+        : count === 7 ? call("exec_command", { cmd: "node -e \"require('fs').writeFileSync('shell-partial.txt', 'partial'); setTimeout(() => {}, 20000)\"", yield_time_ms: 10000 }, "partial")
+        : final(count === 3 ? "answer received" : "write and steering complete");
       const id = `response-${count}`;
       const events = [{ type: "response.created", response: { id } },
         { type: "response.output_item.done", item },
@@ -87,7 +89,7 @@ unified_exec = true
   launch("app-server-broker.mjs", ["serve", "--cwd", repo, "--endpoint", endpoint]);
   let control;
   t.after(async () => {
-    if (t.signal.aborted || serverError || requests.length !== 6) {
+    if (t.signal.aborted || serverError || requests.length !== 8) {
       t.diagnostic(JSON.stringify({ paths, requests: requests.length, processes: children.slice(-3).map((entry) => entry.inspect()) }));
     }
     await control?.close();
@@ -125,18 +127,25 @@ unified_exec = true
   const firstResult = await first;
   assert.equal(firstResult.code, 0, firstResult.stderr);
   assert.match(JSON.stringify(requests[1].input), /Latest/);
+  assert.ok(requests[0].tools.some((tool) => tool.name === "notify_director"));
+  assert.match(JSON.stringify(requests[2].input), /Delivered to the director\./);
+  const notified = await control.request("broker/status", { threadId: job.threadId });
+  assert.equal(notified.notifications[0].message, "Latest source selected.");
 
   const second = launch("codex-companion.mjs", ["task", "--thread", job.threadId, "--write", "--json", "Write and validate the module."]);
-  await waitFor(() => requests.length === 3);
+  await waitFor(() => requests.length === 5);
   const live = await control.request("broker/status", { threadId: job.threadId });
+  assert.ok(requests[3].tools.some((tool) => tool.name === "notify_director"));
+  assert.match(JSON.stringify(requests[4].input), /Delivered to the director\./);
+  assert.deepEqual(live.notifications.map((notification) => notification.message), ["Latest source selected.", "Resumed work can notify."]);
   await control.request("turn/steer", { threadId: job.threadId, expectedTurnId: live.turnId,
     input: [{ type: "text", text: "Use the latest plan, never the stored chargeId." }] });
   const secondResult = await second;
   assert.equal(secondResult.code, 0, secondResult.stderr);
   assert.equal(JSON.parse(secondResult.stdout).threadId, job.threadId);
   assert.equal(fs.readFileSync(path.join(repo, "live-proof.mjs"), "utf8"), "export const value = 2;\n");
-  assert.match(JSON.stringify(requests[3].input), /Use the latest plan/);
-  assert.match(JSON.stringify(requests[3].input), /Process exited with code 0/);
+  assert.match(JSON.stringify(requests[5].input), /Use the latest plan/);
+  assert.match(JSON.stringify(requests[5].input), /Process exited with code 0/);
 
   const third = launch("codex-companion.mjs", ["task", "--thread", job.threadId, "--write", "--json", "Start the next change."]);
   await waitFor(() => fs.existsSync(path.join(repo, "shell-partial.txt")));

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -1,7 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { renderReviewResult, renderStoredJobResult } from "../plugins/codex/scripts/lib/render.mjs";
+import { renderJobStatusReport, renderReviewResult, renderStoredJobResult } from "../plugins/codex/scripts/lib/render.mjs";
+
+test("running job status shows owner liveness and time since progress", () => {
+  const job = { id: "task-live", status: "running", ownerAlive: true, progressAgeMinutes: 17 };
+  assert.match(renderJobStatusReport(job), /Owner: alive\n  Last progress: 17m ago/);
+  assert.match(renderJobStatusReport({ ...job, ownerAlive: false }), /Owner: exited/);
+});
 
 test("renderReviewResult degrades gracefully when JSON is missing required review fields", () => {
   const output = renderReviewResult(
@@ -56,4 +62,18 @@ test("renderStoredJobResult prefers rendered output for structured review jobs",
   assert.doesNotMatch(output, /^\{/);
   assert.match(output, /Codex session ID: thr_123/);
   assert.match(output, /Resume in Codex: codex resume thr_123/);
+});
+
+test("task status and result show the stored sandbox and effective network access", () => {
+  for (const [sandbox, network, expected] of [
+    ["read-only", true, "disabled"],
+    ["workspace-write", false, "disabled"],
+    ["workspace-write", true, "enabled"],
+    ["danger-full-access", false, "enabled"]
+  ]) {
+    const job = { id: "task-1", status: "completed", jobClass: "task", sandbox, network };
+    const details = `Sandbox: ${sandbox} (network: ${expected})`;
+    assert.ok(renderJobStatusReport(job).includes(details));
+    assert.ok(renderStoredJobResult(job, { request: { sandbox, network }, result: { rawOutput: "Finished" } }).includes(details));
+  }
 });

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -28,6 +28,49 @@ async function waitFor(predicate, { timeoutMs = 5000, intervalMs = 50 } = {}) {
   throw new Error("Timed out waiting for condition.");
 }
 
+function seedFakeCodexThread(binDir, repo, threadId) {
+  fs.writeFileSync(
+    path.join(binDir, "fake-codex-state.json"),
+    `${JSON.stringify(
+      {
+        nextThreadId: 2,
+        nextTurnId: 1,
+        appServerStarts: 0,
+        threads: [
+          {
+            id: threadId,
+            cwd: repo,
+            name: null,
+            preview: "",
+            ephemeral: false,
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        capabilities: null,
+        lastInterrupt: null
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+}
+
+function resolveStateDirWithPluginData(repo, pluginDataDir) {
+  const previousPluginDataDir = process.env.CLAUDE_PLUGIN_DATA;
+  process.env.CLAUDE_PLUGIN_DATA = pluginDataDir;
+  try {
+    return resolveStateDir(repo);
+  } finally {
+    if (previousPluginDataDir === undefined) {
+      delete process.env.CLAUDE_PLUGIN_DATA;
+    } else {
+      process.env.CLAUDE_PLUGIN_DATA = previousPluginDataDir;
+    }
+  }
+}
+
 test("setup reports ready when fake codex is installed and authenticated", () => {
   const binDir = makeTempDir();
   installFakeCodex(binDir);
@@ -501,6 +544,127 @@ test("task --resume-last resumes the latest persisted task thread", () => {
 
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout, "Resumed the prior run.\nFollow-up prompt accepted.\n");
+});
+
+test("task --thread resumes the requested thread without leaking the flag into the prompt", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const threadId = "thr_specific";
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  const pluginDataDir = makeTempDir();
+  const env = {
+    ...buildEnv(binDir),
+    CLAUDE_PLUGIN_DATA: pluginDataDir
+  };
+  installFakeCodex(binDir);
+  seedFakeCodexThread(binDir, repo, threadId);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  assert.equal(fs.existsSync(path.join(resolveStateDirWithPluginData(repo, pluginDataDir), "state.json")), false);
+
+  const result = run("node", [SCRIPT, "task", "--thread", threadId, "follow up by id"], {
+    cwd: repo,
+    env
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.threadId, threadId);
+  assert.equal(fakeState.lastTurnStart.prompt, "follow up by id");
+});
+
+test("task --thread works in background mode", async () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const threadId = "thr_background";
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  const pluginDataDir = makeTempDir();
+  const env = {
+    ...buildEnv(binDir),
+    CLAUDE_PLUGIN_DATA: pluginDataDir
+  };
+  installFakeCodex(binDir, "slow-task");
+  seedFakeCodexThread(binDir, repo, threadId);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+
+  const launched = run(
+    "node",
+    [SCRIPT, "task", "--background", "--json", "--thread", threadId, "background follow up"],
+    {
+      cwd: repo,
+      env
+    }
+  );
+
+  assert.equal(launched.status, 0, launched.stderr);
+  const launchPayload = JSON.parse(launched.stdout);
+  const waitedStatus = run(
+    "node",
+    [SCRIPT, "status", launchPayload.jobId, "--wait", "--timeout-ms", "15000", "--json"],
+    {
+      cwd: repo,
+      env
+    }
+  );
+
+  assert.equal(waitedStatus.status, 0, waitedStatus.stderr);
+  assert.equal(JSON.parse(waitedStatus.stdout).job.status, "completed");
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.threadId, threadId);
+  assert.equal(fakeState.lastTurnStart.prompt, "background follow up");
+});
+
+test("task --thread rejects conflicting and invalid routing values", () => {
+  const repo = makeTempDir();
+  initGitRepo(repo);
+
+  for (const conflictingFlag of ["--resume-last", "--resume", "--fresh"]) {
+    const result = run("node", [SCRIPT, "task", "--thread", "thr_specific", conflictingFlag, "follow up"], {
+      cwd: repo
+    });
+    assert.equal(result.status > 0, true);
+    assert.match(result.stderr, /Choose only one of --thread, --resume\/--resume-last, or --fresh/);
+  }
+
+  for (const invalidThreadOption of ["--thread=", "--thread=-bad"]) {
+    const result = run("node", [SCRIPT, "task", invalidThreadOption, "follow up"], {
+      cwd: repo
+    });
+    assert.equal(result.status > 0, true);
+    assert.match(result.stderr, /Provide a thread id with --thread/);
+  }
+});
+
+test("a failed task --thread does not pre-write the requested thread id into the job", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const pluginDataDir = makeTempDir();
+  const env = {
+    ...buildEnv(binDir),
+    CLAUDE_PLUGIN_DATA: pluginDataDir
+  };
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  const result = run("node", [SCRIPT, "task", "--thread", "thr_missing", "follow up"], {
+    cwd: repo,
+    env
+  });
+
+  assert.equal(result.status > 0, true);
+  assert.match(result.stderr, /unknown thread thr_missing/);
+  const state = JSON.parse(
+    fs.readFileSync(path.join(resolveStateDirWithPluginData(repo, pluginDataDir), "state.json"), "utf8")
+  );
+  assert.equal(state.jobs.length, 1);
+  assert.equal(state.jobs[0].status, "failed");
+  assert.equal("threadId" in state.jobs[0], false);
 });
 
 test("task-resume-candidate returns the latest rescue thread from the current session", () => {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1,12 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
-import test from "node:test";
+import test, { beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { buildEnv, installFakeCodex } from "./fake-codex-fixture.mjs";
-import { initGitRepo, makeTempDir, run } from "./helpers.mjs";
+import { initGitRepo, isolateTestEnvironment, makeTempDir, run } from "./helpers.mjs";
 import { loadBrokerSession, saveBrokerSession } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
 import { resolveStateDir } from "../plugins/codex/scripts/lib/state.mjs";
 
@@ -15,6 +15,34 @@ const PLUGIN_ROOT = path.join(ROOT, "plugins", "codex");
 const SCRIPT = path.join(PLUGIN_ROOT, "scripts", "codex-companion.mjs");
 const STOP_HOOK = path.join(PLUGIN_ROOT, "scripts", "stop-review-gate-hook.mjs");
 const SESSION_HOOK = path.join(PLUGIN_ROOT, "scripts", "session-lifecycle-hook.mjs");
+
+beforeEach(isolateTestEnvironment);
+
+test("test environment excludes inherited live broker and session state", () => {
+  const inheritedData = makeTempDir();
+  const result = run(process.execPath, ["--input-type=module", "-e", `
+    import assert from "node:assert/strict";
+    import { isolateTestEnvironment } from ${JSON.stringify(new URL("./helpers.mjs", import.meta.url).href)};
+    const inheritedData = process.env.CLAUDE_PLUGIN_DATA;
+    let cleanup;
+    isolateTestEnvironment({ after(fn) { cleanup = fn; } });
+    assert.notEqual(process.env.CLAUDE_PLUGIN_DATA, inheritedData);
+    assert.equal(Object.keys(process.env).some((key) => key.startsWith("CODEX_COMPANION_")), false);
+    assert.equal(process.env.CLAUDE_ENV_FILE, undefined);
+    await cleanup();
+  `], { env: {
+    ...process.env,
+    CLAUDE_PLUGIN_DATA: inheritedData,
+    CLAUDE_ENV_FILE: path.join(inheritedData, "session.env"),
+    CODEX_COMPANION_APP_SERVER_ENDPOINT: `unix:${path.join(inheritedData, "live.sock")}`,
+    CODEX_COMPANION_APP_SERVER_PID_FILE: path.join(inheritedData, "live.pid"),
+    CODEX_COMPANION_APP_SERVER_LOG_FILE: path.join(inheritedData, "live.log"),
+    CODEX_COMPANION_SESSION_ID: "live-session",
+    CODEX_COMPANION_JOB_ID: "live-job"
+  } });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(fs.readdirSync(inheritedData), []);
+});
 
 async function waitFor(predicate, { timeoutMs = 5000, intervalMs = 50 } = {}) {
   const start = Date.now();

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -71,6 +71,35 @@ function resolveStateDirWithPluginData(repo, pluginDataDir) {
   }
 }
 
+function seedTrackedThread(repo, pluginDataDir, threadId, sessionId = "sess-other") {
+  const stateDir = resolveStateDirWithPluginData(repo, pluginDataDir);
+  fs.mkdirSync(path.join(stateDir, "jobs"), { recursive: true });
+  fs.writeFileSync(
+    path.join(stateDir, "state.json"),
+    `${JSON.stringify(
+      {
+        version: 1,
+        config: { stopReviewGate: false },
+        jobs: [
+          {
+            id: "task-tracked",
+            status: "completed",
+            title: "Codex Task",
+            jobClass: "task",
+            sessionId,
+            threadId,
+            summary: "Tracked task",
+            updatedAt: "2026-09-03T00:00:00.000Z"
+          }
+        ]
+      },
+      null,
+      2
+    )}\n`,
+    "utf8"
+  );
+}
+
 test("setup reports ready when fake codex is installed and authenticated", () => {
   const binDir = makeTempDir();
   installFakeCodex(binDir);
@@ -546,7 +575,7 @@ test("task --resume-last resumes the latest persisted task thread", () => {
   assert.equal(result.stdout, "Resumed the prior run.\nFollow-up prompt accepted.\n");
 });
 
-test("task --thread resumes the requested thread without leaking the flag into the prompt", () => {
+test("task --thread resumes a thread tracked in the current workspace across Claude sessions", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
   const threadId = "thr_specific";
@@ -554,16 +583,16 @@ test("task --thread resumes the requested thread without leaking the flag into t
   const pluginDataDir = makeTempDir();
   const env = {
     ...buildEnv(binDir),
-    CLAUDE_PLUGIN_DATA: pluginDataDir
+    CLAUDE_PLUGIN_DATA: pluginDataDir,
+    CODEX_COMPANION_SESSION_ID: "sess-current"
   };
   installFakeCodex(binDir);
   seedFakeCodexThread(binDir, repo, threadId);
+  seedTrackedThread(repo, pluginDataDir, threadId);
   initGitRepo(repo);
   fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
   run("git", ["add", "README.md"], { cwd: repo });
   run("git", ["commit", "-m", "init"], { cwd: repo });
-
-  assert.equal(fs.existsSync(path.join(resolveStateDirWithPluginData(repo, pluginDataDir), "state.json")), false);
 
   const result = run("node", [SCRIPT, "task", "--thread", threadId, "follow up by id"], {
     cwd: repo,
@@ -588,6 +617,7 @@ test("task --thread works in background mode", async () => {
   };
   installFakeCodex(binDir, "slow-task");
   seedFakeCodexThread(binDir, repo, threadId);
+  seedTrackedThread(repo, pluginDataDir, threadId);
   initGitRepo(repo);
   fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
   run("git", ["add", "README.md"], { cwd: repo });
@@ -641,7 +671,7 @@ test("task --thread rejects conflicting and invalid routing values", () => {
   }
 });
 
-test("a failed task --thread does not pre-write the requested thread id into the job", () => {
+test("task --thread --allow-other-repo with an unknown id fails at codex and does not pre-write the thread id", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
   const pluginDataDir = makeTempDir();
@@ -652,7 +682,7 @@ test("a failed task --thread does not pre-write the requested thread id into the
   installFakeCodex(binDir);
   initGitRepo(repo);
 
-  const result = run("node", [SCRIPT, "task", "--thread", "thr_missing", "follow up"], {
+  const result = run("node", [SCRIPT, "task", "--thread", "thr_missing", "--allow-other-repo", "follow up"], {
     cwd: repo,
     env
   });
@@ -665,6 +695,112 @@ test("a failed task --thread does not pre-write the requested thread id into the
   assert.equal(state.jobs.length, 1);
   assert.equal(state.jobs[0].status, "failed");
   assert.equal("threadId" in state.jobs[0], false);
+});
+
+test("a failed task --thread does not pre-write the requested thread id into the job", () => {
+  const repo = makeTempDir();
+  const otherRepo = makeTempDir();
+  const binDir = makeTempDir();
+  const threadId = "thr_other_repo";
+  const pluginDataDir = makeTempDir();
+  const env = {
+    ...buildEnv(binDir),
+    CLAUDE_PLUGIN_DATA: pluginDataDir
+  };
+  installFakeCodex(binDir);
+  seedFakeCodexThread(binDir, otherRepo, threadId);
+  initGitRepo(repo);
+
+  const result = run("node", [SCRIPT, "task", "--thread", threadId, "follow up"], {
+    cwd: repo,
+    env
+  });
+
+  assert.equal(result.status > 0, true);
+  assert.match(result.stderr, /not tracked for this repository/);
+  assert.match(result.stderr, /--allow-other-repo/);
+  assert.match(result.stderr, /created outside this plugin/);
+  const fakeState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  assert.equal("lastTurnStart" in fakeState, false);
+  const state = JSON.parse(
+    fs.readFileSync(path.join(resolveStateDirWithPluginData(repo, pluginDataDir), "state.json"), "utf8")
+  );
+  assert.equal(state.jobs.length, 1);
+  assert.equal(state.jobs[0].status, "failed");
+  assert.equal("threadId" in state.jobs[0], false);
+});
+
+test("task --thread --allow-other-repo resumes an untracked thread", () => {
+  const repo = makeTempDir();
+  const otherRepo = makeTempDir();
+  const binDir = makeTempDir();
+  const threadId = "thr_other_repo";
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  const pluginDataDir = makeTempDir();
+  const env = {
+    ...buildEnv(binDir),
+    CLAUDE_PLUGIN_DATA: pluginDataDir
+  };
+  installFakeCodex(binDir);
+  seedFakeCodexThread(binDir, otherRepo, threadId);
+  initGitRepo(repo);
+
+  const result = run(
+    "node",
+    [SCRIPT, "task", "--thread", threadId, "--allow-other-repo", "cross-repo follow up"],
+    {
+      cwd: repo,
+      env
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.threadId, threadId);
+  assert.equal(fakeState.lastTurnStart.prompt, "cross-repo follow up");
+});
+
+test("task --thread rejects an untracked thread in background mode", () => {
+  const repo = makeTempDir();
+  const otherRepo = makeTempDir();
+  const binDir = makeTempDir();
+  const threadId = "thr_background_other_repo";
+  const pluginDataDir = makeTempDir();
+  const env = {
+    ...buildEnv(binDir),
+    CLAUDE_PLUGIN_DATA: pluginDataDir
+  };
+  installFakeCodex(binDir);
+  seedFakeCodexThread(binDir, otherRepo, threadId);
+  initGitRepo(repo);
+
+  const launched = run(
+    "node",
+    [SCRIPT, "task", "--background", "--json", "--thread", threadId, "background follow up"],
+    {
+      cwd: repo,
+      env
+    }
+  );
+
+  assert.equal(launched.status, 0, launched.stderr);
+  const launchPayload = JSON.parse(launched.stdout);
+  const waitedStatus = run(
+    "node",
+    [SCRIPT, "status", launchPayload.jobId, "--wait", "--timeout-ms", "15000", "--json"],
+    {
+      cwd: repo,
+      env
+    }
+  );
+
+  assert.equal(waitedStatus.status, 0, waitedStatus.stderr);
+  const job = JSON.parse(waitedStatus.stdout).job;
+  assert.equal(job.status, "failed");
+  assert.match(job.errorMessage, /--allow-other-repo/);
+  assert.equal("threadId" in job, false);
+  const fakeState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  assert.equal("lastTurnStart" in fakeState, false);
 });
 
 test("task-resume-candidate returns the latest rescue thread from the current session", () => {

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -1,13 +1,78 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { beforeEach } from "node:test";
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 
-import { makeTempDir } from "./helpers.mjs";
-import { resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState } from "../plugins/codex/scripts/lib/state.mjs";
+import { isolateTestEnvironment, makeTempDir, run } from "./helpers.mjs";
+import { loadState, resolveJobFile, resolveJobLogFile, resolveStateDir, resolveStateFile, saveState, upsertJob } from "../plugins/codex/scripts/lib/state.mjs";
+
+beforeEach(isolateTestEnvironment);
+
+test("concurrent job writers preserve both indices and artifacts", { timeout: 60000 }, async (t) => {
+  const workspace = makeTempDir();
+  const gate = path.join(workspace, "start");
+  const source = `
+    import fs from "node:fs";
+    import { updateState, writeJobFile, resolveJobLogFile } from ${JSON.stringify(new URL("../plugins/codex/scripts/lib/state.mjs", import.meta.url).href)};
+    const [workspace, id, gate] = process.argv.slice(1);
+    const wait = new Int32Array(new SharedArrayBuffer(4));
+    const logFile = resolveJobLogFile(workspace, id);
+    writeJobFile(workspace, id, { id });
+    fs.writeFileSync(logFile, id);
+    fs.writeFileSync(gate + id, "ready");
+    while (!fs.existsSync(gate)) Atomics.wait(wait, 0, 0, 10);
+    for (let iteration = 0; iteration < 6; iteration += 1) {
+      updateState(workspace, (state) => {
+        Atomics.wait(wait, 0, 0, iteration === 0 ? 100 : 10);
+        const job = { id, iteration, logFile };
+        const index = state.jobs.findIndex((item) => item.id === id);
+        if (index < 0) state.jobs.push(job);
+        else state.jobs[index] = job;
+      });
+    }
+  `;
+  const workers = ["task-one", "task-two"].map((id) => {
+    const child = spawn(process.execPath, ["--input-type=module", "-e", source, workspace, id, gate], { env: process.env });
+    let stderr = "";
+    child.stderr.on("data", (data) => { stderr += data; });
+    const done = new Promise((resolve, reject) => {
+      child.on("error", reject);
+      child.on("exit", (code) => code === 0 ? resolve() : reject(new Error(stderr || `Worker exited ${code}`)));
+    });
+    t.after(() => { if (child.exitCode === null) child.kill(); });
+    return { id, done };
+  });
+  while (!workers.every(({ id }) => fs.existsSync(gate + id))) {
+    t.signal.throwIfAborted();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  fs.writeFileSync(gate, "start");
+  await Promise.all(workers.map(({ done }) => done));
+  assert.deepEqual(loadState(workspace).jobs.map(({ id, iteration }) => ({ id, iteration })).sort((a, b) => a.id.localeCompare(b.id)),
+    workers.map(({ id }) => ({ id, iteration: 5 })));
+  for (const { id } of workers) {
+    assert.equal(JSON.parse(fs.readFileSync(resolveJobFile(workspace, id), "utf8")).id, id);
+    assert.equal(fs.readFileSync(resolveJobLogFile(workspace, id), "utf8"), id);
+  }
+  assert.equal(fs.existsSync(path.join(resolveStateDir(workspace), "state.lock")), false);
+});
+
+test("state writes recover the lock of an exited writer", () => {
+  const workspace = makeTempDir();
+  const exited = run(process.execPath, ["-e", "process.stdout.write(String(process.pid))"]);
+  assert.equal(exited.status, 0, exited.stderr);
+  const stateDir = resolveStateDir(workspace);
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(path.join(stateDir, "state.lock"), exited.stdout);
+  upsertJob(workspace, { id: "recovered", status: "running" });
+  assert.equal(loadState(workspace).jobs[0].id, "recovered");
+  assert.equal(fs.existsSync(path.join(stateDir, "state.lock")), false);
+});
 
 test("resolveStateDir uses a temp-backed per-workspace directory", () => {
+  delete process.env.CLAUDE_PLUGIN_DATA;
   const workspace = makeTempDir();
   const stateDir = resolveStateDir(workspace);
 

--- a/tsconfig.app-server.json
+++ b/tsconfig.app-server.json
@@ -17,6 +17,8 @@
     "plugins/codex/scripts/lib/codex.mjs",
     "plugins/codex/scripts/lib/fs.mjs",
     "plugins/codex/scripts/lib/process.mjs",
+    "plugins/codex/scripts/lib/live-turn-control.mjs",
+    "plugins/codex/scripts/lib/live-commands.mjs",
     "plugins/codex/scripts/lib/app-server-protocol.d.ts",
     "plugins/codex/.generated/app-server-types/**/*.ts"
   ]


### PR DESCRIPTION
## Summary

`task --resume-last` can only continue the newest finished task thread of the current Claude session in the repo. When a caller drives several Codex threads in one session (for example one thread per problem, or a review that ran as a task in between), the older threads become unreachable even though the app-server can resume them by id.

This adds `task --thread <id>` to resume a specific thread through the same path `--resume-last` uses.

## Changes

- `plugins/codex/scripts/codex-companion.mjs`: parse `--thread`, validate it (non-empty, not flag-like, mutually exclusive with `--resume`/`--resume-last`/`--fresh`), pass `resumeThreadId` through `buildTaskRequest`/`executeTaskRun` in both foreground and `--background` modes. The thread id is not pre-written into the job record; it is stored by the existing `Thread ready` progress handling after a successful resume, so a failed resume of an unknown id does not pollute the next `--resume-last`.
- `tests/runtime.test.mjs`: resume by id (foreground and background), flag not leaked into the prompt, conflicting and invalid values rejected, failed resume does not pre-write the id.
- `tests/commands.test.mjs`, `README.md`, `plugins/codex/commands/rescue.md`, `plugins/codex/agents/codex-rescue.md`, `plugins/codex/skills/codex-cli-runtime/SKILL.md`: document the flag and its routing.

No changes under `lib/`; `--resume-last`, `--resume`, and `--fresh` behave as before. Version not bumped.

## Verification

- `npm test`: the new tests pass; no new failures relative to the clean tree on the same machine (the remaining failures there are environment-related `setup`/`status`/`result`/`resolveStateDir` cases that fail identically without this change).
- Manual: with a shared app-server running and a newer thread being the `task-resume-candidate`, `task --thread <older-id> "..."` resumed the older thread (`Thread ready (<older-id>)`) and Codex answered from that thread's context.

## Notes

`--thread` intentionally bypasses the current-session filter used by `--resume-last`. It does not check repository ownership of the thread; the resume request carries the current `cwd`.