### PR TITLE
fix(task): optionally consume prompt files

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -79,7 +79,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [--prompt-file <path> [--prompt-file-consume]] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
@@ -641,8 +641,18 @@ async function executeTransfer(cwd, options = {}) {
 }
 
 function readTaskPrompt(cwd, options, positionals) {
+  const consumePromptFile = Boolean(options["prompt-file-consume"]);
+  if (consumePromptFile && !options["prompt-file"]) {
+    throw new Error("--prompt-file-consume requires --prompt-file.");
+  }
+
   if (options["prompt-file"]) {
-    return fs.readFileSync(path.resolve(cwd, options["prompt-file"]), "utf8");
+    const promptPath = path.resolve(cwd, options["prompt-file"]);
+    const prompt = fs.readFileSync(promptPath, "utf8");
+    if (consumePromptFile) {
+      fs.unlinkSync(promptPath);
+    }
+    return prompt;
   }
 
   const positionalPrompt = positionals.join(" ");
@@ -762,7 +772,15 @@ async function handleReview(argv) {
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["model", "effort", "cwd", "prompt-file"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
+    booleanOptions: [
+      "json",
+      "write",
+      "resume-last",
+      "resume",
+      "fresh",
+      "background",
+      "prompt-file-consume"
+    ],
     aliasMap: {
       m: "model"
     }

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -716,6 +716,59 @@ test("write task output focuses on the Codex result without generic follow-up hi
   assert.equal(result.stdout, "Handled the requested task.\nTask prompt accepted.\n");
 });
 
+test("task --prompt-file-consume removes the prompt file after a successful read", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  const promptPath = path.join(repo, "prompt.txt");
+  fs.writeFileSync(promptPath, "inspect the failing test", "utf8");
+
+  const result = run(
+    "node",
+    [SCRIPT, "task", "--prompt-file", promptPath, "--prompt-file-consume"],
+    { cwd: repo, env: buildEnv(binDir) }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(promptPath), false);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.lastTurnStart.prompt, "inspect the failing test");
+});
+
+test("task --prompt-file preserves the prompt file without consume", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  const promptPath = path.join(repo, "prompt.txt");
+  fs.writeFileSync(promptPath, "inspect the failing test", "utf8");
+
+  const result = run("node", [SCRIPT, "task", "--prompt-file", promptPath], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(promptPath), true);
+});
+
+test("task --prompt-file-consume requires --prompt-file", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+
+  const result = run("node", [SCRIPT, "task", "--prompt-file-consume", "hello"], {
+    cwd: repo,
+    env: buildEnv(binDir)
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /--prompt-file-consume requires --prompt-file\./);
+});
+
 test("task --resume acts like --resume-last without leaking the flag into the prompt", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
## Summary

Fixes #622 by adding an opt-in `--prompt-file-consume` flag to `task`.

When the flag is used with `--prompt-file`, the companion now reads the prompt, unlinks the caller-provided file, and only then proceeds to task dispatch. Without the flag, existing `--prompt-file` behavior is unchanged.

## Semantics

The ordering is deliberately:

`READ -> DELETE -> DISPATCH`

- if the read fails, no deletion is attempted;
- if the unlink fails, task dispatch does not proceed;
- without `--prompt-file-consume`, the prompt file remains caller-owned as before;
- `--prompt-file-consume` without `--prompt-file` fails with a clear error.

This implements the smallest opt-in fix proposed in #622 and does not mix in prompt digest verification or SessionEnd lifecycle changes.

## Regression coverage

Added three runtime tests:

1. consume mode deletes the prompt file after a successful read and the exact prompt still reaches `turn/start`;
2. ordinary `--prompt-file` preserves the file;
3. consume mode without `--prompt-file` is rejected.

RED against `upstream/main` (`db52e28f4d9ded852ab3942cea316258ae4ef346`): 1 pass / 2 fail, with the file remaining and the invalid flag combination exiting 0.

GREEN with this patch: 3/3 pass.

## Validation

- focused prompt-file runtime tests: 3/3 pass
- non-runtime suites (`bump-version`, `commands`, `git`, `process`, `render`, `state`): 28/28 pass
- `node --check plugins/codex/scripts/codex-companion.mjs`: pass
- `npx tsc -p tsconfig.app-server.json`: pass
- `npm run check-version`: pass
- `git diff --check`: pass
- high-confidence secret/private-marker scan of the diff: pass

I also attempted the full Windows suite. It does not terminate cleanly because the current test harness leaves app-server broker/fake-Codex processes behind; the first visible failure, `createBrokerEndpoint uses Unix sockets on non-Windows platforms`, reproduces identically on an untouched `upstream/main` worktree. I therefore am not claiming a full-suite pass from this Windows host.

## Scope

Two files only:

- `plugins/codex/scripts/codex-companion.mjs`
- `tests/runtime.test.mjs`

No version bump or unrelated lifecycle changes.