### PR TITLE
fix: support relocated Claude config transfers

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -21,7 +21,7 @@ import {
     runAppServerReview,
     runAppServerTurn
   } from "./lib/codex.mjs";
-import { resolveClaudeSessionPath } from "./lib/claude-session-transfer.mjs";
+import { prepareClaudeSessionImport, resolveClaudeSessionPath } from "./lib/claude-session-transfer.mjs";
 import { readStdinIfPiped } from "./lib/fs.mjs";
 import { collectReviewContext, ensureGitRepository, resolveReviewTarget } from "./lib/git.mjs";
 import { binaryAvailable, terminateProcessTree } from "./lib/process.mjs";
@@ -626,7 +626,13 @@ async function executeTransfer(cwd, options = {}) {
   const sourcePath = resolveClaudeSessionPath(cwd, {
     source: options.source
   });
-  const result = await importExternalAgentSession(cwd, { sourcePath });
+  const prepared = prepareClaudeSessionImport(cwd, sourcePath);
+  let result;
+  try {
+    result = await importExternalAgentSession(cwd, { sourcePath: prepared.importPath });
+  } finally {
+    prepared.cleanup();
+  }
   const payload = {
     threadId: result.threadId,
     resumeCommand: `codex resume ${result.threadId}`,

--- a/plugins/codex/scripts/lib/claude-session-transfer.mjs
+++ b/plugins/codex/scripts/lib/claude-session-transfer.mjs
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 
@@ -62,6 +62,32 @@ function filesHaveSameContent(source, candidate, sourceSha256) {
   }
 }
 
+const STAGING_MARKER_CONTENT = "codex-plugin-cc-staging-v1\n";
+const STAGING_LOCK_WAIT = new Int32Array(new SharedArrayBuffer(4));
+
+function processIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+function staleLockCanBeRemoved(lockPath) {
+  const ownerPath = path.join(lockPath, "owner");
+  try {
+    const pid = Number(fs.readFileSync(ownerPath, "utf8"));
+    return !(Number.isSafeInteger(pid) && pid > 0 && processIsAlive(pid));
+  } catch {
+    try {
+      return Date.now() - fs.statSync(lockPath).mtimeMs > 1000;
+    } catch {
+      return true;
+    }
+  }
+}
+
 function copyToExclusiveStagingPath(source, preferredPath) {
   const parsed = path.parse(preferredPath);
   const sourceSha256 = fileSha256(source);
@@ -69,15 +95,86 @@ function copyToExclusiveStagingPath(source, preferredPath) {
   for (const candidate of [preferredPath, stableFallback]) {
     try {
       fs.copyFileSync(source, candidate, fs.constants.COPYFILE_EXCL);
-      return { path: candidate, created: true };
+      return { path: candidate, created: true, sourceSha256 };
     } catch (error) {
       if (error?.code !== "EEXIST") throw error;
       if (filesHaveSameContent(source, candidate, sourceSha256)) {
-        return { path: candidate, created: false };
+        return { path: candidate, created: false, sourceSha256 };
       }
     }
   }
   throw new Error(`Cannot allocate a stable staging path under ${parsed.dir}`);
+}
+
+function withStagingLock(stagedPath, callback) {
+  const lockPath = `${stagedPath}.codex-staging-lock`;
+  const ownerPath = path.join(lockPath, "owner");
+  const deadline = Date.now() + 5000;
+  while (true) {
+    try {
+      fs.mkdirSync(lockPath);
+      try {
+        fs.writeFileSync(ownerPath, `${process.pid}\n`, { flag: "wx" });
+      } catch (error) {
+        fs.rmSync(lockPath, { recursive: true, force: true });
+        throw error;
+      }
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      if (staleLockCanBeRemoved(lockPath)) {
+        try { fs.rmSync(lockPath, { recursive: true, force: true }); } catch {}
+        continue;
+      }
+      if (Date.now() >= deadline) throw new Error(`Timed out acquiring staging lock for ${stagedPath}`);
+      Atomics.wait(STAGING_LOCK_WAIT, 0, 0, 5);
+    }
+  }
+  try { return callback(); } finally { fs.rmSync(lockPath, { recursive: true, force: true }); }
+}
+
+function managedMarkerMatches(markerPath) {
+  try { return fs.readFileSync(markerPath, "utf8") === STAGING_MARKER_CONTENT; } catch { return false; }
+}
+
+function acquireStagingLease(stagedPath, staged) {
+  const directory = path.dirname(stagedPath);
+  const base = path.basename(stagedPath);
+  const markerPath = `${stagedPath}.codex-staging-managed`;
+  const leasePrefix = `${base}.codex-staging-lease-`;
+  const leasePath = path.join(directory, `${leasePrefix}${process.pid}-${randomUUID()}`);
+  let managed = false;
+
+  withStagingLock(stagedPath, () => {
+    const markerMatches = managedMarkerMatches(markerPath);
+    if (staged.created) {
+      if (fs.existsSync(markerPath) && !markerMatches) {
+        throw new Error(`Refusing to manage unknown staging marker: ${markerPath}`);
+      }
+      if (!markerMatches) fs.writeFileSync(markerPath, STAGING_MARKER_CONTENT, { flag: "wx" });
+      managed = true;
+    } else {
+      managed = markerMatches;
+    }
+    if (managed) fs.writeFileSync(leasePath, "", { flag: "wx" });
+  });
+
+  return {
+    release() {
+      if (!managed) return;
+      withStagingLock(stagedPath, () => {
+        try { fs.unlinkSync(leasePath); } catch (error) { if (error?.code !== "ENOENT") throw error; }
+        const activeLeases = fs.readdirSync(directory).filter((name) => name.startsWith(leasePrefix));
+        if (activeLeases.length > 0 || !managedMarkerMatches(markerPath)) return;
+        if (fs.existsSync(stagedPath) && fileSha256(stagedPath) !== staged.sourceSha256) {
+          fs.unlinkSync(markerPath);
+          return;
+        }
+        try { fs.unlinkSync(stagedPath); } catch (error) { if (error?.code !== "ENOENT") throw error; }
+        try { fs.unlinkSync(markerPath); } catch (error) { if (error?.code !== "ENOENT") throw error; }
+      });
+    }
+  };
 }
 
 function isWithin(root, candidate) {
@@ -157,19 +254,13 @@ export function prepareClaudeSessionImport(cwd, sourcePath) {
     if (staged.created) fs.unlinkSync(canonicalImportPath);
     throw new Error(`Cannot stage Claude session outside the default Claude projects root: ${canonicalImportPath}`);
   }
+  const lease = acquireStagingLease(canonicalImportPath, staged);
   return {
     sourcePath: source,
     importPath: canonicalImportPath,
     staged: true,
     cleanup() {
-      if (!staged.created) return;
-      try {
-        fs.unlinkSync(canonicalImportPath);
-      } catch (error) {
-        if (error?.code !== "ENOENT") {
-          throw error;
-        }
-      }
+      lease.release();
     }
   };
 }

--- a/plugins/codex/scripts/lib/claude-session-transfer.mjs
+++ b/plugins/codex/scripts/lib/claude-session-transfer.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 
@@ -46,6 +47,22 @@ function nearestExistingAncestor(value) {
     current = parent;
   }
   return fs.realpathSync(current);
+}
+
+function copyToExclusiveStagingPath(source, preferredPath) {
+  const parsed = path.parse(preferredPath);
+  for (let attempt = 0; attempt < 16; attempt += 1) {
+    const candidate = attempt === 0
+      ? preferredPath
+      : path.join(parsed.dir, `${parsed.name}.codex-import-${randomUUID()}${parsed.ext}`);
+    try {
+      fs.copyFileSync(source, candidate, fs.constants.COPYFILE_EXCL);
+      return candidate;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+    }
+  }
+  throw new Error(`Cannot allocate an exclusive staging path under ${parsed.dir}`);
 }
 
 function isWithin(root, candidate) {
@@ -119,12 +136,8 @@ export function prepareClaudeSessionImport(cwd, sourcePath) {
     throw new Error(`Cannot stage Claude session outside the default Claude projects root: ${canonicalImportParent}`);
   }
 
-  if (fs.existsSync(importPath)) {
-    throw new Error(`Cannot stage Claude session for Codex because the destination already exists: ${importPath}`);
-  }
-
-  fs.copyFileSync(source, importPath, fs.constants.COPYFILE_EXCL);
-  const canonicalImportPath = fs.realpathSync(importPath);
+  const stagedPath = copyToExclusiveStagingPath(source, importPath);
+  const canonicalImportPath = fs.realpathSync(stagedPath);
   if (!isWithin(canonicalDefaultRoot, canonicalImportPath)) {
     fs.unlinkSync(canonicalImportPath);
     throw new Error(`Cannot stage Claude session outside the default Claude projects root: ${canonicalImportPath}`);

--- a/plugins/codex/scripts/lib/claude-session-transfer.mjs
+++ b/plugins/codex/scripts/lib/claude-session-transfer.mjs
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 
@@ -49,20 +49,35 @@ function nearestExistingAncestor(value) {
   return fs.realpathSync(current);
 }
 
+function fileSha256(filePath) {
+  return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function filesHaveSameContent(source, candidate, sourceSha256) {
+  try {
+    if (fs.statSync(source).size !== fs.statSync(candidate).size) return false;
+    return fileSha256(candidate) === sourceSha256;
+  } catch {
+    return false;
+  }
+}
+
 function copyToExclusiveStagingPath(source, preferredPath) {
   const parsed = path.parse(preferredPath);
-  for (let attempt = 0; attempt < 16; attempt += 1) {
-    const candidate = attempt === 0
-      ? preferredPath
-      : path.join(parsed.dir, `${parsed.name}.codex-import-${randomUUID()}${parsed.ext}`);
+  const sourceSha256 = fileSha256(source);
+  const stableFallback = path.join(parsed.dir, `${parsed.name}.codex-import-${sourceSha256}${parsed.ext}`);
+  for (const candidate of [preferredPath, stableFallback]) {
     try {
       fs.copyFileSync(source, candidate, fs.constants.COPYFILE_EXCL);
-      return candidate;
+      return { path: candidate, created: true };
     } catch (error) {
       if (error?.code !== "EEXIST") throw error;
+      if (filesHaveSameContent(source, candidate, sourceSha256)) {
+        return { path: candidate, created: false };
+      }
     }
   }
-  throw new Error(`Cannot allocate an exclusive staging path under ${parsed.dir}`);
+  throw new Error(`Cannot allocate a stable staging path under ${parsed.dir}`);
 }
 
 function isWithin(root, candidate) {
@@ -136,10 +151,10 @@ export function prepareClaudeSessionImport(cwd, sourcePath) {
     throw new Error(`Cannot stage Claude session outside the default Claude projects root: ${canonicalImportParent}`);
   }
 
-  const stagedPath = copyToExclusiveStagingPath(source, importPath);
-  const canonicalImportPath = fs.realpathSync(stagedPath);
+  const staged = copyToExclusiveStagingPath(source, importPath);
+  const canonicalImportPath = fs.realpathSync(staged.path);
   if (!isWithin(canonicalDefaultRoot, canonicalImportPath)) {
-    fs.unlinkSync(canonicalImportPath);
+    if (staged.created) fs.unlinkSync(canonicalImportPath);
     throw new Error(`Cannot stage Claude session outside the default Claude projects root: ${canonicalImportPath}`);
   }
   return {
@@ -147,6 +162,7 @@ export function prepareClaudeSessionImport(cwd, sourcePath) {
     importPath: canonicalImportPath,
     staged: true,
     cleanup() {
+      if (!staged.created) return;
       try {
         fs.unlinkSync(canonicalImportPath);
       } catch (error) {

--- a/plugins/codex/scripts/lib/claude-session-transfer.mjs
+++ b/plugins/codex/scripts/lib/claude-session-transfer.mjs
@@ -38,6 +38,16 @@ function realpathIfExists(value) {
   }
 }
 
+function nearestExistingAncestor(value) {
+  let current = value;
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+  return fs.realpathSync(current);
+}
+
 function isWithin(root, candidate) {
   const relative = path.relative(root, candidate);
   return relative !== "" && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
@@ -94,10 +104,17 @@ export function prepareClaudeSessionImport(cwd, sourcePath) {
 
   const relative = path.relative(sourceRoot.realRoot, source);
   const importPath = path.join(defaultProjects, relative);
-  fs.mkdirSync(path.dirname(importPath), { recursive: true });
+  fs.mkdirSync(defaultProjects, { recursive: true });
 
   const canonicalDefaultRoot = fs.realpathSync(defaultProjects);
-  const canonicalImportParent = fs.realpathSync(path.dirname(importPath));
+  const importParent = path.dirname(importPath);
+  const canonicalExistingAncestor = nearestExistingAncestor(importParent);
+  if (!canonicalExistingAncestor || (canonicalExistingAncestor !== canonicalDefaultRoot && !isWithin(canonicalDefaultRoot, canonicalExistingAncestor))) {
+    throw new Error(`Cannot stage Claude session outside the default Claude projects root: ${canonicalExistingAncestor ?? importParent}`);
+  }
+
+  fs.mkdirSync(importParent, { recursive: true });
+  const canonicalImportParent = fs.realpathSync(importParent);
   if (canonicalImportParent !== canonicalDefaultRoot && !isWithin(canonicalDefaultRoot, canonicalImportParent)) {
     throw new Error(`Cannot stage Claude session outside the default Claude projects root: ${canonicalImportParent}`);
   }

--- a/plugins/codex/scripts/lib/claude-session-transfer.mjs
+++ b/plugins/codex/scripts/lib/claude-session-transfer.mjs
@@ -96,12 +96,22 @@ export function prepareClaudeSessionImport(cwd, sourcePath) {
   const importPath = path.join(defaultProjects, relative);
   fs.mkdirSync(path.dirname(importPath), { recursive: true });
 
+  const canonicalDefaultRoot = fs.realpathSync(defaultProjects);
+  const canonicalImportParent = fs.realpathSync(path.dirname(importPath));
+  if (canonicalImportParent !== canonicalDefaultRoot && !isWithin(canonicalDefaultRoot, canonicalImportParent)) {
+    throw new Error(`Cannot stage Claude session outside the default Claude projects root: ${canonicalImportParent}`);
+  }
+
   if (fs.existsSync(importPath)) {
     throw new Error(`Cannot stage Claude session for Codex because the destination already exists: ${importPath}`);
   }
 
   fs.copyFileSync(source, importPath, fs.constants.COPYFILE_EXCL);
   const canonicalImportPath = fs.realpathSync(importPath);
+  if (!isWithin(canonicalDefaultRoot, canonicalImportPath)) {
+    fs.unlinkSync(canonicalImportPath);
+    throw new Error(`Cannot stage Claude session outside the default Claude projects root: ${canonicalImportPath}`);
+  }
   return {
     sourcePath: source,
     importPath: canonicalImportPath,

--- a/plugins/codex/scripts/lib/claude-session-transfer.mjs
+++ b/plugins/codex/scripts/lib/claude-session-transfer.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import { ensureAbsolutePath } from "./fs.mjs";
 
 export const TRANSCRIPT_PATH_ENV = "CODEX_COMPANION_TRANSCRIPT_PATH";
-const CLAUDE_PROJECTS_DIR = path.join(os.homedir(), ".claude", "projects");
+const CLAUDE_CONFIG_DIR_ENV = "CLAUDE_CONFIG_DIR";
 
 function resolveUserPath(cwd, value) {
   if (value === "~") {
@@ -15,6 +15,42 @@ function resolveUserPath(cwd, value) {
     return path.join(os.homedir(), String(value).slice(2));
   }
   return ensureAbsolutePath(cwd, value);
+}
+
+function defaultClaudeProjectsDir() {
+  return path.join(os.homedir(), ".claude", "projects");
+}
+
+function configuredClaudeProjectsDir(cwd) {
+  const configured = process.env[CLAUDE_CONFIG_DIR_ENV];
+  return configured ? path.join(resolveUserPath(cwd, configured), "projects") : null;
+}
+
+function allowedClaudeProjectsDirs(cwd) {
+  return [...new Set([configuredClaudeProjectsDir(cwd), defaultClaudeProjectsDir()].filter(Boolean))];
+}
+
+function realpathIfExists(value) {
+  try {
+    return fs.realpathSync(value);
+  } catch {
+    return null;
+  }
+}
+
+function isWithin(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative !== "" && relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+}
+
+function findContainingProjectsRoot(cwd, source) {
+  for (const configuredPath of allowedClaudeProjectsDirs(cwd)) {
+    const realRoot = realpathIfExists(configuredPath);
+    if (realRoot && isWithin(realRoot, source)) {
+      return { configuredPath, realRoot };
+    }
+  }
+  return null;
 }
 
 export function resolveClaudeSessionPath(cwd, options = {}) {
@@ -29,16 +65,55 @@ export function resolveClaudeSessionPath(cwd, options = {}) {
   }
 
   let source;
-  let projects;
   try {
     source = fs.realpathSync(sourcePath);
-    projects = fs.realpathSync(CLAUDE_PROJECTS_DIR);
   } catch {
     throw new Error(`Claude session file not found: ${sourcePath}`);
   }
-  const relative = path.relative(projects, source);
-  if (relative === "" || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
-    throw new Error(`Codex can import Claude sessions only from ${CLAUDE_PROJECTS_DIR}: ${source}`);
+
+  if (!findContainingProjectsRoot(cwd, source)) {
+    throw new Error(
+      `Codex can import Claude sessions only from ${allowedClaudeProjectsDirs(cwd).join(" or ")}: ${source}`
+    );
   }
   return source;
+}
+
+export function prepareClaudeSessionImport(cwd, sourcePath) {
+  const source = fs.realpathSync(sourcePath);
+  const defaultProjects = defaultClaudeProjectsDir();
+  const defaultRoot = realpathIfExists(defaultProjects);
+  if (defaultRoot && isWithin(defaultRoot, source)) {
+    return { sourcePath: source, importPath: source, staged: false, cleanup() {} };
+  }
+
+  const sourceRoot = findContainingProjectsRoot(cwd, source);
+  if (!sourceRoot) {
+    throw new Error(`Claude session is outside the configured projects roots: ${source}`);
+  }
+
+  const relative = path.relative(sourceRoot.realRoot, source);
+  const importPath = path.join(defaultProjects, relative);
+  fs.mkdirSync(path.dirname(importPath), { recursive: true });
+
+  if (fs.existsSync(importPath)) {
+    throw new Error(`Cannot stage Claude session for Codex because the destination already exists: ${importPath}`);
+  }
+
+  fs.copyFileSync(source, importPath, fs.constants.COPYFILE_EXCL);
+  const canonicalImportPath = fs.realpathSync(importPath);
+  return {
+    sourcePath: source,
+    importPath: canonicalImportPath,
+    staged: true,
+    cleanup() {
+      try {
+        fs.unlinkSync(canonicalImportPath);
+      } catch (error) {
+        if (error?.code !== "ENOENT") {
+          throw error;
+        }
+      }
+    }
+  };
 }

--- a/tests/claude-session-transfer.test.mjs
+++ b/tests/claude-session-transfer.test.mjs
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { prepareClaudeSessionImport } from "../plugins/codex/scripts/lib/claude-session-transfer.mjs";
+
+function tempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+test("shared staged imports keep the file alive until the final cleanup", () => {
+  const home = tempDir("codex-transfer-home-");
+  const repo = path.join(home, "repo");
+  const claudeConfigDir = path.join(home, ".claude-work");
+  const projectDir = path.join(claudeConfigDir, "projects", "-repo");
+  const source = path.join(projectDir, "session.jsonl");
+  const previousHome = process.env.USERPROFILE;
+  const previousConfig = process.env.CLAUDE_CONFIG_DIR;
+
+  fs.mkdirSync(repo, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.writeFileSync(source, '{"type":"user","message":{"content":"hello"}}\n', "utf8");
+  process.env.USERPROFILE = home;
+  process.env.CLAUDE_CONFIG_DIR = claudeConfigDir;
+
+  try {
+    const first = prepareClaudeSessionImport(repo, source);
+    const second = prepareClaudeSessionImport(repo, source);
+
+    assert.equal(path.resolve(first.importPath), path.resolve(second.importPath));
+    assert.equal(fs.existsSync(first.importPath), true);
+
+    first.cleanup();
+    assert.equal(fs.existsSync(second.importPath), true);
+
+    second.cleanup();
+    assert.equal(fs.existsSync(second.importPath), false);
+  } finally {
+    if (previousHome === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = previousHome;
+    if (previousConfig === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previousConfig;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -289,6 +289,34 @@ test("transfer supports CLAUDE_CONFIG_DIR and stages a temporary default-root co
   assert.equal(fs.existsSync(original), true);
 });
 
+test("transfer rejects a staging path that escapes the default projects root through a symlink", () => {
+  const home = makeTempDir();
+  const repo = path.join(home, "repo");
+  const binDir = makeTempDir();
+  const claudeConfigDir = path.join(home, ".claude-work");
+  const projectDir = path.join(claudeConfigDir, "projects", "-repo");
+  const sourcePath = path.join(projectDir, "session-symlink.jsonl");
+  const defaultProjects = path.join(home, ".claude", "projects");
+  const escapedDir = path.join(home, "escaped-staging");
+  fs.mkdirSync(repo, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.mkdirSync(defaultProjects, { recursive: true });
+  fs.mkdirSync(escapedDir, { recursive: true });
+  fs.symlinkSync(escapedDir, path.join(defaultProjects, "-repo"), "junction");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(sourcePath, `${JSON.stringify({ type: "user", cwd: repo, message: { role: "user", content: "Do not escape staging." } })}\n`, "utf8");
+
+  const result = run("node", [SCRIPT, "transfer", "--json"], {
+    cwd: repo,
+    env: { ...buildEnv(binDir), HOME: home, USERPROFILE: home, CODEX_HOME: path.join(home, ".codex"), CLAUDE_CONFIG_DIR: claudeConfigDir, CODEX_COMPANION_TRANSCRIPT_PATH: sourcePath }
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /outside.*default Claude projects root|staging.*outside/i);
+  assert.equal(fs.existsSync(path.join(escapedDir, "session-symlink.jsonl")), false);
+});
+
 test("transfer reports an actionable upgrade error when native import is unsupported", () => {
   const home = makeTempDir();
   const repo = path.join(home, "repo");

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -220,6 +220,7 @@ test("transfer delegates the current Claude session directly to native import", 
     env: {
       ...buildEnv(binDir),
       HOME: home,
+      USERPROFILE: home,
       CODEX_HOME: path.join(home, ".codex"),
       CODEX_COMPANION_TRANSCRIPT_PATH: sourcePath
     }
@@ -244,6 +245,50 @@ test("transfer delegates the current Claude session directly to native import", 
   );
 });
 
+test("transfer supports CLAUDE_CONFIG_DIR and stages a temporary default-root copy", () => {
+  const home = makeTempDir();
+  const repo = path.join(home, "repo");
+  const binDir = makeTempDir();
+  const claudeConfigDir = path.join(home, ".claude-work");
+  const projectDir = path.join(claudeConfigDir, "projects", "-repo");
+  const sourcePath = path.join(projectDir, "session-alt-root.jsonl");
+  fs.mkdirSync(repo, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(
+    sourcePath,
+    `${JSON.stringify({ type: "user", cwd: repo, message: { role: "user", content: "Transfer from relocated config." } })}\n`,
+    "utf8"
+  );
+
+  const result = run("node", [SCRIPT, "transfer", "--json"], {
+    cwd: repo,
+    env: {
+      ...buildEnv(binDir),
+      HOME: home,
+      USERPROFILE: home,
+      CODEX_HOME: path.join(home, ".codex"),
+      CLAUDE_CONFIG_DIR: claudeConfigDir,
+      CODEX_COMPANION_TRANSCRIPT_PATH: sourcePath
+    }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  const original = fs.realpathSync(sourcePath);
+  assert.equal(payload.sourcePath, original);
+
+  const fakeState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  const importedPath = fakeState.lastExternalAgentImport.sourcePath;
+  const defaultProjects = path.join(home, ".claude", "projects");
+  const relativeImport = path.relative(defaultProjects, importedPath);
+  assert.equal(relativeImport.startsWith("..") || path.isAbsolute(relativeImport), false);
+  assert.notEqual(importedPath, original);
+  assert.equal(fs.existsSync(importedPath), false);
+  assert.equal(fs.existsSync(original), true);
+});
+
 test("transfer reports an actionable upgrade error when native import is unsupported", () => {
   const home = makeTempDir();
   const repo = path.join(home, "repo");
@@ -265,6 +310,7 @@ test("transfer reports an actionable upgrade error when native import is unsuppo
     env: {
       ...buildEnv(binDir),
       HOME: home,
+      USERPROFILE: home,
       CODEX_HOME: path.join(home, ".codex")
     }
   });
@@ -295,6 +341,7 @@ test("transfer fails visibly when native import completes without a ledger recor
     env: {
       ...buildEnv(binDir),
       HOME: home,
+      USERPROFILE: home,
       CODEX_HOME: path.join(home, ".codex")
     }
   });
@@ -320,7 +367,7 @@ test("transfer rejects sources outside the Claude projects directory", () => {
 
   const result = run("node", [SCRIPT, "transfer", "--source", sourcePath], {
     cwd: repo,
-    env: { ...buildEnv(binDir), HOME: home }
+    env: { ...buildEnv(binDir), HOME: home, USERPROFILE: home }
   });
 
   assert.notEqual(result.status, 0);

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -313,8 +313,18 @@ test("transfer retries with a collision-free staged filename when the mirrored d
   assert.equal(result.status, 0, result.stderr);
   assert.equal(fs.readFileSync(mirroredPath, "utf8"), "STALE-STAGING\n");
   const fakeState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
-  assert.notEqual(path.resolve(fakeState.lastExternalAgentImport.sourcePath), path.resolve(mirroredPath));
-  assert.equal(fs.existsSync(fakeState.lastExternalAgentImport.sourcePath), false);
+  const firstImportedPath = fakeState.lastExternalAgentImport.sourcePath;
+  assert.notEqual(path.resolve(firstImportedPath), path.resolve(mirroredPath));
+  assert.equal(fs.existsSync(firstImportedPath), false);
+
+  const retry = run("node", [SCRIPT, "transfer", "--json"], {
+    cwd: repo,
+    env: { ...buildEnv(binDir), HOME: home, USERPROFILE: home, CODEX_HOME: path.join(home, ".codex"), CLAUDE_CONFIG_DIR: claudeConfigDir, CODEX_COMPANION_TRANSCRIPT_PATH: sourcePath }
+  });
+  assert.equal(retry.status, 0, retry.stderr);
+  const retryState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  assert.equal(path.resolve(retryState.lastExternalAgentImport.sourcePath), path.resolve(firstImportedPath));
+  assert.equal(fs.existsSync(retryState.lastExternalAgentImport.sourcePath), false);
 });
 
 test("transfer rejects a staging path that escapes the default projects root through a symlink", () => {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -295,11 +295,11 @@ test("transfer rejects a staging path that escapes the default projects root thr
   const binDir = makeTempDir();
   const claudeConfigDir = path.join(home, ".claude-work");
   const projectDir = path.join(claudeConfigDir, "projects", "-repo");
-  const sourcePath = path.join(projectDir, "session-symlink.jsonl");
+  const sourcePath = path.join(projectDir, "new", "session-symlink.jsonl");
   const defaultProjects = path.join(home, ".claude", "projects");
   const escapedDir = path.join(home, "escaped-staging");
   fs.mkdirSync(repo, { recursive: true });
-  fs.mkdirSync(projectDir, { recursive: true });
+  fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
   fs.mkdirSync(defaultProjects, { recursive: true });
   fs.mkdirSync(escapedDir, { recursive: true });
   fs.symlinkSync(escapedDir, path.join(defaultProjects, "-repo"), "junction");
@@ -314,7 +314,7 @@ test("transfer rejects a staging path that escapes the default projects root thr
 
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /outside.*default Claude projects root|staging.*outside/i);
-  assert.equal(fs.existsSync(path.join(escapedDir, "session-symlink.jsonl")), false);
+  assert.equal(fs.existsSync(path.join(escapedDir, "new")), false);
 });
 
 test("transfer reports an actionable upgrade error when native import is unsupported", () => {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -289,6 +289,34 @@ test("transfer supports CLAUDE_CONFIG_DIR and stages a temporary default-root co
   assert.equal(fs.existsSync(original), true);
 });
 
+test("transfer retries with a collision-free staged filename when the mirrored destination exists", () => {
+  const home = makeTempDir();
+  const repo = path.join(home, "repo");
+  const binDir = makeTempDir();
+  const claudeConfigDir = path.join(home, ".claude-work");
+  const projectDir = path.join(claudeConfigDir, "projects", "-repo");
+  const sourcePath = path.join(projectDir, "session-collision.jsonl");
+  const mirroredPath = path.join(home, ".claude", "projects", "-repo", "session-collision.jsonl");
+  fs.mkdirSync(repo, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+  fs.mkdirSync(path.dirname(mirroredPath), { recursive: true });
+  fs.writeFileSync(mirroredPath, "STALE-STAGING\n", "utf8");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(sourcePath, `${JSON.stringify({ type: "user", cwd: repo, message: { role: "user", content: "Retry safely." } })}\n`, "utf8");
+
+  const result = run("node", [SCRIPT, "transfer", "--json"], {
+    cwd: repo,
+    env: { ...buildEnv(binDir), HOME: home, USERPROFILE: home, CODEX_HOME: path.join(home, ".codex"), CLAUDE_CONFIG_DIR: claudeConfigDir, CODEX_COMPANION_TRANSCRIPT_PATH: sourcePath }
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.readFileSync(mirroredPath, "utf8"), "STALE-STAGING\n");
+  const fakeState = JSON.parse(fs.readFileSync(path.join(binDir, "fake-codex-state.json"), "utf8"));
+  assert.notEqual(path.resolve(fakeState.lastExternalAgentImport.sourcePath), path.resolve(mirroredPath));
+  assert.equal(fs.existsSync(fakeState.lastExternalAgentImport.sourcePath), false);
+});
+
 test("transfer rejects a staging path that escapes the default projects root through a symlink", () => {
   const home = makeTempDir();
   const repo = path.join(home, "repo");


### PR DESCRIPTION
## Summary

Fixes #721.

- accept Claude transcripts under `CLAUDE_CONFIG_DIR/projects` as well as the default `~/.claude/projects`
- separate source-file resolution from allowed-root resolution so a missing default root no longer misreports an existing relocated transcript as missing
- stage relocated transcripts temporarily under the default Claude projects root before invoking Codex native import
- preserve the original source path in the transfer result and remove only the temporary staged copy after import
- never overwrite an existing staging destination
- make transfer tests portable on Windows by setting `USERPROFILE` alongside the synthetic `HOME`

## Validation

On Windows 11 / Node 26.3.1:

- test-first reproduction failed on `main` with `Claude session file not found` even though the transcript existed under `CLAUDE_CONFIG_DIR/projects`
- `node --test --test-name-pattern "transfer" tests/runtime.test.mjs` -> **5 passed, 0 failed**
- relocated-config test verifies Codex receives a path under the default projects root, the staged file is removed after import, and the original remains intact
- `node --check plugins/codex/scripts/lib/claude-session-transfer.mjs`
- `node --check plugins/codex/scripts/codex-companion.mjs`
- `git diff --cached --check`

The existing Node DEP0190 warning on this Windows base is tracked separately by #717 / PR #725.
