### PR TITLE
docs(rescue): document writable sandbox scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Ask Codex to redesign the database connection to be more resilient.
 - if you do not pass `--model` or `--effort`, Codex chooses its own defaults.
 - if you say `spark`, the plugin maps that to `gpt-5.3-codex-spark`
 - follow-up rescue requests can continue the latest Codex task in the repo
+- write-capable rescue runs can write only inside the current repository and temporary directories. For destinations such as `~/.local/bin` or `~/.config`, have Codex create the artifact in the repository, then install or copy it separately.
 
 ### `/codex:transfer`
 

--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -32,6 +32,7 @@ Forwarding rules:
 - If the user asks for a concrete model name such as `gpt-5.4-mini`, pass it through with `--model`.
 - Treat `--effort <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
 - Default to a write-capable Codex run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
+- `--write` allows changes only inside the current repository and temporary directories; it does not make home-directory, configuration, or system paths writable.
 - Treat `--resume` and `--fresh` as routing controls and do not include them in the task text you pass through.
 - `--resume` means add `--resume-last`.
 - `--fresh` means do not add `--resume-last`.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -37,6 +37,7 @@ Command selection:
 
 Safety rules:
 - Default to write-capable Codex work in `codex:codex-rescue` unless the user explicitly asks for read-only behavior.
+- `--write` allows changes only inside the current repository and temporary directories. If an artifact ultimately belongs elsewhere, have Codex create it in the repository so the caller can install or copy it afterward.
 - Preserve the user's task text as-is apart from stripping routing flags.
 - Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
 - Return the stdout of the `task` command exactly as-is.


### PR DESCRIPTION
## Summary

- document that write-capable rescue runs are limited to the current repository and temporary directories
- recommend staging artifacts in the repository when their final destination is a home, configuration, or system path
- keep the user-facing README, rescue agent, and runtime guidance aligned

## Testing

- `npm test` (91 tests passed)
- `npm run build`
- `npm run check-version`
- `git diff --check`

Fixes #673