### PR TITLE
Add an explicit --network flag for read-only tasks

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -79,7 +79,7 @@ function printUsage() {
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
       "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
-      "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
+      "  node scripts/codex-companion.mjs task [--background] [--write] [--network] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
       "  node scripts/codex-companion.mjs result [job-id] [--json]",
@@ -488,7 +488,9 @@ async function executeTaskRun(request) {
     defaultPrompt: resumeThreadId ? DEFAULT_CONTINUE_PROMPT : "",
     model: request.model,
     effort: request.effort,
-    sandbox: request.write ? "workspace-write" : "read-only",
+    // Codex 0.147.0 turns network off for read-only, so network-only mandates use workspace-write.
+    sandbox: request.write || request.network ? "workspace-write" : "read-only",
+    network: request.network,
     onProgress: request.onProgress,
     persistThread: true,
     threadName: resumeThreadId ? null : buildPersistentTaskThreadName(request.prompt || DEFAULT_CONTINUE_PROMPT)
@@ -601,13 +603,14 @@ function buildTaskJob(workspaceRoot, taskMetadata, write) {
   });
 }
 
-function buildTaskRequest({ cwd, model, effort, prompt, write, resumeLast, jobId }) {
+function buildTaskRequest({ cwd, model, effort, prompt, write, network, resumeLast, jobId }) {
   return {
     cwd,
     model,
     effort,
     prompt,
     write,
+    network,
     resumeLast,
     jobId
   };
@@ -762,7 +765,7 @@ async function handleReview(argv) {
 async function handleTask(argv) {
   const { options, positionals } = parseCommandInput(argv, {
     valueOptions: ["model", "effort", "cwd", "prompt-file"],
-    booleanOptions: ["json", "write", "resume-last", "resume", "fresh", "background"],
+    booleanOptions: ["json", "write", "network", "resume-last", "resume", "fresh", "background"],
     aliasMap: {
       m: "model"
     }
@@ -780,6 +783,7 @@ async function handleTask(argv) {
     throw new Error("Choose either --resume/--resume-last or --fresh.");
   }
   const write = Boolean(options.write);
+  const network = Boolean(options.network);
   const taskMetadata = buildTaskRunMetadata({
     prompt,
     resumeLast
@@ -796,6 +800,7 @@ async function handleTask(argv) {
       effort,
       prompt,
       write,
+      network,
       resumeLast,
       jobId: job.id
     });
@@ -814,6 +819,7 @@ async function handleTask(argv) {
         effort,
         prompt,
         write,
+        network,
         resumeLast,
         jobId: job.id,
         onProgress: progress

--- a/plugins/codex/scripts/lib/codex.mjs
+++ b/plugins/codex/scripts/lib/codex.mjs
@@ -66,6 +66,7 @@ function buildThreadParams(cwd, options = {}) {
     model: options.model ?? null,
     approvalPolicy: options.approvalPolicy ?? "never",
     sandbox: options.sandbox ?? "read-only",
+    ...(options.network ? { config: { sandbox_workspace_write: { network_access: true } } } : {}),
     serviceName: SERVICE_NAME,
     ephemeral: options.ephemeral ?? true
   };
@@ -78,7 +79,8 @@ function buildResumeParams(threadId, cwd, options = {}) {
     cwd,
     model: options.model ?? null,
     approvalPolicy: options.approvalPolicy ?? "never",
-    sandbox: options.sandbox ?? "read-only"
+    sandbox: options.sandbox ?? "read-only",
+    ...(options.network ? { config: { sandbox_workspace_write: { network_access: true } } } : {})
   };
 }
 
@@ -1106,6 +1108,7 @@ export async function runAppServerTurn(cwd, options = {}) {
       const response = await resumeThread(client, options.resumeThreadId, cwd, {
         model: options.model,
         sandbox: options.sandbox,
+        network: options.network,
         ephemeral: false
       });
       threadId = response.thread.id;
@@ -1114,6 +1117,7 @@ export async function runAppServerTurn(cwd, options = {}) {
       const response = await startThread(client, cwd, {
         model: options.model,
         sandbox: options.sandbox,
+        network: options.network,
         ephemeral: options.persistThread ? false : true,
         threadName: options.persistThread ? options.threadName : options.threadName ?? null
       });


### PR DESCRIPTION
# Title

Add an explicit network flag for read-only mandates

## Problem

In Codex CLI 0.147.0, the read-only sandbox has no network access. As a
result, read-only mandates that need to reach the network fail with a
misleading DNS error. The existing `--write` flag cannot express a mandate
that needs network access but must not write to the workspace.

## Solution

Add an explicit `--network` boolean flag, separate from `--write`. When
`--network` is selected, task startup uses `workspace-write` and explicitly
enables `sandbox_workspace_write.network_access`; `--write` remains
independent, and the default behavior is unchanged when neither flag is
provided.

## Verification

- Red: before the patch, a task started without `--network` uses the
  `read-only` sandbox and a network probe fails with the sandbox's DNS error.
- Green: after the patch, a task started with `--network` uses
  `workspace-write` with network access enabled and the same network probe
  succeeds; a task without `--network` remains network-disabled.
- `node --check` passes for `scripts/codex-companion.mjs` and
  `scripts/lib/codex.mjs`.
