### PR TITLE
fix: make runCommand maxBuffer explicit

### DIFF
--- a/plugins/codex/scripts/lib/process.mjs
+++ b/plugins/codex/scripts/lib/process.mjs
@@ -1,13 +1,16 @@
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
+// Git metadata can exceed Node's 1 MiB spawnSync default. Keep a generous explicit bound.
+const DEFAULT_MAX_BUFFER = 256 * 1024 * 1024;
+
 export function runCommand(command, args = [], options = {}) {
   const result = spawnSync(command, args, {
     cwd: options.cwd,
     env: options.env,
     encoding: "utf8",
     input: options.input,
-    maxBuffer: options.maxBuffer,
+    maxBuffer: options.maxBuffer ?? DEFAULT_MAX_BUFFER,
     stdio: options.stdio ?? "pipe",
     shell: options.shell ?? (process.platform === "win32" ? (process.env.SHELL || true) : false),
     windowsHide: true

--- a/tests/process.test.mjs
+++ b/tests/process.test.mjs
@@ -1,7 +1,29 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+import { runCommand, terminateProcessTree } from "../plugins/codex/scripts/lib/process.mjs";
+
+test("runCommand allows output larger than Node's default maxBuffer", () => {
+  const outputBytes = 2 * 1024 * 1024;
+  const result = runCommand(process.execPath, [
+    "-e",
+    `process.stdout.write("x".repeat(${outputBytes}))`
+  ]);
+
+  assert.equal(result.error, null);
+  assert.equal(result.status, 0);
+  assert.equal(Buffer.byteLength(result.stdout), outputBytes);
+});
+
+test("runCommand preserves an explicit maxBuffer override", () => {
+  const result = runCommand(
+    process.execPath,
+    ["-e", `process.stdout.write("x".repeat(${2 * 1024}))`],
+    { maxBuffer: 1024 }
+  );
+
+  assert.equal(result.error?.code, "ENOBUFS");
+});
 
 test("terminateProcessTree uses taskkill on Windows", () => {
   let captured = null;


### PR DESCRIPTION
## Summary

Thanks for the detailed report in #744. This makes the intended buffering behaviour explicit instead of relying on an `undefined` option overriding Node's 1 MiB `spawnSync` default.

- use an explicit 256 MiB default for `runCommand`
- preserve smaller caller-provided `maxBuffer` values used by measurement gates
- add regressions for output above 1 MiB and for explicit bounded output

## Validation

- `npm test` (93 passed)
- `node --test tests/process.test.mjs` (4 passed)
- `npm run check-version`
- `git diff --check`

Fixes #744
