### PR TITLE
fix: reconcile stale background job workers

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -974,6 +974,12 @@ async function handleCancel(argv) {
   const threadId = existing.threadId ?? job.threadId ?? null;
   const turnId = existing.turnId ?? job.turnId ?? null;
 
+  if (job.workerExited && threadId && !turnId) {
+    throw new Error(
+      `Cannot safely cancel ${job.id}: the worker exited after turn/start was accepted, but the turn id is not yet known. The Codex turn may still be running.`
+    );
+  }
+
   const interrupt = await interruptAppServerTurn(cwd, { threadId, turnId });
   if (interrupt.attempted) {
     appendLogLine(

--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -38,6 +38,7 @@ import {
   buildSingleJobSnapshot,
   buildStatusSnapshot,
   readStoredJob,
+  reconcileJobsLiveness,
   resolveCancelableJob,
   resolveResultJob,
   sortJobsNewestFirst
@@ -336,7 +337,7 @@ async function waitForSingleJobSnapshot(cwd, reference, options = {}) {
 async function resolveLatestTrackedTaskThread(cwd, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const sessionId = getCurrentClaudeSessionId();
-  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot)).filter((job) => job.id !== options.excludeJobId);
+  const jobs = sortJobsNewestFirst(reconcileJobsLiveness(listJobs(workspaceRoot))).filter((job) => job.id !== options.excludeJobId);
   const visibleJobs = filterJobsForCurrentClaudeSession(jobs);
   const activeTask = visibleJobs.find((job) => job.jobClass === "task" && (job.status === "queued" || job.status === "running"));
   if (activeTask) {
@@ -934,7 +935,7 @@ function handleTaskResumeCandidate(argv) {
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveCommandWorkspace(options);
   const sessionId = getCurrentClaudeSessionId();
-  const jobs = filterJobsForCurrentClaudeSession(sortJobsNewestFirst(listJobs(workspaceRoot)));
+  const jobs = filterJobsForCurrentClaudeSession(sortJobsNewestFirst(reconcileJobsLiveness(listJobs(workspaceRoot))));
   const candidate = findLatestResumableTaskJob(jobs);
 
   const payload = {

--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -24,6 +24,34 @@ function filterJobsForCurrentSession(jobs, options = {}) {
   return jobs.filter((job) => job.sessionId === sessionId);
 }
 
+function isActiveJob(job) {
+  return job.status === "queued" || job.status === "running";
+}
+
+export function reconcileJobLiveness(job, options = {}) {
+  if (!isActiveJob(job) || !Number.isSafeInteger(job.pid) || job.pid <= 0) {
+    return job;
+  }
+
+  const killImpl = options.killImpl ?? process.kill.bind(process);
+  try {
+    killImpl(job.pid, 0);
+    return job;
+  } catch (error) {
+    if (error?.code === "EPERM") {
+      return job;
+    }
+    if (error?.code === "ESRCH") {
+      return { ...job, status: "terminated-unknown", phase: "worker-exited" };
+    }
+    return job;
+  }
+}
+
+function reconcileJobsLiveness(jobs, options = {}) {
+  return jobs.map((job) => reconcileJobLiveness(job, options));
+}
+
 function getJobTypeLabel(job) {
   if (typeof job.kindLabel === "string" && job.kindLabel) {
     return job.kindLabel;
@@ -213,7 +241,9 @@ function matchJobReference(jobs, reference, predicate = () => true) {
 export function buildStatusSnapshot(cwd, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const config = getConfig(workspaceRoot);
-  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot), options));
+  const jobs = sortJobsNewestFirst(
+    reconcileJobsLiveness(filterJobsForCurrentSession(listJobs(workspaceRoot), options), options)
+  );
   const maxJobs = options.maxJobs ?? DEFAULT_MAX_STATUS_JOBS;
   const maxProgressLines = options.maxProgressLines ?? DEFAULT_MAX_PROGRESS_LINES;
 
@@ -241,7 +271,7 @@ export function buildStatusSnapshot(cwd, options = {}) {
 
 export function buildSingleJobSnapshot(cwd, reference, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
-  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot));
+  const jobs = sortJobsNewestFirst(reconcileJobsLiveness(listJobs(workspaceRoot), options));
   const selected = matchJobReference(jobs, reference);
   if (!selected) {
     throw new Error(`No job found for "${reference}". Run /codex:status to inspect known jobs.`);
@@ -253,13 +283,18 @@ export function buildSingleJobSnapshot(cwd, reference, options = {}) {
   };
 }
 
-export function resolveResultJob(cwd, reference) {
+export function resolveResultJob(cwd, reference, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
-  const jobs = sortJobsNewestFirst(reference ? listJobs(workspaceRoot) : filterJobsForCurrentSession(listJobs(workspaceRoot)));
+  const scopedJobs = reference ? listJobs(workspaceRoot) : filterJobsForCurrentSession(listJobs(workspaceRoot), options);
+  const jobs = sortJobsNewestFirst(reconcileJobsLiveness(scopedJobs, options));
   const selected = matchJobReference(
     jobs,
     reference,
-    (job) => job.status === "completed" || job.status === "failed" || job.status === "cancelled"
+    (job) =>
+      job.status === "completed" ||
+      job.status === "failed" ||
+      job.status === "cancelled" ||
+      job.status === "terminated-unknown"
   );
 
   if (selected) {
@@ -280,7 +315,7 @@ export function resolveResultJob(cwd, reference) {
 
 export function resolveCancelableJob(cwd, reference, options = {}) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
-  const jobs = sortJobsNewestFirst(listJobs(workspaceRoot));
+  const jobs = sortJobsNewestFirst(reconcileJobsLiveness(listJobs(workspaceRoot), options));
   const activeJobs = jobs.filter((job) => job.status === "queued" || job.status === "running");
 
   if (reference) {

--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -48,7 +48,7 @@ export function reconcileJobLiveness(job, options = {}) {
   }
 }
 
-function reconcileJobsLiveness(jobs, options = {}) {
+export function reconcileJobsLiveness(jobs, options = {}) {
   return jobs.map((job) => reconcileJobLiveness(job, options));
 }
 

--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -42,7 +42,7 @@ export function reconcileJobLiveness(job, options = {}) {
       return job;
     }
     if (error?.code === "ESRCH") {
-      if (job.threadId && job.turnId) {
+      if (job.threadId) {
         return {
           ...job,
           status: "running",

--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -42,6 +42,15 @@ export function reconcileJobLiveness(job, options = {}) {
       return job;
     }
     if (error?.code === "ESRCH") {
+      if (job.threadId && job.turnId) {
+        return {
+          ...job,
+          status: "running",
+          phase: "worker-exited-turn-unknown",
+          pid: null,
+          workerExited: true
+        };
+      }
       return { ...job, status: "terminated-unknown", phase: "worker-exited" };
     }
     return job;

--- a/plugins/codex/scripts/lib/job-control.mjs
+++ b/plugins/codex/scripts/lib/job-control.mjs
@@ -294,7 +294,7 @@ export function resolveResultJob(cwd, reference, options = {}) {
       job.status === "completed" ||
       job.status === "failed" ||
       job.status === "cancelled" ||
-      job.status === "terminated-unknown"
+      (Boolean(reference) && job.status === "terminated-unknown")
   );
 
   if (selected) {

--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import process from "node:process";
 
 import { terminateProcessTree } from "./lib/process.mjs";
+import { reconcileJobLiveness } from "./lib/job-control.mjs";
 import { BROKER_ENDPOINT_ENV } from "./lib/app-server.mjs";
 import {
   clearBrokerSession,
@@ -57,7 +58,8 @@ function cleanupSessionJobs(cwd, sessionId) {
   }
 
   for (const job of removedJobs) {
-    const stillRunning = job.status === "queued" || job.status === "running";
+    const reconciled = reconcileJobLiveness(job);
+    const stillRunning = reconciled.status === "queued" || reconciled.status === "running";
     if (!stillRunning) {
       continue;
     }

--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -57,10 +57,15 @@ function cleanupSessionJobs(cwd, sessionId) {
     return;
   }
 
+  const retainedJobs = new Map();
   for (const job of removedJobs) {
     const reconciled = reconcileJobLiveness(job);
     const stillRunning = reconciled.status === "queued" || reconciled.status === "running";
     if (!stillRunning) {
+      continue;
+    }
+    if (reconciled.workerExited && reconciled.threadId) {
+      retainedJobs.set(job.id, reconciled);
       continue;
     }
     try {
@@ -72,7 +77,9 @@ function cleanupSessionJobs(cwd, sessionId) {
 
   saveState(workspaceRoot, {
     ...state,
-    jobs: state.jobs.filter((job) => job.sessionId !== sessionId)
+    jobs: state.jobs
+      .filter((job) => job.sessionId !== sessionId || retainedJobs.has(job.id))
+      .map((job) => retainedJobs.get(job.id) ?? job)
   });
 }
 

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 import { getCodexAvailability } from "./lib/codex.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
 import { getConfig, listJobs } from "./lib/state.mjs";
-import { sortJobsNewestFirst } from "./lib/job-control.mjs";
+import { reconcileJobsLiveness, sortJobsNewestFirst } from "./lib/job-control.mjs";
 import { SESSION_ID_ENV } from "./lib/tracked-jobs.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
 
@@ -145,7 +145,7 @@ function main() {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const config = getConfig(workspaceRoot);
 
-  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(listJobs(workspaceRoot), input));
+  const jobs = sortJobsNewestFirst(filterJobsForCurrentSession(reconcileJobsLiveness(listJobs(workspaceRoot)), input));
   const runningJob = jobs.find((job) => job.status === "queued" || job.status === "running");
   const runningTaskNote = runningJob
     ? `Codex task ${runningJob.id} is still running. Check /codex:status and use /codex:cancel ${runningJob.id} if you want to stop it before ending the session.`

--- a/tests/job-control.test.mjs
+++ b/tests/job-control.test.mjs
@@ -102,3 +102,31 @@ test("buildStatusSnapshot moves a dead worker out of the active queue", () => {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+
+test("implicit result ignores a newer dead worker in favor of stored final output", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-job-result-"));
+  const workspace = path.join(root, "workspace");
+  const previousPluginData = process.env.CLAUDE_PLUGIN_DATA;
+  fs.mkdirSync(workspace, { recursive: true });
+  process.env.CLAUDE_PLUGIN_DATA = path.join(root, "plugin-data");
+
+  try {
+    saveState(workspace, {
+      config: { stopReviewGate: false },
+      jobs: [
+        activeJob({ sessionId: "sess-current", updatedAt: "2026-09-04T10:02:00.000Z" }),
+        { id: "task-completed", status: "completed", sessionId: "sess-current", result: { rawOutput: "done" }, updatedAt: "2026-09-04T10:01:00.000Z" }
+      ]
+    });
+    const killImpl = () => { const error = new Error("no such process"); error.code = "ESRCH"; throw error; };
+    const options = { env: { CODEX_COMPANION_SESSION_ID: "sess-current" }, killImpl };
+
+    assert.equal(resolveResultJob(workspace, null, options).job.id, "task-completed");
+    assert.equal(resolveResultJob(workspace, "task-dead-worker", options).job.status, "terminated-unknown");
+  } finally {
+    if (previousPluginData === undefined) delete process.env.CLAUDE_PLUGIN_DATA;
+    else process.env.CLAUDE_PLUGIN_DATA = previousPluginData;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/job-control.test.mjs
+++ b/tests/job-control.test.mjs
@@ -37,6 +37,24 @@ test("reconcileJobLiveness marks an absent worker as terminated-unknown", () => 
   assert.equal(job.pid, 999999);
 });
 
+test("reconcileJobLiveness keeps a dead worker active when its Codex turn may still run", () => {
+  const job = reconcileJobLiveness(
+    activeJob({ threadId: "thr_live", turnId: "turn_live" }),
+    {
+      killImpl() {
+        const error = new Error("no such process");
+        error.code = "ESRCH";
+        throw error;
+      }
+    }
+  );
+
+  assert.equal(job.status, "running");
+  assert.equal(job.phase, "worker-exited-turn-unknown");
+  assert.equal(job.threadId, "thr_live");
+  assert.equal(job.turnId, "turn_live");
+});
+
 test("reconcileJobLiveness treats EPERM as alive", () => {
   const original = activeJob();
   const job = reconcileJobLiveness(original, {
@@ -58,6 +76,43 @@ test("reconcileJobLiveness leaves terminal and pid-less jobs untouched", () => {
   assert.deepEqual(reconcileJobLiveness(completed, { killImpl }), completed);
   assert.deepEqual(reconcileJobLiveness(noPid, { killImpl }), noPid);
   assert.equal(calls, 0);
+});
+
+test("dead wrapper with a live turn stays active and cancelable", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-job-turn-unknown-"));
+  const workspace = path.join(root, "workspace");
+  const previousPluginData = process.env.CLAUDE_PLUGIN_DATA;
+  fs.mkdirSync(workspace, { recursive: true });
+  process.env.CLAUDE_PLUGIN_DATA = path.join(root, "plugin-data");
+
+  try {
+    saveState(workspace, {
+      config: { stopReviewGate: false },
+      jobs: [activeJob({
+        threadId: "thr_live",
+        turnId: "turn_live",
+        sessionId: "sess-current",
+        createdAt: "2026-09-04T10:00:00.000Z",
+        updatedAt: "2026-09-04T10:01:00.000Z"
+      })]
+    });
+    const killImpl = () => {
+      const error = new Error("no such process");
+      error.code = "ESRCH";
+      throw error;
+    };
+    const options = { env: { CODEX_COMPANION_SESSION_ID: "sess-current" }, killImpl };
+    const report = buildStatusSnapshot(workspace, options);
+    assert.equal(report.running.length, 1);
+    assert.equal(report.running[0].phase, "worker-exited-turn-unknown");
+    assert.equal(report.running[0].pid, null);
+    assert.equal(resolveCancelableJob(workspace, "task-dead-worker", options).job.turnId, "turn_live");
+    assert.throws(() => resolveResultJob(workspace, "task-dead-worker", options));
+  } finally {
+    if (previousPluginData === undefined) delete process.env.CLAUDE_PLUGIN_DATA;
+    else process.env.CLAUDE_PLUGIN_DATA = previousPluginData;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("buildStatusSnapshot moves a dead worker out of the active queue", () => {

--- a/tests/job-control.test.mjs
+++ b/tests/job-control.test.mjs
@@ -1,0 +1,104 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { saveState } from "../plugins/codex/scripts/lib/state.mjs";
+
+import {
+  buildStatusSnapshot,
+  reconcileJobLiveness,
+  resolveCancelableJob,
+  resolveResultJob
+} from "../plugins/codex/scripts/lib/job-control.mjs";
+
+function activeJob(overrides = {}) {
+  return {
+    id: "task-dead-worker",
+    status: "running",
+    phase: "editing",
+    pid: 999999,
+    ...overrides
+  };
+}
+
+test("reconcileJobLiveness marks an absent worker as terminated-unknown", () => {
+  const job = reconcileJobLiveness(activeJob(), {
+    killImpl() {
+      const error = new Error("no such process");
+      error.code = "ESRCH";
+      throw error;
+    }
+  });
+
+  assert.equal(job.status, "terminated-unknown");
+  assert.equal(job.phase, "worker-exited");
+  assert.equal(job.pid, 999999);
+});
+
+test("reconcileJobLiveness treats EPERM as alive", () => {
+  const original = activeJob();
+  const job = reconcileJobLiveness(original, {
+    killImpl() {
+      const error = new Error("not permitted");
+      error.code = "EPERM";
+      throw error;
+    }
+  });
+  assert.deepEqual(job, original);
+});
+
+test("reconcileJobLiveness leaves terminal and pid-less jobs untouched", () => {
+  let calls = 0;
+  const killImpl = () => { calls += 1; };
+  const completed = activeJob({ status: "completed" });
+  const noPid = activeJob({ pid: null });
+
+  assert.deepEqual(reconcileJobLiveness(completed, { killImpl }), completed);
+  assert.deepEqual(reconcileJobLiveness(noPid, { killImpl }), noPid);
+  assert.equal(calls, 0);
+});
+
+test("buildStatusSnapshot moves a dead worker out of the active queue", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "codex-job-control-"));
+  const workspace = path.join(root, "workspace");
+  const previousPluginData = process.env.CLAUDE_PLUGIN_DATA;
+  fs.mkdirSync(workspace, { recursive: true });
+  process.env.CLAUDE_PLUGIN_DATA = path.join(root, "plugin-data");
+
+  try {
+    saveState(workspace, {
+      config: { stopReviewGate: false },
+      jobs: [{
+        id: "task-dead-worker",
+        status: "running",
+        phase: "editing",
+        pid: 999999,
+        createdAt: "2026-09-04T10:00:00.000Z",
+        updatedAt: "2026-09-04T10:01:00.000Z"
+      }]
+    });
+    const reportKill = () => {
+      const error = new Error("no such process");
+      error.code = "ESRCH";
+      throw error;
+    };
+    const report = buildStatusSnapshot(workspace, { env: {}, killImpl: reportKill });
+    assert.equal(report.running.length, 0);
+    assert.equal(report.latestFinished.status, "terminated-unknown");
+    assert.equal(report.latestFinished.phase, "worker-exited");
+    assert.equal(
+      resolveResultJob(workspace, "task-dead-worker", { killImpl: reportKill }).job.status,
+      "terminated-unknown"
+    );
+    assert.throws(
+      () => resolveCancelableJob(workspace, "task-dead-worker", { killImpl: reportKill }),
+      /No job found|No active job/
+    );
+  } finally {
+    if (previousPluginData === undefined) delete process.env.CLAUDE_PLUGIN_DATA;
+    else process.env.CLAUDE_PLUGIN_DATA = previousPluginData;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/job-control.test.mjs
+++ b/tests/job-control.test.mjs
@@ -55,6 +55,20 @@ test("reconcileJobLiveness keeps a dead worker active when its Codex turn may st
   assert.equal(job.turnId, "turn_live");
 });
 
+test("reconcileJobLiveness keeps the turn-start response window active", () => {
+  const job = reconcileJobLiveness(activeJob({ threadId: "thr_pending", turnId: null }), {
+    killImpl() {
+      const error = new Error("no such process");
+      error.code = "ESRCH";
+      throw error;
+    }
+  });
+  assert.equal(job.status, "running");
+  assert.equal(job.phase, "worker-exited-turn-unknown");
+  assert.equal(job.pid, null);
+  assert.equal(job.workerExited, true);
+});
+
 test("reconcileJobLiveness treats EPERM as alive", () => {
   const original = activeJob();
   const job = reconcileJobLiveness(original, {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -523,6 +523,26 @@ test("task --resume-last ignores a stale current-session worker and resumes the 
   assert.equal(resumed.stdout, "Resumed the prior run.\nFollow-up prompt accepted.\n");
 });
 
+test("task --resume-last blocks when a dead wrapper still has a live turn identity", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  const env = { ...buildEnv(binDir), CODEX_COMPANION_SESSION_ID: "sess-current" };
+  const first = run("node", [SCRIPT, "task", "initial task"], { cwd: repo, env });
+  assert.equal(first.status, 0, first.stderr);
+  const statePath = path.join(resolveStateDir(repo), "state.json");
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  state.jobs.push({ id: "task-orphan-turn", status: "running", title: "Codex Task", jobClass: "task", sessionId: "sess-current", pid: 999999, threadId: "thr_orphan", turnId: "turn_orphan", updatedAt: "2099-01-01T00:00:00.000Z" });
+  fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  const resumed = run("node", [SCRIPT, "task", "--resume-last", "follow up"], { cwd: repo, env });
+  assert.notEqual(resumed.status, 0);
+  assert.match(resumed.stderr, /task-orphan-turn is still running/i);
+});
+
 test("task-resume-candidate returns the latest rescue thread from the current session", () => {
   const workspace = makeTempDir();
   const stateDir = resolveStateDir(workspace);
@@ -2073,6 +2093,25 @@ test("stop hook ignores a stale current-session worker when the review gate is d
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout.trim(), "");
   assert.doesNotMatch(result.stderr, /task-stale is still running/i);
+});
+
+test("stop hook keeps an orphaned live turn active when its wrapper died", () => {
+  const repo = makeTempDir();
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  const stateDir = resolveStateDir(repo);
+  fs.mkdirSync(path.join(stateDir, "jobs"), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, "state.json"), `${JSON.stringify({ version: 1, config: { stopReviewGate: false }, jobs: [{ id: "task-orphan-turn", status: "running", title: "Codex Task", jobClass: "task", sessionId: "sess-current", pid: 999999, threadId: "thr_orphan", turnId: "turn_orphan", updatedAt: "2099-01-01T00:00:00.000Z" }] }, null, 2)}\n`, "utf8");
+  const result = run("node", [STOP_HOOK], {
+    cwd: repo,
+    env: { ...process.env, CODEX_COMPANION_SESSION_ID: "sess-current" },
+    input: JSON.stringify({ cwd: repo })
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "");
+  assert.match(result.stderr, /task-orphan-turn is still running/i);
 });
 
 test("stop hook allows the stop when the review gate is enabled and the stop-time review task is clean", () => {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -1777,6 +1777,26 @@ test("cancel with a job id can still target an active job from another Claude se
   assert.equal(state.jobs[0].status, "cancelled");
 });
 
+test("cancel fails closed when an orphaned turn has no persisted turn id", () => {
+  const workspace = makeTempDir();
+  const stateDir = resolveStateDir(workspace);
+  fs.mkdirSync(path.join(stateDir, "jobs"), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, "state.json"), `${JSON.stringify({
+    version: 1, config: { stopReviewGate: false }, jobs: [{
+      id: "task-turn-pending", status: "running", title: "Codex Task", jobClass: "task",
+      sessionId: "sess-current", pid: 999999, threadId: "thr_pending",
+      updatedAt: "2099-01-01T00:00:00.000Z"
+    }]
+  }, null, 2)}
+`, "utf8");
+  const env = { ...process.env, CODEX_COMPANION_SESSION_ID: "sess-current" };
+  const result = run("node", [SCRIPT, "cancel", "task-turn-pending", "--json"], { cwd: workspace, env });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /turn id|safely interrupt|still running/i);
+  const state = JSON.parse(fs.readFileSync(path.join(stateDir, "state.json"), "utf8"));
+  assert.equal(state.jobs[0].status, "running");
+});
+
 test("cancel sends turn interrupt to the shared app-server before killing a brokered task", async () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();
@@ -1839,6 +1859,28 @@ test("cancel sends turn interrupt to the shared app-server before killing a brok
     })
   });
   assert.equal(cleanup.status, 0, cleanup.stderr);
+});
+
+test("session end preserves an orphaned turn whose worker exited", () => {
+  const workspace = makeTempDir();
+  const stateDir = resolveStateDir(workspace);
+  fs.mkdirSync(path.join(stateDir, "jobs"), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, "state.json"), `${JSON.stringify({
+    version: 1, config: { stopReviewGate: false }, jobs: [{
+      id: "task-orphaned-turn", status: "running", title: "Codex Task", jobClass: "task",
+      sessionId: "sess-current", pid: 999999, threadId: "thr_pending",
+      updatedAt: "2099-01-01T00:00:00.000Z"
+    }]
+  }, null, 2)}
+`, "utf8");
+  const result = run("node", [SESSION_HOOK, "SessionEnd"], {
+    cwd: workspace, env: { ...process.env, CODEX_COMPANION_SESSION_ID: "sess-current" },
+    input: JSON.stringify({ hook_event_name: "SessionEnd", session_id: "sess-current", cwd: workspace })
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const state = JSON.parse(fs.readFileSync(path.join(stateDir, "state.json"), "utf8"));
+  assert.equal(state.jobs.length, 1);
+  assert.equal(state.jobs[0].id, "task-orphaned-turn");
 });
 
 test("session end fully cleans up jobs for the ending session", async (t) => {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -503,6 +503,26 @@ test("task --resume-last resumes the latest persisted task thread", () => {
   assert.equal(result.stdout, "Resumed the prior run.\nFollow-up prompt accepted.\n");
 });
 
+test("task --resume-last ignores a stale current-session worker and resumes the prior completed thread", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  const env = { ...buildEnv(binDir), CODEX_COMPANION_SESSION_ID: "sess-current" };
+  const first = run("node", [SCRIPT, "task", "initial task"], { cwd: repo, env });
+  assert.equal(first.status, 0, first.stderr);
+  const statePath = path.join(resolveStateDir(repo), "state.json");
+  const state = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  state.jobs.push({ id: "task-stale", status: "running", title: "Codex Task", jobClass: "task", sessionId: "sess-current", pid: 999999, updatedAt: "2099-01-01T00:00:00.000Z" });
+  fs.writeFileSync(statePath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  const resumed = run("node", [SCRIPT, "task", "--resume-last", "follow up"], { cwd: repo, env });
+  assert.equal(resumed.status, 0, resumed.stderr);
+  assert.equal(resumed.stdout, "Resumed the prior run.\nFollow-up prompt accepted.\n");
+});
+
 test("task-resume-candidate returns the latest rescue thread from the current session", () => {
   const workspace = makeTempDir();
   const stateDir = resolveStateDir(workspace);
@@ -2034,6 +2054,25 @@ test("stop hook logs running tasks to stderr without blocking when the review ga
   assert.match(blocked.stderr, /Codex task task-live is still running/i);
   assert.match(blocked.stderr, /\/codex:status/i);
   assert.match(blocked.stderr, /\/codex:cancel task-live/i);
+});
+
+test("stop hook ignores a stale current-session worker when the review gate is disabled", () => {
+  const repo = makeTempDir();
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  const stateDir = resolveStateDir(repo);
+  fs.mkdirSync(path.join(stateDir, "jobs"), { recursive: true });
+  fs.writeFileSync(path.join(stateDir, "state.json"), `${JSON.stringify({ version: 1, config: { stopReviewGate: false }, jobs: [{ id: "task-stale", status: "running", title: "Codex Task", jobClass: "task", sessionId: "sess-current", pid: 999999, updatedAt: "2099-01-01T00:00:00.000Z" }] }, null, 2)}\n`, "utf8");
+  const result = run("node", [STOP_HOOK], {
+    cwd: repo,
+    env: { ...process.env, CODEX_COMPANION_SESSION_ID: "sess-current" },
+    input: JSON.stringify({ cwd: repo })
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), "");
+  assert.doesNotMatch(result.stderr, /task-stale is still running/i);
 });
 
 test("stop hook allows the stop when the review gate is enabled and the stop-time review task is clean", () => {


### PR DESCRIPTION
## Summary

Fixes #704.

- reconcile `queued` / `running` job records against the recorded worker PID when jobs are read
- treat `process.kill(pid, 0)` `ESRCH` as a missing worker and project the job as `terminated-unknown` with phase `worker-exited`
- treat `EPERM` as alive and fail open on unrecognized probe errors to avoid false termination
- use the same reconciled view for status, result, and cancel resolution
- keep reconciliation read-only: persisted job records are not rewritten
- add deterministic coverage for missing workers, `EPERM`, terminal/pid-less records, and active-queue classification

This fixes stale jobs already on disk without requiring a worker-side protocol change.

## Validation

On Windows 11 / Node 26.3.1:

- test-first check initially failed because `reconcileJobLiveness` did not exist
- `node --test tests/job-control.test.mjs tests/render.test.mjs tests/commands.test.mjs` -> 14 passed, 0 failed
- real liveness probe with PID `999999` projects `{ status: "terminated-unknown", phase: "worker-exited" }`
- `node --check plugins/codex/scripts/lib/job-control.mjs`
- `git diff --cached --check`

I also attempted the repository-wide `npm test` on this Windows host. It encounters an unrelated existing `broker-endpoint.test.mjs` failure for the Unix-socket case before the new job-control coverage; this PR does not modify broker endpoint code.

A Codex CLI review was also attempted but did not execute because the account had reached its code-review usage limit, so it is not claimed as validation.
