### PR TITLE
fix: avoid shell:true deprecation on Windows

### DIFF
--- a/plugins/codex/scripts/lib/app-server.mjs
+++ b/plugins/codex/scripts/lib/app-server.mjs
@@ -14,7 +14,7 @@ import { spawn } from "node:child_process";
 import readline from "node:readline";
 import { parseBrokerEndpoint } from "./broker-endpoint.mjs";
 import { ensureBrokerSession, loadBrokerSession } from "./broker-lifecycle.mjs";
-import { terminateProcessTree } from "./process.mjs";
+import { commandWithWindowsShim, terminateProcessTree } from "./process.mjs";
 
 const PLUGIN_MANIFEST_URL = new URL("../../.claude-plugin/plugin.json", import.meta.url);
 const PLUGIN_MANIFEST = JSON.parse(fs.readFileSync(PLUGIN_MANIFEST_URL, "utf8"));
@@ -187,11 +187,12 @@ class SpawnedCodexAppServerClient extends AppServerClientBase {
   }
 
   async initialize() {
-    this.proc = spawn("codex", ["app-server"], {
+    const invocation = commandWithWindowsShim("codex", ["app-server"]);
+    this.proc = spawn(invocation.command, invocation.args, {
       cwd: this.cwd,
       env: this.options.env ?? process.env,
       stdio: ["pipe", "pipe", "pipe"],
-      shell: process.platform === "win32" ? (process.env.SHELL || true) : false,
+      shell: invocation.shell,
       windowsHide: true
     });
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -100,7 +100,7 @@ export function terminateProcessTree(pid, options = {}) {
     }
 
     const combinedOutput = `${result.stderr}\n${result.stdout}`.trim();
-    if (!result.error && looksLikeMissingProcessMessage(combinedOutput)) {
+    if (!result.error && (result.status === 128 || looksLikeMissingProcessMessage(combinedOutput))) {
       return { attempted: true, delivered: false, method: "taskkill", result };
     }
 

--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -9,7 +9,7 @@ export function runCommand(command, args = [], options = {}) {
     input: options.input,
     maxBuffer: options.maxBuffer,
     stdio: options.stdio ?? "pipe",
-    shell: options.shell ?? (process.platform === "win32" ? (process.env.SHELL || true) : false),
+    shell: options.shell ?? false,
     windowsHide: true
   });
 
@@ -35,8 +35,33 @@ export function runCommandChecked(command, args = [], options = {}) {
   return result;
 }
 
+export function commandWithWindowsShim(command, args = [], options = {}) {
+  const platform = options.platform ?? process.platform;
+  if (platform !== "win32") {
+    return { command, args, shell: false };
+  }
+
+  return {
+    command: options.comspec ?? process.env.ComSpec ?? "cmd.exe",
+    args: ["/d", "/s", "/c", "call", command, ...args],
+    shell: false
+  };
+}
+
 export function binaryAvailable(command, versionArgs = ["--version"], options = {}) {
-  const result = runCommand(command, versionArgs, options);
+  const runCommandImpl = options.runCommandImpl ?? runCommand;
+  let result;
+
+  if (options.shell !== undefined) {
+    result = runCommandImpl(command, versionArgs, options);
+  } else {
+    const invocation = commandWithWindowsShim(command, versionArgs, options);
+    result = runCommandImpl(invocation.command, invocation.args, {
+      cwd: options.cwd,
+      env: options.env,
+      shell: invocation.shell
+    });
+  }
   if (result.error && /** @type {NodeJS.ErrnoException} */ (result.error).code === "ENOENT") {
     return { available: false, detail: "not found" };
   }
@@ -66,7 +91,8 @@ export function terminateProcessTree(pid, options = {}) {
   if (platform === "win32") {
     const result = runCommandImpl("taskkill", ["/PID", String(pid), "/T", "/F"], {
       cwd: options.cwd,
-      env: options.env
+      env: options.env,
+      shell: false
     });
 
     if (!result.error && result.status === 0) {

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -84,7 +84,7 @@ test("terminateProcessTree treats missing Windows processes as already stopped",
         args,
         status: 128,
         signal: null,
-        stdout: "ERROR: The process \"1234\" not found.",
+        stdout: "ERROR: no se encontró el proceso \"1234\".",
         stderr: "",
         error: null
       };
@@ -94,5 +94,5 @@ test("terminateProcessTree treats missing Windows processes as already stopped",
   assert.equal(outcome.attempted, true);
   assert.equal(outcome.method, "taskkill");
   assert.equal(outcome.result.status, 128);
-  assert.match(outcome.result.stdout, /not found/i);
+  assert.equal(outcome.delivered, false);
 });

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -1,14 +1,56 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+import { binaryAvailable, commandWithWindowsShim, terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+
+
+test("commandWithWindowsShim avoids shell:true on Windows", () => {
+  assert.deepEqual(
+    commandWithWindowsShim("codex", ["app-server"], {
+      platform: "win32",
+      comspec: "C:\\Windows\\System32\\cmd.exe"
+    }),
+    {
+      command: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/s", "/c", "call", "codex", "app-server"],
+      shell: false
+    }
+  );
+});
+
+test("binaryAvailable uses cmd.exe explicitly for Windows command shims", () => {
+  let captured = null;
+  const outcome = binaryAvailable("npm", ["--version"], {
+    platform: "win32",
+    comspec: "C:\\Windows\\System32\\cmd.exe",
+    runCommandImpl(command, args, options) {
+      captured = { command, args, options };
+      return {
+        command,
+        args,
+        status: 0,
+        signal: null,
+        stdout: "11.16.0\n",
+        stderr: "",
+        error: null
+      };
+    }
+  });
+
+  assert.deepEqual(captured, {
+    command: "C:\\Windows\\System32\\cmd.exe",
+    args: ["/d", "/s", "/c", "call", "npm", "--version"],
+    options: { cwd: undefined, env: undefined, shell: false }
+  });
+  assert.deepEqual(outcome, { available: true, detail: "11.16.0" });
+});
 
 test("terminateProcessTree uses taskkill on Windows", () => {
   let captured = null;
   const outcome = terminateProcessTree(1234, {
     platform: "win32",
-    runCommandImpl(command, args) {
-      captured = { command, args };
+    runCommandImpl(command, args, options) {
+      captured = { command, args, options };
       return {
         command,
         args,
@@ -26,7 +68,8 @@ test("terminateProcessTree uses taskkill on Windows", () => {
 
   assert.deepEqual(captured, {
     command: "taskkill",
-    args: ["/PID", "1234", "/T", "/F"]
+    args: ["/PID", "1234", "/T", "/F"],
+    options: { cwd: undefined, env: undefined, shell: false }
   });
   assert.equal(outcome.delivered, true);
   assert.equal(outcome.method, "taskkill");


### PR DESCRIPTION
## Summary

Fixes #717.

Related: #708, #525.

- stop defaulting shared process launches to `shell: true` on Windows
- route `node` / `npm` / `codex` shim-style probes through an explicit `ComSpec /d /s /c call ...` invocation with `shell: false`
- use the same Windows invocation for direct `codex app-server` startup
- invoke `taskkill` directly with `shell: false`, avoiding Git Bash/MSYS conversion of `/PID`, `/T`, and `/F`
- treat `taskkill` exit 128 as an already-stopped process, so cleanup does not depend on English error text
- add regression coverage for the Windows shim invocation, taskkill options, and localized missing-process output

This avoids Node's DEP0190 warning without breaking `.cmd` shims such as `npm` on Windows. It also addresses the shell/argument-conversion root cause reported in #708 and #525 and makes the already-dead `taskkill` path locale-independent.

## Validation

On Windows 11 / Node 26.3.1:

- reproduced the pre-fix warning with `node --trace-deprecation plugins/codex/scripts/codex-companion.mjs setup --json`
- after the change, the same command exits 0 with `stderr_bytes=0`
- reproduced Git Bash/MSYS mangling on a nonexistent PID: `taskkill /PID 999999 /T /F` reaches `taskkill` as `C:/Program Files/Git/PID` and exits 1
- verified direct, no-shell `taskkill /PID 999999 /T /F` returns localized Spanish `ERROR: no se encontró el proceso "999999".` with exit 128
- `node --test tests/process.test.mjs tests/commands.test.mjs tests/bump-version.test.mjs` -> 14 passed, 0 failed
- `node --check plugins/codex/scripts/lib/process.mjs`
- `node --check plugins/codex/scripts/lib/app-server.mjs`
- `git diff --check`

I also verified on the same host that direct `spawnSync(..., { shell: false })` works for `.exe` binaries but returns `EINVAL` for an absolute `npm.cmd`, which is why the patch keeps explicit `cmd.exe` handling for Windows command shims instead of globally assuming every command is directly executable.