### PR TITLE
Fix: retry stdin reads on EAGAIN instead of crashing the hook

### DIFF
--- a/plugins/codex/scripts/lib/fs.mjs
+++ b/plugins/codex/scripts/lib/fs.mjs
@@ -32,9 +32,35 @@ export function isProbablyText(buffer) {
   return true;
 }
 
+// fs.readFileSync(0) can throw EAGAIN on a piped (non-TTY) stdin whose
+// underlying fd is still non-blocking when the read fires, before the
+// writer has finished flushing. Retry on EAGAIN instead of letting it
+// escape as a hook failure.
+export function readStdinSync() {
+  const chunks = [];
+  const buffer = Buffer.alloc(65536);
+  for (;;) {
+    let bytesRead;
+    try {
+      bytesRead = fs.readSync(0, buffer, 0, buffer.length, null);
+    } catch (error) {
+      if (error.code === "EAGAIN") {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+        continue;
+      }
+      throw error;
+    }
+    if (bytesRead === 0) {
+      break;
+    }
+    chunks.push(Buffer.from(buffer.subarray(0, bytesRead)));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
 export function readStdinIfPiped() {
   if (process.stdin.isTTY) {
     return "";
   }
-  return fs.readFileSync(0, "utf8");
+  return readStdinSync();
 }

--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -16,12 +16,13 @@ import {
 import { loadState, resolveStateFile, saveState } from "./lib/state.mjs";
 import { TRANSCRIPT_PATH_ENV } from "./lib/claude-session-transfer.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
+import { readStdinSync } from "./lib/fs.mjs";
 
 export const SESSION_ID_ENV = "CODEX_COMPANION_SESSION_ID";
 const PLUGIN_DATA_ENV = "CLAUDE_PLUGIN_DATA";
 
 function readHookInput() {
-  const raw = fs.readFileSync(0, "utf8").trim();
+  const raw = readStdinSync().trim();
   if (!raw) {
     return {};
   }

--- a/plugins/codex/scripts/stop-review-gate-hook.mjs
+++ b/plugins/codex/scripts/stop-review-gate-hook.mjs
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-import fs from "node:fs";
 import process from "node:process";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { getCodexAvailability } from "./lib/codex.mjs";
+import { readStdinSync } from "./lib/fs.mjs";
 import { loadPromptTemplate, interpolateTemplate } from "./lib/prompts.mjs";
 import { getConfig, listJobs } from "./lib/state.mjs";
 import { sortJobsNewestFirst } from "./lib/job-control.mjs";
@@ -19,7 +19,7 @@ const ROOT_DIR = path.resolve(SCRIPT_DIR, "..");
 const STOP_REVIEW_TASK_MARKER = "Run a stop-gate review of the previous Claude turn.";
 
 function readHookInput() {
-  const raw = fs.readFileSync(0, "utf8").trim();
+  const raw = readStdinSync().trim();
   if (!raw) {
     return {};
   }


### PR DESCRIPTION
Root-caused from a live SessionStart hook failure: `Failed with non-blocking status code: EAGAIN: resource temporarily unavailable, read`.

`fs.readFileSync(0, "utf8")` throws `EAGAIN` when stdin is piped (non-TTY) and the fd is still non-blocking at the moment of the read, before the writer has finished flushing — a known Node/libuv race, not a Claude Code daemon issue. It hit `session-lifecycle-hook.mjs` directly, and `stop-review-gate-hook.mjs` / `lib/fs.mjs`'s `readStdinIfPiped()` shared the identical unguarded pattern.

## Fix
Adds `readStdinSync()` to `lib/fs.mjs`: a `fs.readSync` loop that catches `EAGAIN`, waits briefly (`Atomics.wait`, 20ms), and retries, rather than letting it escape as an uncaught exception. Routed all three call sites through it instead of the bare `readFileSync(0)`.

## Testing
- `node --check` on all three edited files
- Unit test mocking `fs.readSync` to throw `EAGAIN` once then succeed — confirms the retry loop recovers and returns the correct data
- Functional smoke test: valid piped JSON through `session-lifecycle-hook.mjs` and `stop-review-gate-hook.mjs` — unchanged behavior, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
