### PR TITLE
Support --effort on adversarial-review, and surface unrecognised options

### DIFF
--- a/plugins/codex/scripts/codex-companion.mjs
+++ b/plugins/codex/scripts/codex-companion.mjs
@@ -78,7 +78,7 @@ function printUsage() {
       "Usage:",
       "  node scripts/codex-companion.mjs setup [--enable-review-gate|--disable-review-gate] [--json]",
       "  node scripts/codex-companion.mjs review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>]",
-      "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [focus text]",
+      "  node scripts/codex-companion.mjs adversarial-review [--wait|--background] [--base <ref>] [--scope <auto|working-tree|branch>] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [focus text]",
       "  node scripts/codex-companion.mjs task [--background] [--write] [--resume-last|--resume|--fresh] [--model <model|spark>] [--effort <none|minimal|low|medium|high|xhigh>] [prompt]",
       "  node scripts/codex-companion.mjs transfer [--source <claude-jsonl>] [--json]",
       "  node scripts/codex-companion.mjs status [job-id] [--all] [--json]",
@@ -139,13 +139,25 @@ function normalizeArgv(argv) {
 }
 
 function parseCommandInput(argv, config = {}) {
-  return parseArgs(normalizeArgv(argv), {
+  const parsed = parseArgs(normalizeArgv(argv), {
     ...config,
     aliasMap: {
       C: "cwd",
       ...(config.aliasMap ?? {})
     }
   });
+
+  // An unrecognised long option is still treated as a positional, because some
+  // commands take free-form text. Say so on stderr rather than swallowing it:
+  // a mistyped or unsupported flag would otherwise be silently folded into a
+  // prompt, and the run would look like it did what was asked.
+  for (const token of parsed.unknownOptions ?? []) {
+    console.warn(
+      `Warning: unrecognised option ${token}; treating it as text. It will be passed through verbatim, not interpreted as a flag.`
+    );
+  }
+
+  return parsed;
 }
 
 function resolveCommandCwd(options = {}) {
@@ -411,6 +423,7 @@ async function executeReviewRun(request) {
   const result = await runAppServerTurn(context.repoRoot, {
     prompt,
     model: request.model,
+    effort: request.effort,
     sandbox: "read-only",
     outputSchema: readOutputSchema(REVIEW_SCHEMA),
     onProgress: request.onProgress
@@ -711,7 +724,7 @@ function enqueueBackgroundTask(cwd, job, request) {
 
 async function handleReviewCommand(argv, config) {
   const { options, positionals } = parseCommandInput(argv, {
-    valueOptions: ["base", "scope", "model", "cwd"],
+    valueOptions: ["base", "scope", "model", "effort", "cwd"],
     booleanOptions: ["json", "background", "wait"],
     aliasMap: {
       m: "model"
@@ -720,6 +733,7 @@ async function handleReviewCommand(argv, config) {
 
   const cwd = resolveCommandCwd(options);
   const workspaceRoot = resolveCommandWorkspace(options);
+  const effort = normalizeReasoningEffort(options.effort);
   const focusText = positionals.join(" ").trim();
   const target = resolveReviewTarget(cwd, {
     base: options.base,
@@ -744,6 +758,7 @@ async function handleReviewCommand(argv, config) {
         base: options.base,
         scope: options.scope,
         model: options.model,
+        effort,
         focusText,
         reviewName: config.reviewName,
         onProgress: progress

--- a/plugins/codex/scripts/lib/args.mjs
+++ b/plugins/codex/scripts/lib/args.mjs
@@ -4,6 +4,7 @@ export function parseArgs(argv, config = {}) {
   const aliasMap = config.aliasMap ?? {};
   const options = {};
   const positionals = [];
+  const unknownOptions = [];
   let passthrough = false;
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -45,6 +46,7 @@ export function parseArgs(argv, config = {}) {
         continue;
       }
 
+      unknownOptions.push(token);
       positionals.push(token);
       continue;
     }
@@ -70,7 +72,7 @@ export function parseArgs(argv, config = {}) {
     positionals.push(token);
   }
 
-  return { options, positionals };
+  return { options, positionals, unknownOptions };
 }
 
 export function splitRawArgumentString(raw) {

--- a/tests/args.test.mjs
+++ b/tests/args.test.mjs
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseArgs, splitRawArgumentString } from "../plugins/codex/scripts/lib/args.mjs";
+
+const REVIEW_CONFIG = {
+  valueOptions: ["base", "scope", "model", "effort", "cwd"],
+  booleanOptions: ["json", "background", "wait"],
+  aliasMap: { m: "model" }
+};
+
+test("parseArgs reports an unrecognised long option instead of silently demoting it", () => {
+  const { options, positionals, unknownOptions } = parseArgs(
+    ["--model", "gpt-6-astra", "--nonsense", "value"],
+    { valueOptions: ["model"], booleanOptions: [] }
+  );
+
+  assert.equal(options.model, "gpt-6-astra");
+  // Behaviour is unchanged: the token still reaches positionals, because some
+  // commands take free-form text after their flags.
+  assert.deepEqual(positionals, ["--nonsense", "value"]);
+  // But it is now reported, so a caller can warn rather than swallow it.
+  assert.deepEqual(unknownOptions, ["--nonsense"]);
+});
+
+test("parseArgs reports nothing when every option is recognised", () => {
+  const { unknownOptions } = parseArgs(["--model", "gpt-6-astra", "--json"], {
+    valueOptions: ["model"],
+    booleanOptions: ["json"]
+  });
+
+  assert.deepEqual(unknownOptions, []);
+});
+
+test("parseArgs does not treat text after -- as an unrecognised option", () => {
+  const { positionals, unknownOptions } = parseArgs(["--", "--not-a-flag"], {
+    valueOptions: [],
+    booleanOptions: []
+  });
+
+  assert.deepEqual(positionals, ["--not-a-flag"]);
+  assert.deepEqual(unknownOptions, []);
+});
+
+test("review commands accept --effort rather than folding it into the focus text", () => {
+  const { options, positionals, unknownOptions } = parseArgs(
+    ["--model", "gpt-6-astra", "--effort", "xhigh", "focus", "on", "auth"],
+    REVIEW_CONFIG
+  );
+
+  assert.equal(options.model, "gpt-6-astra");
+  assert.equal(options.effort, "xhigh");
+  assert.deepEqual(unknownOptions, []);
+  // The regression this guards: --effort and xhigh used to land here and be
+  // joined into the prompt the reviewer was given.
+  assert.deepEqual(positionals, ["focus", "on", "auth"]);
+  assert.equal(positionals.join(" "), "focus on auth");
+});
+
+test("splitRawArgumentString keeps a quoted focus phrase together", () => {
+  assert.deepEqual(
+    splitRawArgumentString('--model gpt-6-astra --effort xhigh "the auth path"'),
+    ["--model", "gpt-6-astra", "--effort", "xhigh", "the auth path"]
+  );
+});


### PR DESCRIPTION
## The problem

`/codex:adversarial-review --model gpt-6-astra --effort xhigh` silently does something other than what it says, with no error and no warning.

Two independent causes compound:

1. **`--effort` is not a flag on the review commands.** `handleReviewCommand` ([codex-companion.mjs#L713-L719](https://github.com/openai/codex-plugin-cc/blob/main/plugins/codex/scripts/codex-companion.mjs#L713-L719)) parses `valueOptions: ["base", "scope", "model", "cwd"]`. Only `handleTask` ([#L763-L769](https://github.com/openai/codex-plugin-cc/blob/main/plugins/codex/scripts/codex-companion.mjs#L763-L769)) parses `effort`.

2. **Unrecognised long options are silently demoted to positionals.** [`args.mjs#L48`](https://github.com/openai/codex-plugin-cc/blob/main/plugins/codex/scripts/lib/args.mjs#L48) falls through to `positionals.push(token)` after the known-flag branches, and `handleReviewCommand` then builds the review's focus text with `positionals.join(" ")` ([#L723](https://github.com/openai/codex-plugin-cc/blob/main/plugins/codex/scripts/codex-companion.mjs#L723)).

So the literal tokens `--effort` and `xhigh` get concatenated into the prompt handed to the reviewer, the run uses whatever `model_reasoning_effort` the config holds, and the invocation looks like it worked.

The second cause is the more general one. It is not specific to `--effort`: **any** mistyped or unsupported flag on **any** command currently ends up pasted verbatim into a prompt with nothing said about it.

This is not hypothetical for us. Our own always-loaded team instructions had been recommending exactly that invocation as the standard escalation, so every session following them was getting a corrupted prompt at the wrong reasoning effort. We only noticed by reading the parser.

## The fix

**1. Review commands accept `--effort`.** Normalised through the existing `normalizeReasoningEffort`, then threaded into the `runAppServerTurn` call the adversarial path already makes. `runAppServerTurn` already accepts an `effort` option, so this is plumbing rather than new capability. The usage line is updated to match, including the `--model` flag it already supported but never advertised.

**2. `parseArgs` reports what it demoted.** It now returns `unknownOptions` alongside `options` and `positionals`, and `parseCommandInput` warns on stderr for each.

Behaviour is deliberately **unchanged**: the token still reaches `positionals`. Commands like `adversarial-review` take free-form focus text, so a hard error would break a prose word that happens to start with two dashes, and existing callers that destructure `{ options, positionals }` are unaffected. The only change is that the demotion stops being silent.

I am happy to make it a hard rejection instead if you would prefer that — it is a smaller change, and arguably the right one for the strictly-flagged commands — but a warning seemed the safer default given the free-text commands.

## Tests

Five new tests in `tests/args.test.mjs`, covering the unknown-option report, the clean case, the `--` passthrough boundary, `--effort` staying out of the focus text under the real review config, and quoted focus phrases.

Mutation-tested rather than merely written: reverting the `unknownOptions.push` line makes the first test fail, and restoring it makes it pass.

## Suite status

Run on Windows, `node --test tests/*.test.mjs`:

| | pass | fail |
|---|---:|---:|
| clean `main` | 79 | 12 |
| this branch | 84 | 12 |

The 12 failures are identical on clean `main` and are untouched by this change — they are platform tests (Unix sockets, temp-backed state dirs) that do not pass on Windows. Happy to open a separate issue for those if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbutZdFgSLna89DcLEhe7Z
