### PR TITLE
fix: keep only the latest value per key in CLAUDE_ENV_FILE (SessionStart)

### DIFF
--- a/plugins/codex/scripts/session-lifecycle-hook.mjs
+++ b/plugins/codex/scripts/session-lifecycle-hook.mjs
@@ -32,11 +32,27 @@ function shellEscape(value) {
   return `'${String(value).replace(/'/g, `'\"'\"'`)}'`;
 }
 
-function appendEnvVar(name, value) {
-  if (!process.env.CLAUDE_ENV_FILE || value == null || value === "") {
+function setEnv(name, value) {
+  const envFile = process.env.CLAUDE_ENV_FILE;
+  if (!envFile || value == null || value === "") {
     return;
   }
-  fs.appendFileSync(process.env.CLAUDE_ENV_FILE, `export ${name}=${shellEscape(value)}\n`, "utf8");
+  const prefix = `export ${name}=`;
+  const line = `${prefix}${shellEscape(value)}`;
+
+  let content = "";
+  try {
+    content = fs.readFileSync(envFile, "utf8");
+  } catch (err) {
+    if (err.code !== "ENOENT") throw err;
+  }
+
+  const lines = content.split(/\r?\n/).filter((l) => l && !l.startsWith(prefix));
+  lines.push(line);
+
+  const tmp = `${envFile}.${process.pid}.tmp`;
+  fs.writeFileSync(tmp, lines.join("\n") + "\n", "utf8");
+  fs.renameSync(tmp, envFile);
 }
 
 function cleanupSessionJobs(cwd, sessionId) {
@@ -75,9 +91,9 @@ function cleanupSessionJobs(cwd, sessionId) {
 }
 
 function handleSessionStart(input) {
-  appendEnvVar(SESSION_ID_ENV, input.session_id);
-  appendEnvVar(TRANSCRIPT_PATH_ENV, input.transcript_path);
-  appendEnvVar(PLUGIN_DATA_ENV, process.env[PLUGIN_DATA_ENV]);
+  setEnv(SESSION_ID_ENV, input.session_id);
+  setEnv(TRANSCRIPT_PATH_ENV, input.transcript_path);
+  setEnv(PLUGIN_DATA_ENV, process.env[PLUGIN_DATA_ENV]);
 }
 
 async function handleSessionEnd(input) {


### PR DESCRIPTION
## Problem

`handleSessionStart` calls `appendEnvVar` for `CODEX_COMPANION_SESSION_ID`, `CODEX_COMPANION_TRANSCRIPT_PATH`, and `CLAUDE_PLUGIN_DATA` on every fire. `hooks/hooks.json` registers SessionStart with no matcher, so it runs on startup, resume, /clear, and compact. Those three values are constant for the life of a session, so every fire after the first re-appends bytes already in `CLAUDE_ENV_FILE`. The file grows without bound.

Claude Code inlines that file into the `bash -c` preamble of every Bash tool call, so past a size threshold every command in the session breaks. On Windows (Git Bash) I saw one env file reach 1248 lines / 130 KB containing only 3 unique lines, with three failure shapes by size:

- ~8 KB+: preamble truncated mid single-quoted export, giving `unexpected EOF while looking for matching '`
- ~32 KB+: command line exceeds the Windows CreateProcess limit, giving `ENAMETOOLONG ... uv_spawn`

Quote escaping in `shellEscape` is correct; the bug is purely the unbounded append.

## Fix

Replace the unconditional append with set semantics. `setEnv` removes any existing `export <name>=` line and writes the current value, so each key appears once with its latest value. This bounds the file and, unlike dedup-by-line, correctly handles a key returning to an earlier value (A -> B -> A ends at A, not a stale B). The write goes through a temp file plus rename so a concurrent SessionStart can't read a half-written file.

## Test

Repeated identical fires keep the file at one line per key; a fire with a changed value replaces the line instead of appending.
