### PR TITLE
feat: enforce scoped Codex task reads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Codex plugins to use in Claude Code for delegation and code review.",
-    "version": "1.0.6"
+    "version": "1.0.7"
   },
   "plugins": [
     {
       "name": "codex",
       "description": "Use Codex from Claude Code to review code or delegate tasks.",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "author": {
         "name": "OpenAI"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Codex plugins to use in Claude Code for delegation and code review.",
-    "version": "1.0.8"
+    "version": "1.0.9"
   },
   "plugins": [
     {
       "name": "codex",
       "description": "Use Codex from Claude Code to review code or delegate tasks.",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "author": {
         "name": "OpenAI"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Codex plugins to use in Claude Code for delegation and code review.",
-    "version": "1.0.7"
+    "version": "1.0.8"
   },
   "plugins": [
     {
       "name": "codex",
       "description": "Use Codex from Claude Code to review code or delegate tasks.",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "author": {
         "name": "OpenAI"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Codex plugins to use in Claude Code for delegation and code review.",
-    "version": "1.0.9"
+    "version": "1.0.10"
   },
   "plugins": [
     {
       "name": "codex",
       "description": "Use Codex from Claude Code to review code or delegate tasks.",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "author": {
         "name": "OpenAI"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
   },
   "metadata": {
     "description": "Codex plugins to use in Claude Code for delegation and code review.",
-    "version": "1.0.10"
+    "version": "1.0.11"
   },
   "plugins": [
     {
       "name": "codex",
       "description": "Use Codex from Claude Code to review code or delegate tasks.",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "author": {
         "name": "OpenAI"
       },

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Ask Codex to redesign the database connection to be more resilient.
 - if you do not pass `--model` or `--effort`, Codex chooses its own defaults.
 - if you say `spark`, the plugin maps that to `gpt-5.3-codex-spark`
 - follow-up rescue requests can continue the latest Codex task in the repo
-- each `--read-root <path>` opts into an OS-enforced permission profile that denies local command reads outside the listed paths and Codex's minimal runtime paths
+- each `--read-root <directory>` must name an existing directory and opts into an OS-enforced permission profile that denies local command reads outside the listed directories and Codex's minimal runtime paths
 - scoped reads require Codex 0.138.0 or later and fail closed when the runtime cannot enforce permission profiles
 - filesystem profiles apply to local sandboxed commands, not web search, MCP servers, connectors, browser tools, or computer use
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Ask Codex to redesign the database connection to be more resilient.
 - if you say `spark`, the plugin maps that to `gpt-5.3-codex-spark`
 - follow-up rescue requests can continue the latest Codex task in the repo
 - each `--read-root <directory>` must name an existing directory and opts into an OS-enforced permission profile that denies local command reads outside the listed directories and Codex's minimal runtime paths
-- scoped `--write` requires the approved read roots to cover the workspace directory and retains Codex's built-in `:workspace` safeguards for protected repository metadata
+- scoped `--write` requires the approved read roots to cover the workspace directory and uses Codex's built-in `:workspace` write policy
 - scoped reads require Codex 0.138.0 or later and fail closed when the runtime cannot enforce permission profiles
 - filesystem profiles apply to local sandboxed commands, not web search, MCP servers, connectors, browser tools, or computer use
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Ask Codex to redesign the database connection to be more resilient.
 - if you say `spark`, the plugin maps that to `gpt-5.3-codex-spark`
 - follow-up rescue requests can continue the latest Codex task in the repo
 - each `--read-root <directory>` must name an existing directory and opts into an OS-enforced permission profile that denies local command reads outside the listed directories and Codex's minimal runtime paths
+- scoped `--write` requires the approved read roots to cover the workspace directory and retains Codex's built-in `:workspace` safeguards for protected repository metadata
 - scoped reads require Codex 0.138.0 or later and fail closed when the runtime cannot enforce permission profiles
 - filesystem profiles apply to local sandboxed commands, not web search, MCP servers, connectors, browser tools, or computer use
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Examples:
 /codex:rescue --model gpt-5.4-mini --effort medium investigate the flaky integration test
 /codex:rescue --model spark fix the issue quickly
 /codex:rescue --background investigate the regression
+/codex:rescue --read-root ./src --read-root ./tests inspect only the approved paths
 ```
 
 You can also just ask for a task to be delegated to Codex:
@@ -161,6 +162,9 @@ Ask Codex to redesign the database connection to be more resilient.
 - if you do not pass `--model` or `--effort`, Codex chooses its own defaults.
 - if you say `spark`, the plugin maps that to `gpt-5.3-codex-spark`
 - follow-up rescue requests can continue the latest Codex task in the repo
+- each `--read-root <path>` opts into an OS-enforced permission profile that denies local command reads outside the listed paths and Codex's minimal runtime paths
+- scoped reads require Codex 0.138.0 or later and fail closed when the runtime cannot enforce permission profiles
+- filesystem profiles apply to local sandboxed commands, not web search, MCP servers, connectors, browser tools, or computer use
 
 ### `/codex:transfer`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openai/codex-plugin-cc",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openai/codex-plugin-cc",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openai/codex-plugin-cc",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openai/codex-plugin-cc",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@openai/codex-plugin-cc",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "type": "module",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "type": "module",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "type": "module",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "type": "module",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex-plugin-cc",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "type": "module",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",

--- a/plugins/codex/.claude-plugin/plugin.json
+++ b/plugins/codex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "OpenAI"

--- a/plugins/codex/.claude-plugin/plugin.json
+++ b/plugins/codex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "OpenAI"

--- a/plugins/codex/.claude-plugin/plugin.json
+++ b/plugins/codex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "OpenAI"

--- a/plugins/codex/.claude-plugin/plugin.json
+++ b/plugins/codex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "OpenAI"

--- a/plugins/codex/.claude-plugin/plugin.json
+++ b/plugins/codex/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "codex",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Use Codex from Claude Code to review code or delegate tasks.",
   "author": {
     "name": "OpenAI"

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+## 1.0.11
+
+- Reject empty `--read-root` values instead of resolving them to the current workspace.
+
 ## 1.0.10
 
 - Deny inherited system temp roots in scoped profiles so only approved directories and minimal runtime paths remain readable.
 
 ## 1.0.9
 
-- Preserve the built-in `:workspace` safeguards for scoped write tasks and require the approved read roots to cover the workspace.
+- Use the built-in `:workspace` profile for scoped write tasks and require the approved read roots to cover the workspace.
 
 ## 1.0.8
 

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.7
+
+- Add opt-in `--read-root` enforcement for Codex rescue tasks using request-scoped permission profiles.
+- Preserve scoped roots across foreground, background, and resumed tasks, with fail-closed runtime compatibility errors.
+
 ## 1.0.0
 
 - Initial version of the Codex plugin for Claude Code

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.10
+
+- Deny inherited system temp roots in scoped profiles so only approved directories and minimal runtime paths remain readable.
+
 ## 1.0.9
 
 - Preserve the built-in `:workspace` safeguards for scoped write tasks and require the approved read roots to cover the workspace.

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.9
+
+- Preserve the built-in `:workspace` safeguards for scoped write tasks and require the approved read roots to cover the workspace.
+
 ## 1.0.8
 
 - Require every `--read-root` to be an existing directory so scoped tasks do not claim unsupported file-level isolation on macOS.

--- a/plugins/codex/CHANGELOG.md
+++ b/plugins/codex/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.8
+
+- Require every `--read-root` to be an existing directory so scoped tasks do not claim unsupported file-level isolation on macOS.
+
 ## 1.0.7
 
 - Add opt-in `--read-root` enforcement for Codex rescue tasks using request-scoped permission profiles.

--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -31,7 +31,7 @@ Forwarding rules:
 - If the user asks for `spark`, map that to `--model gpt-5.3-codex-spark`.
 - If the user asks for a concrete model name such as `gpt-5.4-mini`, pass it through with `--model`.
 - Treat `--effort <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
-- Preserve every `--read-root <path>` pair as a runtime control and do not include either token in the task text you pass through.
+- Preserve every `--read-root <directory>` pair as a runtime control and do not include either token in the task text you pass through.
 - Default to a write-capable Codex run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
 - Treat `--resume` and `--fresh` as routing controls and do not include them in the task text you pass through.
 - `--resume` means add `--resume-last`.

--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -32,6 +32,7 @@ Forwarding rules:
 - If the user asks for a concrete model name such as `gpt-5.4-mini`, pass it through with `--model`.
 - Treat `--effort <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
 - Preserve every `--read-root <directory>` pair as a runtime control and do not include either token in the task text you pass through.
+- When forwarding both scoped roots and `--write`, include an approved read root that covers the workspace directory.
 - Default to a write-capable Codex run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
 - Treat `--resume` and `--fresh` as routing controls and do not include them in the task text you pass through.
 - `--resume` means add `--resume-last`.

--- a/plugins/codex/agents/codex-rescue.md
+++ b/plugins/codex/agents/codex-rescue.md
@@ -31,6 +31,7 @@ Forwarding rules:
 - If the user asks for `spark`, map that to `--model gpt-5.3-codex-spark`.
 - If the user asks for a concrete model name such as `gpt-5.4-mini`, pass it through with `--model`.
 - Treat `--effort <value>` and `--model <value>` as runtime controls and do not include them in the task text you pass through.
+- Preserve every `--read-root <path>` pair as a runtime control and do not include either token in the task text you pass through.
 - Default to a write-capable Codex run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
 - Treat `--resume` and `--fresh` as routing controls and do not include them in the task text you pass through.
 - `--resume` means add `--resume-last`.

--- a/plugins/codex/commands/rescue.md
+++ b/plugins/codex/commands/rescue.md
@@ -1,6 +1,6 @@
 ---
 description: Delegate investigation, an explicit fix request, or follow-up rescue work to the Codex rescue subagent
-argument-hint: "[--background|--wait] [--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [what Codex should investigate, solve, or continue]"
+argument-hint: "[--background|--wait] [--resume|--fresh] [--read-root <path> ...] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [what Codex should investigate, solve, or continue]"
 allowed-tools: Bash(node:*), AskUserQuestion, Agent
 ---
 
@@ -18,6 +18,7 @@ Execution mode:
 - If neither flag is present, default to foreground.
 - `--background` and `--wait` are execution flags for Claude Code. Do not forward them to `task`, and do not treat them as part of the natural-language task text.
 - `--model` and `--effort` are runtime-selection flags. Preserve them for the forwarded `task` call, but do not treat them as part of the natural-language task text.
+- Preserve every `--read-root <path>` pair for the forwarded `task` call and remove both tokens from the natural-language task text.
 - If the request includes `--resume`, do not ask whether to continue. The user already chose.
 - If the request includes `--fresh`, do not ask whether to continue. The user already chose.
 - Otherwise, before starting Codex, check for a resumable rescue thread from this Claude session by running:

--- a/plugins/codex/commands/rescue.md
+++ b/plugins/codex/commands/rescue.md
@@ -19,6 +19,7 @@ Execution mode:
 - `--background` and `--wait` are execution flags for Claude Code. Do not forward them to `task`, and do not treat them as part of the natural-language task text.
 - `--model` and `--effort` are runtime-selection flags. Preserve them for the forwarded `task` call, but do not treat them as part of the natural-language task text.
 - Preserve every `--read-root <directory>` pair for the forwarded `task` call and remove both tokens from the natural-language task text.
+- When scoped `--write` is requested, the approved read roots must cover the workspace directory.
 - If the request includes `--resume`, do not ask whether to continue. The user already chose.
 - If the request includes `--fresh`, do not ask whether to continue. The user already chose.
 - Otherwise, before starting Codex, check for a resumable rescue thread from this Claude session by running:

--- a/plugins/codex/commands/rescue.md
+++ b/plugins/codex/commands/rescue.md
@@ -1,6 +1,6 @@
 ---
 description: Delegate investigation, an explicit fix request, or follow-up rescue work to the Codex rescue subagent
-argument-hint: "[--background|--wait] [--resume|--fresh] [--read-root <path> ...] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [what Codex should investigate, solve, or continue]"
+argument-hint: "[--background|--wait] [--resume|--fresh] [--read-root <directory> ...] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [what Codex should investigate, solve, or continue]"
 allowed-tools: Bash(node:*), AskUserQuestion, Agent
 ---
 
@@ -18,7 +18,7 @@ Execution mode:
 - If neither flag is present, default to foreground.
 - `--background` and `--wait` are execution flags for Claude Code. Do not forward them to `task`, and do not treat them as part of the natural-language task text.
 - `--model` and `--effort` are runtime-selection flags. Preserve them for the forwarded `task` call, but do not treat them as part of the natural-language task text.
-- Preserve every `--read-root <path>` pair for the forwarded `task` call and remove both tokens from the natural-language task text.
+- Preserve every `--read-root <directory>` pair for the forwarded `task` call and remove both tokens from the natural-language task text.
 - If the request includes `--resume`, do not ask whether to continue. The user already chose.
 - If the request includes `--fresh`, do not ask whether to continue. The user already chose.
 - Otherwise, before starting Codex, check for a resumable rescue thread from this Claude session by running:

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -79,7 +79,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--read-root <path> ...] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--read-root <directory> ...] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
@@ -158,7 +158,10 @@ function resolveCommandWorkspace(options = {}) {
 
 function resolveReadRoot(cwd, readRoot) {
   const resolved = path.resolve(cwd, readRoot);
-  return fs.existsSync(resolved) ? fs.realpathSync(resolved) : resolved;
+  if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) {
+    throw new Error(`--read-root must name an existing directory: ${readRoot}`);
+  }
+  return fs.realpathSync(resolved);
 }
 
 function sleep(ms) {

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -157,6 +157,9 @@ function resolveCommandWorkspace(options = {}) {
 }
 
 function resolveReadRoot(cwd, readRoot) {
+  if (typeof readRoot !== "string" || !readRoot.trim()) {
+    throw new Error("--read-root must name an existing directory: value is empty");
+  }
   const resolved = path.resolve(cwd, readRoot);
   if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) {
     throw new Error(`--read-root must name an existing directory: ${readRoot}`);

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -164,6 +164,11 @@ function resolveReadRoot(cwd, readRoot) {
   return fs.realpathSync(resolved);
 }
 
+function pathCovers(parent, child) {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== "..");
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -793,6 +798,9 @@ async function handleTask(argv) {
   }
   const write = Boolean(options.write);
   const readRoots = (options["read-root"] ?? []).map((readRoot) => resolveReadRoot(cwd, readRoot));
+  if (write && readRoots.length > 0 && !readRoots.some((readRoot) => pathCovers(readRoot, workspaceRoot))) {
+    throw new Error("--write requires an approved --read-root that covers the workspace directory.");
+  }
   const taskMetadata = buildTaskRunMetadata({
     prompt,
     resumeLast

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -79,7 +79,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--read-root <path> ...] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
@@ -154,6 +154,11 @@ function resolveCommandCwd(options = {}) {
 
 function resolveCommandWorkspace(options = {}) {
   return resolveWorkspaceRoot(resolveCommandCwd(options));
+}
+
+function resolveReadRoot(cwd, readRoot) {
+  const resolved = path.resolve(cwd, readRoot);
+  return fs.existsSync(resolved) ? fs.realpathSync(resolved) : resolved;
 }
 
 function sleep(ms) {
@@ -489,6 +494,8 @@ async function executeTaskRun(request) {
     model: request.model,
     effort: request.effort,
     sandbox: request.write ? "workspace-write" : "read-only",
+    readRoots: request.readRoots,
+    write: request.write,
     onProgress: request.onProgress,
     persistThread: true,
     threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
@@ -601,13 +608,14 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, readRoots, resumeLast, jobId }) {
   return {
     cwd,
     model,
     effort,
     prompt,
     write,
+    readRoots,
     resumeLast,
     jobId
   };
@@ -762,6 +770,7 @@ async function handleReview(argv) {
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["model", "effort", "cwd", "prompt-file"],
+    multiValueOptions: ["read-root"],
     booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
     aliasMap: {
       m: "model"
@@ -780,6 +789,7 @@ async function handleTask(argv) {
     throw new Error("Choose either --resume/--resume-last or --fresh.");
   }
   const write = Boolean(options.write);
+  const readRoots = (options["read-root"] ?? []).map((readRoot) => resolveReadRoot(cwd, readRoot));
   const taskMetadata = buildTaskRunMetadata({
     prompt,
     resumeLast
@@ -796,6 +806,7 @@ async function handleTask(argv) {
       effort,
       prompt,
       write,
+      readRoots,
       resumeLast,
       jobId: job.id
     });
@@ -814,6 +825,7 @@ async function handleTask(argv) {
         effort,
         prompt,
         write,
+        readRoots,
         resumeLast,
         jobId: job.id,
         onProgress: progress

--- a/plugins/codex/scripts/lib/args.mjs
+++ b/plugins/codex/scripts/lib/args.mjs
@@ -1,5 +1,6 @@
 export function parseArgs(argv, config = {}) {
   const valueOptions = new Set(config.valueOptions ?? []);
+  const multiValueOptions = new Set(config.multiValueOptions ?? []);
   const booleanOptions = new Set(config.booleanOptions ?? []);
   const aliasMap = config.aliasMap ?? {};
   const options = {};
@@ -33,12 +34,16 @@ export function parseArgs(argv, config = {}) {
         continue;
       }
 
-      if (valueOptions.has(key)) {
+      if (valueOptions.has(key) || multiValueOptions.has(key)) {
         const nextValue = inlineValue ?? argv[index + 1];
         if (nextValue === undefined) {
           throw new Error(`Missing value for --${rawKey}`);
         }
-        options[key] = nextValue;
+        if (multiValueOptions.has(key)) {
+          options[key] = [...(options[key] ?? []), nextValue];
+        } else {
+          options[key] = nextValue;
+        }
         if (inlineValue === undefined) {
           index += 1;
         }
@@ -57,12 +62,16 @@ export function parseArgs(argv, config = {}) {
       continue;
     }
 
-    if (valueOptions.has(key)) {
+    if (valueOptions.has(key) || multiValueOptions.has(key)) {
       const nextValue = argv[index + 1];
       if (nextValue === undefined) {
         throw new Error(`Missing value for -${shortKey}`);
       }
-      options[key] = nextValue;
+      if (multiValueOptions.has(key)) {
+        options[key] = [...(options[key] ?? []), nextValue];
+      } else {
+        options[key] = nextValue;
+      }
       index += 1;
       continue;
     }

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -65,9 +65,6 @@ function buildThreadAccessParams(cwd, options = {}) {
   for (const readRoot of readRoots) {
     filesystem[path.resolve(cwd, readRoot)] = "read";
   }
-  if (options.write) {
-    filesystem[path.resolve(cwd)] = "write";
-  }
 
   return {
     config: {
@@ -75,6 +72,7 @@ function buildThreadAccessParams(cwd, options = {}) {
       permissions: {
         [SCOPED_PERMISSION_PROFILE]: {
           description: "Claude companion request-scoped filesystem access",
+          ...(options.write ? { extends: ":workspace" } : {}),
           filesystem
         }
       }

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -50,6 +50,51 @@ const DEFAULT_CONTINUE_PROMPT =
   "Continue from the current thread state. Pick the next highest-value step and follow through until the task is resolved.";
 const EXTERNAL_AGENT_IMPORT_COMPLETED = "externalAgentConfig/import/completed";
 const EXTERNAL_AGENT_IMPORT_TIMEOUT_MS = 2 * 60 * 1000;
+const SCOPED_PERMISSION_PROFILE = "claude_companion_scoped";
+
+function buildThreadAccessParams(cwd, options = {}) {
+  const readRoots = Array.isArray(options.readRoots) ? options.readRoots : [];
+  if (readRoots.length === 0) {
+    return { sandbox: options.sandbox ?? "read-only" };
+  }
+
+  const filesystem = {
+    ":root": "deny",
+    ":minimal": "read"
+  };
+  for (const readRoot of readRoots) {
+    filesystem[path.resolve(cwd, readRoot)] = "read";
+  }
+  if (options.write) {
+    filesystem[path.resolve(cwd)] = "write";
+  }
+
+  return {
+    config: {
+      default_permissions: SCOPED_PERMISSION_PROFILE,
+      permissions: {
+        [SCOPED_PERMISSION_PROFILE]: {
+          description: "Claude companion request-scoped filesystem access",
+          filesystem
+        }
+      }
+    }
+  };
+}
+
+function scopedAccessError(error, options = {}) {
+  const message = String(error?.message ?? error ?? "");
+  if (
+    (options.readRoots?.length ?? 0) > 0 &&
+    /default_permissions|permission profiles?|unknown field.*config|invalid.*permissions/i.test(message)
+  ) {
+    return new Error(
+      `Codex cannot enforce the requested read scope. Upgrade to a runtime with permission profiles (0.138.0 or later). Original error: ${message}`,
+      { cause: error }
+    );
+  }
+  return error;
+}
 
 function cleanCodexStderr(stderr) {
   return stderr
@@ -65,7 +110,7 @@ function buildThreadParams(cwd, options = {}) {
     cwd,
     model: options.model ?? null,
     approvalPolicy: options.approvalPolicy ?? "never",
-    sandbox: options.sandbox ?? "read-only",
+    ...buildThreadAccessParams(cwd, options),
     serviceName: SERVICE_NAME,
     ephemeral: options.ephemeral ?? true
   };
@@ -78,7 +123,7 @@ function buildResumeParams(threadId, cwd, options = {}) {
     cwd,
     model: options.model ?? null,
     approvalPolicy: options.approvalPolicy ?? "never",
-    sandbox: options.sandbox ?? "read-only"
+    ...buildThreadAccessParams(cwd, options)
   };
 }
 
@@ -1101,23 +1146,31 @@ export async function runAppServerTurn(cwd, options = {}) {
   return withAppServer(cwd, async (client) => {
     let threadId;
 
-    if (options.resumeThreadId) {
-      emitProgress(options.onProgress, `Resuming thread ${options.resumeThreadId}.`, "starting");
-      const response = await resumeThread(client, options.resumeThreadId, cwd, {
-        model: options.model,
-        sandbox: options.sandbox,
-        ephemeral: false
-      });
-      threadId = response.thread.id;
-    } else {
-      emitProgress(options.onProgress, "Starting Codex task thread.", "starting");
-      const response = await startThread(client, cwd, {
-        model: options.model,
-        sandbox: options.sandbox,
-        ephemeral: options.persistThread ? false : true,
-        threadName: options.persistThread ? options.threadName : options.threadName ?? null
-      });
-      threadId = response.thread.id;
+    try {
+      if (options.resumeThreadId) {
+        emitProgress(options.onProgress, `Resuming thread ${options.resumeThreadId}.`, "starting");
+        const response = await resumeThread(client, options.resumeThreadId, cwd, {
+          model: options.model,
+          sandbox: options.sandbox,
+          readRoots: options.readRoots,
+          write: options.write,
+          ephemeral: false
+        });
+        threadId = response.thread.id;
+      } else {
+        emitProgress(options.onProgress, "Starting Codex task thread.", "starting");
+        const response = await startThread(client, cwd, {
+          model: options.model,
+          sandbox: options.sandbox,
+          readRoots: options.readRoots,
+          write: options.write,
+          ephemeral: options.persistThread ? false : true,
+          threadName: options.persistThread ? options.threadName : options.threadName ?? null
+        });
+        threadId = response.thread.id;
+      }
+    } catch (error) {
+      throw scopedAccessError(error, options);
     }
 
     emitProgress(options.onProgress, `Thread ready (${threadId}).`, "starting", {

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -60,7 +60,9 @@ function buildThreadAccessParams(cwd, options = {}) {
 
   const filesystem = {
     ":root": "deny",
-    ":minimal": "read"
+    ":minimal": "read",
+    ":tmpdir": "deny",
+    ":slash_tmp": "deny"
   };
   for (const readRoot of readRoots) {
     filesystem[path.resolve(cwd, readRoot)] = "read";

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -28,6 +28,7 @@ Command selection:
 - If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only. Strip it before calling `task`, and do not treat it as part of the natural-language task text.
 - If the forwarded request includes `--model`, normalize `spark` to `gpt-5.3-codex-spark` and pass it through to `task`.
 - If the forwarded request includes `--effort`, pass it through to `task`.
+- Preserve every `--read-root <path>` pair, pass it through to `task`, and exclude both tokens from the natural-language task text.
 - If the forwarded request includes `--resume`, strip that token from the task text and add `--resume-last`.
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.
 - `--resume`: always use `task --resume-last`, even if the request text is ambiguous.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -28,7 +28,7 @@ Command selection:
 - If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only. Strip it before calling `task`, and do not treat it as part of the natural-language task text.
 - If the forwarded request includes `--model`, normalize `spark` to `gpt-5.3-codex-spark` and pass it through to `task`.
 - If the forwarded request includes `--effort`, pass it through to `task`.
-- Preserve every `--read-root <path>` pair, pass it through to `task`, and exclude both tokens from the natural-language task text.
+- Preserve every `--read-root <directory>` pair, pass it through to `task`, and exclude both tokens from the natural-language task text. Each value must name an existing directory; files and missing paths fail before Codex starts.
 - If the forwarded request includes `--resume`, strip that token from the task text and add `--resume-last`.
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.
 - `--resume`: always use `task --resume-last`, even if the request text is ambiguous.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -29,7 +29,7 @@ Command selection:
 - If the forwarded request includes `--model`, normalize `spark` to `gpt-5.3-codex-spark` and pass it through to `task`.
 - If the forwarded request includes `--effort`, pass it through to `task`.
 - Preserve every `--read-root <directory>` pair, pass it through to `task`, and exclude both tokens from the natural-language task text. Each value must name an existing directory; files and missing paths fail before Codex starts.
-- With scoped access, `--write` requires an approved read root to cover the workspace directory; the runtime keeps the built-in `:workspace` safeguards.
+- With scoped access, `--write` requires an approved read root to cover the workspace directory and uses Codex's built-in `:workspace` write policy.
 - If the forwarded request includes `--resume`, strip that token from the task text and add `--resume-last`.
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.
 - `--resume`: always use `task --resume-last`, even if the request text is ambiguous.

--- a/plugins/codex/skills/codex-cli-runtime/SKILL.md
+++ b/plugins/codex/skills/codex-cli-runtime/SKILL.md
@@ -29,6 +29,7 @@ Command selection:
 - If the forwarded request includes `--model`, normalize `spark` to `gpt-5.3-codex-spark` and pass it through to `task`.
 - If the forwarded request includes `--effort`, pass it through to `task`.
 - Preserve every `--read-root <directory>` pair, pass it through to `task`, and exclude both tokens from the natural-language task text. Each value must name an existing directory; files and missing paths fail before Codex starts.
+- With scoped access, `--write` requires an approved read root to cover the workspace directory; the runtime keeps the built-in `:workspace` safeguards.
 - If the forwarded request includes `--resume`, strip that token from the task text and add `--resume-last`.
 - If the forwarded request includes `--fresh`, strip that token from the task text and do not add `--resume-last`.
 - `--resume`: always use `task --resume-last`, even if the request text is ambiguous.

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -105,6 +105,8 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /--resume\|--fresh/);
   assert.match(rescue, /--model <model\|spark>/);
   assert.match(rescue, /--effort <none\|minimal\|low\|medium\|high\|xhigh>/);
+  assert.match(rescue, /--read-root <path>/);
+  assert.match(rescue, /Preserve every `--read-root <path>`/i);
   assert.match(rescue, /task-resume-candidate --json/);
   assert.match(rescue, /AskUserQuestion/);
   assert.match(rescue, /Continue current Codex thread/);
@@ -126,6 +128,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /Leave `--resume` and `--fresh` in the forwarded request/i);
   assert.match(agent, /--resume/);
   assert.match(agent, /--fresh/);
+  assert.match(agent, /Preserve every `--read-root <path>`/i);
   assert.match(agent, /thin forwarding wrapper/i);
   assert.match(agent, /prefer foreground for a small, clearly bounded rescue request/i);
   assert.match(agent, /If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution/i);
@@ -151,11 +154,13 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only/i);
   assert.match(runtimeSkill, /Strip it before calling `task`/i);
   assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`/i);
+  assert.match(runtimeSkill, /Preserve every `--read-root <path>`/i);
   assert.match(runtimeSkill, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
   assert.match(readme, /`codex:codex-rescue` subagent/i);
   assert.match(readme, /if you do not pass `--model` or `--effort`, Codex chooses its own defaults/i);
   assert.match(readme, /--model gpt-5\.4-mini --effort medium/i);
+  assert.match(readme, /--read-root/);
   assert.match(readme, /`spark`, the plugin maps that to `gpt-5\.3-codex-spark`/i);
   assert.match(readme, /continue a previous Codex task/i);
   assert.match(readme, /### `\/codex:setup`/);

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -156,12 +156,14 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`/i);
   assert.match(runtimeSkill, /Preserve every `--read-root <directory>`/i);
   assert.match(runtimeSkill, /existing directory/i);
+  assert.match(runtimeSkill, /`--write`.*cover the workspace directory/i);
   assert.match(runtimeSkill, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
   assert.match(readme, /`codex:codex-rescue` subagent/i);
   assert.match(readme, /if you do not pass `--model` or `--effort`, Codex chooses its own defaults/i);
   assert.match(readme, /--model gpt-5\.4-mini --effort medium/i);
   assert.match(readme, /--read-root/);
+  assert.match(readme, /`--write`.*cover the workspace directory/i);
   assert.match(readme, /`spark`, the plugin maps that to `gpt-5\.3-codex-spark`/i);
   assert.match(readme, /continue a previous Codex task/i);
   assert.match(readme, /### `\/codex:setup`/);

--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -105,8 +105,8 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /--resume\|--fresh/);
   assert.match(rescue, /--model <model\|spark>/);
   assert.match(rescue, /--effort <none\|minimal\|low\|medium\|high\|xhigh>/);
-  assert.match(rescue, /--read-root <path>/);
-  assert.match(rescue, /Preserve every `--read-root <path>`/i);
+  assert.match(rescue, /--read-root <directory>/);
+  assert.match(rescue, /Preserve every `--read-root <directory>`/i);
   assert.match(rescue, /task-resume-candidate --json/);
   assert.match(rescue, /AskUserQuestion/);
   assert.match(rescue, /Continue current Codex thread/);
@@ -128,7 +128,7 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(rescue, /Leave `--resume` and `--fresh` in the forwarded request/i);
   assert.match(agent, /--resume/);
   assert.match(agent, /--fresh/);
-  assert.match(agent, /Preserve every `--read-root <path>`/i);
+  assert.match(agent, /Preserve every `--read-root <directory>`/i);
   assert.match(agent, /thin forwarding wrapper/i);
   assert.match(agent, /prefer foreground for a small, clearly bounded rescue request/i);
   assert.match(agent, /If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Codex running for a long time, prefer background execution/i);
@@ -154,7 +154,8 @@ test("rescue command absorbs continue semantics", () => {
   assert.match(runtimeSkill, /If the forwarded request includes `--background` or `--wait`, treat that as Claude-side execution control only/i);
   assert.match(runtimeSkill, /Strip it before calling `task`/i);
   assert.match(runtimeSkill, /`--effort`: accepted values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`/i);
-  assert.match(runtimeSkill, /Preserve every `--read-root <path>`/i);
+  assert.match(runtimeSkill, /Preserve every `--read-root <directory>`/i);
+  assert.match(runtimeSkill, /existing directory/i);
   assert.match(runtimeSkill, /Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own/i);
   assert.match(runtimeSkill, /If the Bash call fails or Codex cannot be invoked, return nothing/i);
   assert.match(readme, /`codex:codex-rescue` subagent/i);

--- a/tests/fake-codex-fixture.mjs
+++ b/tests/fake-codex-fixture.mjs
@@ -309,9 +309,13 @@ rl.on("line", (line) => {
         if (BEHAVIOR === "auth-run-fails") {
           throw new Error("authentication expired; run codex login");
         }
+        if (BEHAVIOR === "permission-profiles-unsupported" && message.params.config) {
+          throw new Error("unknown field config.default_permissions");
+        }
         if (requiresExperimental("persistExtendedHistory", message, state) || requiresExperimental("persistFullHistory", message, state)) {
           throw new Error("thread/start.persistFullHistory requires experimentalApi capability");
         }
+        state.lastThreadStart = message.params;
         const thread = nextThread(state, message.params.cwd, message.params.ephemeral);
         send({ id: message.id, result: { thread: buildThread(thread), model: message.params.model || "gpt-5.4", modelProvider: "openai", serviceTier: null, cwd: thread.cwd, approvalPolicy: "never", sandbox: { type: "readOnly", access: { type: "fullAccess" }, networkAccess: false }, reasoningEffort: null } });
         send({ method: "thread/started", params: { thread: { id: thread.id } } });
@@ -341,9 +345,13 @@ rl.on("line", (line) => {
       }
 
       case "thread/resume": {
+        if (BEHAVIOR === "permission-profiles-unsupported" && message.params.config) {
+          throw new Error("unknown field config.default_permissions");
+        }
         if (requiresExperimental("persistExtendedHistory", message, state) || requiresExperimental("persistFullHistory", message, state)) {
           throw new Error("thread/resume.persistFullHistory requires experimentalApi capability");
         }
+        state.lastThreadResume = message.params;
         const thread = ensureThread(state, message.params.threadId);
         thread.updatedAt = now();
         saveState(state);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -785,6 +785,23 @@ test("task --read-root fails closed when permission profiles are unsupported", (
   assert.match(result.stderr, /0\.138\.0 or later/);
 });
 
+test("task --read-root rejects files and missing directories before starting Codex", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "allowed.txt"), "fixture\n");
+
+  for (const readRoot of ["allowed.txt", "missing-directory"]) {
+    const result = run("node", [SCRIPT, "task", "--read-root", readRoot, "inspect"], {
+      cwd: repo,
+      env: buildEnv(binDir)
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--read-root must name an existing directory/);
+  }
+});
+
 test("task --resume acts like --resume-last without leaking the flag into the prompt", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -738,6 +738,8 @@ test("task --read-root sends a scoped permission profile without legacy sandbox"
   assert.equal(params.config.default_permissions, "claude_companion_scoped");
   assert.equal(profile.filesystem[":root"], "deny");
   assert.equal(profile.filesystem[":minimal"], "read");
+  assert.equal(profile.filesystem[":tmpdir"], "deny");
+  assert.equal(profile.filesystem[":slash_tmp"], "deny");
   assert.equal(profile.filesystem[fs.realpathSync(repo)], "read");
   assert.equal(profile.filesystem[fs.realpathSync(extraReadRoot)], "read");
   assert.equal(profile.extends, ":workspace");

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -809,7 +809,7 @@ test("task --read-root rejects files and missing directories before starting Cod
   initGitRepo(repo);
   fs.writeFileSync(path.join(repo, "allowed.txt"), "fixture\n");
 
-  for (const readRoot of ["allowed.txt", "missing-directory"]) {
+  for (const readRoot of ["", "allowed.txt", "missing-directory"]) {
     const result = run("node", [SCRIPT, "task", "--read-root", readRoot, "inspect"], {
       cwd: repo,
       env: buildEnv(binDir)

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -716,6 +716,75 @@ test("write task output focuses on the Codex result without generic follow-up hi
   assert.equal(result.stdout, "Handled the requested task.\nTask prompt accepted.\n");
 });
 
+test("task --read-root sends a scoped permission profile without legacy sandbox", () => {
+  const repo = makeTempDir();
+  const extraReadRoot = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.mkdirSync(path.join(repo, "src"));
+
+  const result = run(
+    "node",
+    [SCRIPT, "task", "--write", "--read-root", "src", "--read-root", extraReadRoot, "fix the test"],
+    { cwd: repo, env: buildEnv(binDir) }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  const params = fakeState.lastThreadStart;
+  const profile = params.config.permissions.claude_companion_scoped;
+  assert.equal(params.sandbox, undefined);
+  assert.equal(params.config.default_permissions, "claude_companion_scoped");
+  assert.equal(profile.filesystem[":root"], "deny");
+  assert.equal(profile.filesystem[":minimal"], "read");
+  assert.equal(profile.filesystem[fs.realpathSync(path.join(repo, "src"))], "read");
+  assert.equal(profile.filesystem[fs.realpathSync(extraReadRoot)], "read");
+  assert.equal(profile.filesystem[fs.realpathSync(repo)], "write");
+});
+
+test("task --resume-last reapplies the approved read roots", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  const first = run("node", [SCRIPT, "task", "initial task"], { cwd: repo, env: buildEnv(binDir) });
+  assert.equal(first.status, 0, first.stderr);
+
+  const result = run("node", [SCRIPT, "task", "--resume-last", "--read-root", repo, "follow up"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastThreadResume.sandbox, undefined);
+  assert.equal(fakeState.lastThreadResume.config.default_permissions, "claude_companion_scoped");
+  assert.equal(
+    fakeState.lastThreadResume.config.permissions.claude_companion_scoped.filesystem[fs.realpathSync(repo)],
+    "read"
+  );
+});
+
+test("task --read-root fails closed when permission profiles are unsupported", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir, "permission-profiles-unsupported");
+  initGitRepo(repo);
+
+  const result = run("node", [SCRIPT, "task", "--read-root", repo, "inspect the file"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /cannot enforce the requested read scope/i);
+  assert.match(result.stderr, /0\.138\.0 or later/);
+});
+
 test("task --resume acts like --resume-last without leaking the flag into the prompt", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
@@ -967,6 +1036,30 @@ test("task --background enqueues a detached worker and exposes per-job status", 
   assert.equal(resultPayload.job.id, launchPayload.jobId);
   assert.equal(resultPayload.job.status, "completed");
   assert.match(resultPayload.storedJob.rendered, /Handled the requested task/);
+});
+
+test("task --background preserves read roots for the detached worker", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  const launched = run("node", [SCRIPT, "task", "--background", "--json", "--read-root", repo, "inspect"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+  assert.equal(launched.status, 0, launched.stderr);
+  const jobId = JSON.parse(launched.stdout).jobId;
+  const waited = run("node", [SCRIPT, "status", jobId, "--wait", "--timeout-ms", "15000", "--json"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(waited.status, 0, waited.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastThreadStart.sandbox, undefined);
+  assert.equal(fakeState.lastThreadStart.config.default_permissions, "claude_companion_scoped");
 });
 
 test("review rejects focus text because it is native-review only", () => {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -723,11 +723,10 @@ test("task --read-root sends a scoped permission profile without legacy sandbox"
   const statePath = path.join(binDir, "fake-codex-state.json");
   installFakeCodex(binDir);
   initGitRepo(repo);
-  fs.mkdirSync(path.join(repo, "src"));
 
   const result = run(
     "node",
-    [SCRIPT, "task", "--write", "--read-root", "src", "--read-root", extraReadRoot, "fix the test"],
+    [SCRIPT, "task", "--write", "--read-root", repo, "--read-root", extraReadRoot, "fix the test"],
     { cwd: repo, env: buildEnv(binDir) }
   );
 
@@ -739,9 +738,25 @@ test("task --read-root sends a scoped permission profile without legacy sandbox"
   assert.equal(params.config.default_permissions, "claude_companion_scoped");
   assert.equal(profile.filesystem[":root"], "deny");
   assert.equal(profile.filesystem[":minimal"], "read");
-  assert.equal(profile.filesystem[fs.realpathSync(path.join(repo, "src"))], "read");
+  assert.equal(profile.filesystem[fs.realpathSync(repo)], "read");
   assert.equal(profile.filesystem[fs.realpathSync(extraReadRoot)], "read");
-  assert.equal(profile.filesystem[fs.realpathSync(repo)], "write");
+  assert.equal(profile.extends, ":workspace");
+});
+
+test("task --write requires the approved read scope to cover the workspace", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.mkdirSync(path.join(repo, "src"));
+
+  const result = run("node", [SCRIPT, "task", "--write", "--read-root", "src", "fix"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--write requires an approved --read-root that covers the workspace/);
 });
 
 test("task --resume-last reapplies the approved read roots", () => {


### PR DESCRIPTION
## Summary

- add repeatable `--read-root <directory>` support for Codex task and rescue flows
- enforce request-scoped permission profiles across foreground, background, and resumed tasks
- fail closed for invalid roots, unsupported runtimes, and unapproved temp/workspace access
- document the option and add regression coverage

## Verification

- `npm test` (97 passed)
- `npm run build`
- `node scripts/bump-version.mjs --check 1.0.11`
- `claude plugin validate plugins/codex`
- `git diff --check`