### PR TITLE
fix: ignore recommended plugin context in thread titles

### DIFF
--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -105,7 +105,11 @@ function looksLikeVerificationCommand(command) {
 }
 
 function buildTaskThreadName(prompt) {
-  const excerpt = shorten(prompt, 56);
+  const titleSource = String(prompt ?? "").replace(
+    /^\s*<recommended_plugins>[\s\S]*?<\/recommended_plugins>\s*/i,
+    ""
+  );
+  const excerpt = shorten(titleSource, 56);
   return excerpt ? `${TASK_THREAD_PREFIX}: ${excerpt}` : TASK_THREAD_PREFIX;
 }
 

--- a/tests/runtime.test.mjs
+++ b/tests/runtime.test.mjs
@@ -157,6 +157,20 @@ test("review renders a no-findings result from app-server review/start", () => {
   assert.match(result.stdout, /No material issues found/);
 });
 
+test("task thread names ignore leading recommended_plugins context", () => {
+  const repo = makeTempDir();
+  const binDir = makeTempDir();
+  const statePath = path.join(binDir, "fake-codex-state.json");
+  installFakeCodex(binDir);
+  initGitRepo(repo);
+  const promptPath = path.join(repo, "prompt.txt");
+  fs.writeFileSync(promptPath, `<recommended_plugins>\nHere is a list of plugins.\n</recommended_plugins>\nFix the flaky login test`, "utf8");
+  const result = run("node", [SCRIPT, "task", "--prompt-file", promptPath], { cwd: repo, env: buildEnv(binDir) });
+  assert.equal(result.status, 0, result.stderr);
+  const fakeState = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  assert.equal(fakeState.threads[0].name, "Codex Companion Task: Fix the flaky login test");
+});
+
 test("task runs when the active provider does not require OpenAI login", () => {
   const repo = makeTempDir();
   const binDir = makeTempDir();


### PR DESCRIPTION
## Summary

Fixes #726.

Codex Companion task threads are explicitly named from the task prompt. When Claude prepends its injected `<recommended_plugins>...</recommended_plugins>` context block, that metadata currently becomes the visible Codex history title.

This patch strips only a leading `recommended_plugins` block before deriving the thread-name excerpt. The task prompt itself is unchanged and still reaches Codex verbatim; only the display-name source is sanitized.

## Validation

Windows 11 / Node 26.3.1:

- test-first reproduction via `--prompt-file`: **RED on `upstream/main`** with thread name `Codex Companion Task: <recommended_plugins> Here is a list of plugins. </re...`
- after the patch: `Codex Companion Task: Fix the flaky login test`
- targeted naming / resume-last / background runtime: **3 passed, 0 failed**
- `node --check plugins/codex/scripts/lib/codex.mjs`
- `git diff --check`

Fresh collision check immediately before publication found no open PR for #726.