### PR TITLE
fix: make native review JSON contract explicit

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -382,7 +382,11 @@ async function executeReviewRun(request) {
         stderr: result.stderr,
         stdout: result.reviewText,
         reasoning: result.reasoningSummary
-      }
+      },
+      result: null,
+      rawOutput: result.reviewText,
+      parseError: "The built-in reviewer returns prose; use adversarial-review for structured output.",
+      reasoningSummary: result.reasoningSummary
     };
     const rendered = renderNativeReviewResult(
       {

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -157,6 +157,23 @@ test("review renders a no-findings result from app-server review/start", () => {
   assert.match(result.stdout, /No material issues found/);
 });
 
+test("review --json explicitly reports that native review output is unstructured", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  fs.writeFileSync(path.join(repo, "README.md"), "hello\n");
+  run("git", ["add", "README.md"], { cwd: repo });
+  run("git", ["commit", "-m", "init"], { cwd: repo });
+  fs.writeFileSync(path.join(repo, "README.md"), "hello again\n");
+  const result = run("node", [SCRIPT, "review", "--json"], { cwd: repo, env: buildEnv(binDir) });
+  assert.equal(result.status, 0, result.stderr);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.result, null);
+  assert.equal(payload.rawOutput, payload.codex.stdout);
+  assert.match(payload.parseError, /built-in reviewer.*prose.*adversarial-review/i);
+});
+
 test("task runs when the active provider does not require OpenAI login", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
## Summary

Fixes #679.

The built-in `review` path intentionally returns prose rather than schema-shaped findings, but its `--json` payload previously omitted `result`, `rawOutput`, and `parseError` entirely. Consumers could not distinguish "no structured output exists" from a parse failure.

This makes the contract explicit without heuristically parsing reviewer prose:

- `result: null`
- `rawOutput`: the native review text
- `parseError`: an actionable explanation that built-in review returns prose and `adversarial-review` should be used for structured output
- `reasoningSummary`: exposed consistently with the structured review path

Human-readable review output is unchanged.

## Validation

Windows 11 / Node 26.3.1:

- test-first reproduction failed on `main` because `payload.result` was `undefined`
- native JSON contract + existing review regressions: **3 passed, 0 failed**
- `node --check plugins/codex/scripts/codex-companion.mjs`
- `git diff --check`
