### PR TITLE
docs: drop the /reload-plugins step from install

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,6 @@ Install the plugin:
 /plugin install codex@openai-codex
 ```
 
-Reload plugins:
-
-```bash
-/reload-plugins
-```
-
 Then run:
 
 ```bash


### PR DESCRIPTION
`/plugin install` activates the plugin right away now — claude code prints `✓ Installed codex. Plugin is now active.` the moment it lands, so the `/reload-plugins` step in the readme is dead weight.

what i saw locally:

```
› /plugin marketplace add openai/codex-plugin-cc
  └ Successfully added marketplace: openai-codex

› /plugin install codex@openai-codex
  └ ✓ Installed codex. Plugin is now active.
```

slash commands and the `codex:codex-rescue` subagent were both there immediately, no reload needed. dropping the step so nobody burns a turn on a command they don't need.

readme-only change, no code touched — would appreciate a merge whenever you get a sec 🙏