### PR TITLE
Do not run taskkill through a shell on Windows

### DIFF
--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -66,7 +66,13 @@ export function terminateProcessTree(pid, options = {}) {
   if (platform === "win32") {
     const result = runCommandImpl("taskkill", ["/PID", String(pid), "/T", "/F"], {
       cwd: options.cwd,
-      env: options.env
+      env: options.env,
+      // runCommand prefers process.env.SHELL on Windows, so under Git Bash this
+      // ran as `bash -c "taskkill /PID ..."` and MSYS path conversion rewrote
+      // the /PID switch into C:/Program Files/Git/PID, failing every kill with
+      // "ERROR: Invalid argument/option". taskkill takes /-switches and an
+      // argument array, so it does not need a shell.
+      shell: false
     });
 
     if (!result.error && result.status === 0) {

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -7,8 +7,8 @@ test("terminateProcessTree uses taskkill on Windows", () => {
   let captured = null;
   const outcome = terminateProcessTree(1234, {
     platform: "win32",
-    runCommandImpl(command, args) {
-      captured = { command, args };
+    runCommandImpl(command, args, options) {
+      captured = { command, args, shell: options?.shell };
       return {
         command,
         args,
@@ -26,7 +26,10 @@ test("terminateProcessTree uses taskkill on Windows", () => {
 
   assert.deepEqual(captured, {
     command: "taskkill",
-    args: ["/PID", "1234", "/T", "/F"]
+    args: ["/PID", "1234", "/T", "/F"],
+    // Not through a shell: under Git Bash, MSYS path conversion turns the /PID
+    // switch into C:/Program Files/Git/PID and taskkill rejects it.
+    shell: false
   });
   assert.equal(outcome.delivered, true);
   assert.equal(outcome.method, "taskkill");


### PR DESCRIPTION
`runCommand` prefers `process.env.SHELL` on Windows. When Claude Code runs under Git Bash the process kill became `bash -c "taskkill /PID ..."`, and MSYS path conversion rewrote the `/PID` switch into `C:/Program Files/Git/PID`. taskkill rejected it before touching the process:

```
ERROR: Invalid argument/option - 'C:/Program Files/Git/PID'.
```

Every `/codex:cancel` failed that way, and so did the internal kills, so nothing could stop a running job from a Git Bash session.

taskkill takes `/`-switches and an argument array, so it never needed a shell. Passing `shell: false` at this one call site fixes it and leaves every other command alone. `runCommand` still prefers the user's shell everywhere else, where the quoting it provides is wanted. This follows the pattern from #447: fix the call site that cannot tolerate a shell, rather than changing the default for every command.

**Verification.** Windows 11, `SHELL=C:\Program Files\Git\bin\bash.exe`, against a real process with a child of its own so the `/T` tree kill was exercised. Before the change taskkill never ran. After it, `delivered: true`, exit 0, and the tree is gone.

The existing Windows test now asserts the absence of a shell too. The command and its arguments are identical in the working and the broken case, so only the shell option separates them and the old assertion could not have caught this.