### PR TITLE
fix(hooks): align SessionEnd timeout with Codex runtime cap

### DIFF
--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -18,7 +18,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/session-lifecycle-hook.mjs\" SessionEnd",
-            "timeout": 5
+            "timeout": 3
           }
         ]
       }

--- a/plugins/codex/scripts/lib/broker-lifecycle.mjs
+++ b/plugins/codex/scripts/lib/broker-lifecycle.mjs
@@ -40,10 +40,11 @@ export async function waitForBrokerEndpoint(endpoint, timeoutMs = 2000) {
   return false;
 }
 
-export async function sendBrokerShutdown(endpoint) {
+export async function sendBrokerShutdown(endpoint, timeoutMs = 750) {
   await new Promise((resolve) => {
     const socket = connectToEndpoint(endpoint);
     socket.setEncoding("utf8");
+    socket.setTimeout(timeoutMs);
     socket.on("connect", () => {
       socket.write(`${JSON.stringify({ id: 1, method: "broker/shutdown", params: {} })}\n`);
     });
@@ -53,6 +54,10 @@ export async function sendBrokerShutdown(endpoint) {
     });
     socket.on("error", resolve);
     socket.on("close", resolve);
+    socket.on("timeout", () => {
+      socket.destroy();
+      resolve();
+    });
   });
 }
 

--- a/tests/broker-lifecycle.test.mjs
+++ b/tests/broker-lifecycle.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import test from "node:test";
+
+import { makeTempDir } from "./helpers.mjs";
+import { sendBrokerShutdown } from "../plugins/codex/scripts/lib/broker-lifecycle.mjs";
+
+test("sendBrokerShutdown returns when a broker accepts but never replies", async (t) => {
+  const socketPath = path.join(makeTempDir(), "broker.sock");
+  const sockets = new Set();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+  });
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(() => {
+    for (const socket of sockets) socket.destroy();
+    server.close();
+    fs.rmSync(path.dirname(socketPath), { recursive: true, force: true });
+  });
+
+  const startedAt = Date.now();
+  await sendBrokerShutdown(`unix:${socketPath}`, 50);
+  assert.ok(Date.now() - startedAt < 500);
+});

--- a/tests/hooks.test.mjs
+++ b/tests/hooks.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const HOOKS_PATH = path.join(ROOT, "plugins", "codex", "hooks", "hooks.json");
+
+test("SessionEnd stays within the Codex runtime teardown budget", () => {
+  const manifest = JSON.parse(fs.readFileSync(HOOKS_PATH, "utf8"));
+  const handlers = manifest.hooks.SessionEnd.flatMap((group) => group.hooks);
+
+  assert.ok(handlers.length > 0, "SessionEnd must remain configured");
+  for (const handler of handlers) {
+    assert.ok(
+      handler.timeout <= 3,
+      `SessionEnd timeout ${handler.timeout}s exceeds the Codex runtime 3s hard cap`
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- set the SessionEnd hook timeout to the runtime hard cap of 3 seconds
- bound the broker shutdown request at 750 ms so teardown stays inside that budget
- add focused manifest and non-responsive-broker regression tests

## Evidence
- RED manifest: SessionEnd timeout 5s exceeds the runtime 3s hard cap
- RED stalled broker: focused test remained pending until external timeout, rc=124
- `node --test tests/broker-lifecycle.test.mjs tests/hooks.test.mjs`: 2 pass
- `npm test`: 93 pass
- Desktop 0.153.4 `hooks/list`, before: effective `timeoutSec: 3` plus the clamp warning
- fresh isolated home from this head, after: effective `timeoutSec: 3`, `warnings: []`, `errors: []` in two project roots

## Why
The runtime enforces `SESSION_END_MAX_TIMEOUT_SEC = 3` to retain headroom inside its five-second app-server shutdown bound. A plugin value of 5 is valid input but is always clamped, producing a warning in every project where the globally enabled plugin is loaded. The prior shutdown request could also wait indefinitely after a broker accepted without replying, so lowering only the manifest value would create a false-green contract.

## Scope
This bounds the request and removes the manifest/runtime mismatch. It does not change shared-broker ownership or cross-session shutdown policy.

Related: #474, #540, #671
